### PR TITLE
missing signal connection in r_dp_req

### DIFF
--- a/src/backend/tpl/idma_backend.sv.tpl
+++ b/src/backend/tpl/idma_backend.sv.tpl
@@ -470,7 +470,8 @@ _rsp_t ${protocol}_write_rsp_i,
             offset:      idma_req_i.src_addr[OffsetWidth-1:0],
             tailer:      OffsetWidth'(idma_req_i.length + idma_req_i.src_addr[OffsetWidth-1:0]),
             shift:       OffsetWidth'(idma_req_i.src_addr[OffsetWidth-1:0]),
-            decouple_aw: idma_req_i.opt.beo.decouple_aw
+            decouple_aw: idma_req_i.opt.beo.decouple_aw,
+            is_single: len == '0
         };
 
         // assemble write datapath request


### PR DESCRIPTION
Hi,

It seems the missing `is_single` signal in ` r_dp_req` stucture is causing problem in synthesis. 
Here is the related CI check [results](https://iis-git.ee.ethz.ch/github-mirror/cheshire/-/jobs/1251876), just in case you want to have a look : ) 

Thank you! @thommythomaso 