### PR TITLE
Fix idma_backend instantiation in dma_core_wrap.sv

### DIFF
--- a/src/systems/cva6_reg/dma_core_wrap.sv
+++ b/src/systems/cva6_reg/dma_core_wrap.sv
@@ -123,8 +123,10 @@ module dma_core_wrap #(
     .idma_rsp_t          ( idma_rsp_t                  ),
     .idma_eh_req_t       ( idma_pkg::idma_eh_req_t     ),
     .idma_busy_t         ( idma_pkg::idma_busy_t       ),
-    .axi_req_t           ( axi_mst_req_t               ),
-    .axi_rsp_t           ( axi_mst_resp_t              )
+    .protocol_req_t      ( axi_mst_req_t               ),
+    .protocol_rsp_t      ( axi_mst_resp_t              ),
+    .aw_chan_t           ( axi_mst_aw_chan_t           ),
+    .ar_chan_t           ( axi_mst_ar_chan_t           )
   ) i_idma_backend (
     .clk_i,
     .rst_ni,
@@ -142,8 +144,8 @@ module dma_core_wrap #(
     .eh_req_valid_i( 1'b1              ),
     .eh_req_ready_o( /*NOT CONNECTED*/ ),
 
-    .axi_req_o     ( axi_mst_req       ),
-    .axi_rsp_i     ( axi_mst_resp      ),
+    .protocol_req_o( axi_mst_req       ),
+    .protocol_rsp_i( axi_mst_resp      ),
     .busy_o        ( idma_busy         )
   );
 


### PR DESCRIPTION
Parameter and signal names were changed in idma_backend.sv.
This PR updates dma_core_wrap.sv to adhere to the new interface.