### PR TITLE
Fix missing ND response to zero-length ND request

### DIFF
--- a/src/backend/tpl/idma_backend.sv.tpl
+++ b/src/backend/tpl/idma_backend.sv.tpl
@@ -398,6 +398,7 @@ _rsp_t ${protocol}_write_rsp_i,
                 // generate new response
                 rsp_valid_o             = 1'b1;
                 idma_rsp_o              =  '0;
+                idma_rsp_o.last         = 1'b1;
                 idma_rsp_o.error        = 1'b1;
                 idma_rsp_o.pld.err_type = idma_pkg::BACKEND;
             end


### PR DESCRIPTION
### Issue

The `idma_nd_midend` module fails to generate a response to zero-length ND requests.

### How it arises

`nd_rsp_valid_o` is never asserted due to the `last` signal in the burst response from the backend not being asserted: 
https://github.com/pulp-platform/iDMA/blob/5ebff11232c7c5af208067c534b68092cd8506c4/src/midend/idma_nd_midend.sv#L208

This is in turn due to how the backend handles zero-length transfers, setting most of the response signals to zero:
https://github.com/pulp-platform/iDMA/blob/5ebff11232c7c5af208067c534b68092cd8506c4/src/backend/tpl/idma_backend.sv.tpl#L394-L403

### What it implies

As a consequence of the missing response from the `idma_nd_midend`, the frontend does not properly keep track of the `completed_id`, as it never asserts `retire_id` for zero-length transfers:
https://github.com/pulp-platform/iDMA/blob/5ebff11232c7c5af208067c534b68092cd8506c4/src/frontend/inst64/idma_inst64_top.sv#L255-L272

### Fix

This PR proposes to correct this condition in the backend, by always asserting the `last` signal in response to zero-length transfers.