### PR TITLE
dma_core_wrap, idma_reg64_frontend: Minor fixes

### DIFF
--- a/src/frontends/register_64bit/idma_reg64_frontend.sv
+++ b/src/frontends/register_64bit/idma_reg64_frontend.sv
@@ -7,8 +7,6 @@
 // Description: DMA frontend module that includes 64bit config and status reg handling
 
 module idma_reg64_frontend #(
-    /// address width of the DMA AXI Master port
-    parameter int  unsigned DmaAddrWidth     = -1,
     /// register_interface request type
     parameter type          dma_regs_req_t   = logic,
     /// register_interface response type
@@ -38,7 +36,7 @@ module idma_reg64_frontend #(
     idma_reg64_frontend_reg_pkg::idma_reg64_frontend_hw2reg_t dma_hw2reg;
 
     // transaction id
-    logic [DmaAddrWidth-1:0] next_id, done_id;
+    logic [DmaRegisterWidth-1:0] next_id, done_id;
     logic issue;
 
     dma_regs_rsp_t dma_ctrl_rsp_tmp;

--- a/src/systems/cva6_reg/dma_core_wrap.sv
+++ b/src/systems/cva6_reg/dma_core_wrap.sv
@@ -57,7 +57,7 @@ module dma_core_wrap #(
 
   `REG_BUS_TYPEDEF_ALL(dma_regs, logic[5:0], logic[63:0], logic[7:0])
 
-  burst_req_t burst_req;
+  idma_req_t burst_req;
   logic be_valid, be_ready, be_trans_complete;
   idma_pkg::idma_busy_t idma_busy;
 
@@ -91,7 +91,7 @@ module dma_core_wrap #(
     .DmaAddrWidth    ( AXI_ADDR_WIDTH ),
     .dma_regs_req_t  ( dma_regs_req_t ),
     .dma_regs_rsp_t  ( dma_regs_rsp_t ),
-    .burst_req_t     ( burst_req_t     )
+    .burst_req_t     ( idma_req_t     )
   ) i_dma_frontend (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
In dma_core_wrap we encountered this error:
`Error: src/systems/cva6_reg/dma_core_wrap.sv(60): 'burst_req_t' is an unknown type.`
We believe that this was meant to be idma_req_t as this type was declared just before.

And in idma_reg64_frontend we encountered these warnings:
```
Warning: (vsim-3015) [PCDPC] - Port size (64) does not match connection size (48) for port 'next_o'. The port definition is at: src/frontends/idma_transfer_id_gen.sv(19).
File: src/frontends/register_64bit/idma_reg64_frontend.sv Line: 143

Warning: (vsim-3015) [PCDPC] - Port size (64) does not match connection size (48) for port 'completed_o'. The port definition is at: src/frontends/idma_transfer_id_gen.sv(21).
File: src/frontends/register_64bit/idma_reg64_frontend.sv Line: 143
```
The signals next_id, done_id are declared with length DmaAddrWidth instead of DmaRegisterWidth. We believe that this is unintentional, as the config registers are 64 bits wide.
However, note that with this fix the parameter DmaAddrWidth will not be used anywhere in the module.