### PR TITLE
Restore tracing in Snitch DMA

### DIFF
--- a/src/frontend/inst64/idma_inst64_top.sv
+++ b/src/frontend/inst64/idma_inst64_top.sv
@@ -7,6 +7,7 @@
 
 `include "common_cells/registers.svh"
 `include "idma/typedef.svh"
+`include "idma/tracer.svh"
 
 /// Implements the tightly-coupled frontend. This module can directly be connected
 /// to an accelerator bus in the snitch system
@@ -18,6 +19,7 @@ module idma_inst64_top #(
     parameter int unsigned NumAxInFlight   = 32'd3,
     parameter int unsigned DMAReqFifoDepth = 32'd3,
     parameter int unsigned NumChannels     = 32'd1,
+    parameter int unsigned DMATracing      = 32'd0,
     parameter type         axi_ar_chan_t   = logic,
     parameter type         axi_aw_chan_t   = logic,
     parameter type         axi_req_t       = logic,
@@ -207,7 +209,6 @@ module idma_inst64_top #(
 
         assign busy_o[c] = (|idma_busy[c]) | idma_nd_busy[c];
     end
-
 
 
     //--------------------------------------
@@ -506,5 +507,30 @@ module idma_inst64_top #(
     // State
     //--------------------------------------
     `FF(idma_fe_req_q, idma_fe_req_d, '0)
+
+
+    //--------------------------------------
+    // DMA Tracer
+    //--------------------------------------
+    // only activate tracer if requested
+`ifndef SYNTHESIS
+    if (DMATracing) begin : gen_tracer
+        for (genvar c = 0; c < NumChannels; c++) begin : gen_channels
+            // derive the name of the trace file from the hart and channel IDs
+            string trace_file;
+            initial begin
+                // We need to schedule the assignment into a safe region, otherwise
+                // `hart_id_i` won't have a value assigned at the beginning of the first
+                // delta cycle.
+`ifndef VERILATOR
+                #0;
+`endif
+                $sformat(trace_file, "dma_trace_%05x_%05x.log", hart_id_i, c);
+            end
+            // attach the tracer
+            `IDMA_TRACER_RW_AXI(gen_backend[c].i_idma_backend_rw_axi, trace_file);
+        end
+    end
+`endif
 
 endmodule

--- a/util/mario/tracer.py
+++ b/util/mario/tracer.py
@@ -14,22 +14,26 @@ from mako.template import Template
 TRACER_BODY = '''
 // The tracer for the ${identifier} iDMA
 `define IDMA_TRACER_${identifier_cap}(__backend_inst, __out_f) <%text>\\</%text>
-`ifndef SYNTHESYS <%text>\\</%text>
-`ifndef VERILATOR <%text>\\</%text>
+`ifndef SYNTHESIS <%text>\\</%text>
     initial begin : inital_tracer_${identifier} <%text>\\</%text>
         automatic bit first_iter = 1; <%text>\\</%text>
         automatic integer tf; <%text>\\</%text>
         automatic `IDMA_TRACER_MAX_TYPE cnst [string]; <%text>\\</%text>
         automatic `IDMA_TRACER_MAX_TYPE meta [string]; <%text>\\</%text>
+        automatic `IDMA_TRACER_MAX_TYPE backend [string]; <%text>\\</%text>
         automatic `IDMA_TRACER_MAX_TYPE busy [string]; <%text>\\</%text>
         automatic `IDMA_TRACER_MAX_TYPE bus [string]; <%text>\\</%text>
         automatic string trace; <%text>\\</%text>
+`ifndef VERILATOR <%text>\\</%text>
         #0; <%text>\\</%text>
+`endif <%text>\\</%text>
         tf = $fopen(__out_f, "w"); <%text>\\</%text>
         $display("[iDMA Tracer] Logging %s to %s", `"__backend_inst`", __out_f); <%text>\\</%text>
         forever begin <%text>\\</%text>
             @(posedge __backend_inst``.clk_i); <%text>\\</%text>
-            if(__backend_inst``.rst_ni & |__backend_inst``.busy_o) begin <%text>\\</%text>
+            if(__backend_inst``.rst_ni & (|__backend_inst``.busy_o | <%text>\\</%text>
+                                          __backend_inst``.req_valid_i | <%text>\\</%text>
+                                          __backend_inst``.rsp_valid_o)) begin <%text>\\</%text>
                 /* Trace */ <%text>\\</%text>
                 trace = "{"; <%text>\\</%text>
                 /* Constants */ <%text>\\</%text>
@@ -55,6 +59,13 @@ TRACER_BODY = '''
                 meta = '{ <%text>\\</%text>
                     "time" : $time() <%text>\\</%text>
                 }; <%text>\\</%text>
+                backend = '{ <%text>\\</%text>
+                    "req_valid"  : __backend_inst``.req_valid_i, <%text>\\</%text>
+                    "req_ready"  : __backend_inst``.req_ready_o, <%text>\\</%text>
+                    "rsp_valid"  : __backend_inst``.rsp_valid_o, <%text>\\</%text>
+                    "rsp_ready"  : __backend_inst``.rsp_ready_i, <%text>\\</%text>
+                    "req_length" : __backend_inst``.idma_req_i.length <%text>\\</%text>
+                }; <%text>\\</%text>
                 busy = '{ <%text>\\</%text>
                     "buffer"      : __backend_inst``.busy_o.buffer_busy, <%text>\\</%text>
                     "r_dp"        : __backend_inst``.busy_o.r_dp_busy, <%text>\\</%text>
@@ -71,6 +82,7 @@ ${signals}
                 /* Assembly */ <%text>\\</%text>
                 `IDMA_TRACER_STR_ASSEMBLY(cnst, first_iter); <%text>\\</%text>
                 `IDMA_TRACER_STR_ASSEMBLY(meta, 1); <%text>\\</%text>
+                `IDMA_TRACER_STR_ASSEMBLY(backend, 1); <%text>\\</%text>
                 `IDMA_TRACER_STR_ASSEMBLY(busy, 1); <%text>\\</%text>
                 `IDMA_TRACER_STR_ASSEMBLY(bus, 1); <%text>\\</%text>
                 `IDMA_TRACER_CLEAR_COND(first_iter); <%text>\\</%text>
@@ -79,7 +91,6 @@ ${signals}
             end <%text>\\</%text>
         end <%text>\\</%text>
     end <%text>\\</%text>
-`endif <%text>\\</%text>
 `endif
 '''
 


### PR DESCRIPTION
### Contributions
- Restore DMA tracing in Snitch, to the extent this feature had before the old DMA was replaced in https://github.com/pulp-platform/snitch_cluster/pull/108. Note this does not restore all previously logged signals as significant changes were made to the backend.
- Correct a potentially dangerous typo in the tracer RTL (`SYNTHESIS` being misspelled).
- Enable tracing multiple DMA channels, when present.
- Add backend signals required to parse the DMA traces in Snitch, as used in https://github.com/pulp-platform/snitch_cluster/pull/71. These are equivalent substitutes to some of the previously logged signals in the Snitch DMA.
- Tentative support for tracing in Verilator (see below).

### Tracing in Verilator
Before the iDMA integration in Snitch I was able to enable DMA tracing also in Verilator (version 4.110). With the iDMA this fails with the following error:
```
%Error-UNSUPPORTED: /scratch/colluca/workspace/snitch_cluster/traces-dma/working_dir/idma/src/frontend/inst64/idma_inst64_top.sv:530:60: Unsupported: Non-single-bit pos/negedge clock statement under some complicated block
  530 |             @(posedge gen_backend[c].i_idma_backend_rw_axi.clk_i); 
      |                                                            ^~~~~
```
Upgrading to a newer version of Verilator (tested on 5.006) would solve this, but the `--timing` flag needs to be provided (given the `@` timing block, whereas in the legacy DMA the tracer used an `always_ff` block).

This still fails on the zero-delay statements:
```
%Error-ZERODLY: /scratch/colluca/workspace/snitch_cluster/traces-dma/working_dir/idma/src/frontend/inst64/idma_inst64_top.sv:530:9: Unsupported: #0 delays do not schedule process resumption in the Inactive region
  530 |         #0; 
      |         ^
```
but if we guard these with `` `ifndef VERILATOR ``, thereby omitting the zero-delays altogether for Verilator, all works as expected.

The question is if we can accept to support only Verilator >5.0, or if we would need to implement version-based guarding. AFAIK, Verilator does not define a `VERILATOR_5` macro itself, so we would need to implement something like that ourselves.