### PR TITLE
Fix DMCPY instruction for multi-channel iDMA

### DIFF
--- a/src/frontend/inst64/idma_inst64_top.sv
+++ b/src/frontend/inst64/idma_inst64_top.sv
@@ -423,12 +423,12 @@ module idma_inst64_top #(
                     // 5. acknowledge acc request (qready)
                     if (acc_res_ready) begin
                         idma_fe_req_valid [idma_fe_sel_chan] = 1'b1;
-                        if (idma_fe_req_ready) begin
+                        if (idma_fe_req_ready[idma_fe_sel_chan]) begin
                             acc_res.id      = acc_req_i.id;
-                            acc_res.data    = next_id;
+                            acc_res.data    = next_id[idma_fe_sel_chan];
                             acc_res.error   = 1'b0;
                             acc_res_valid   = 1'b1;
-                            acc_req_ready_o = idma_fe_req_ready;
+                            acc_req_ready_o = idma_fe_req_ready[idma_fe_sel_chan];
                         end
                     end
                 end


### PR DESCRIPTION
The DMCPY instruction didn't return the correct transfer id for other channels than channel 0. This made the test program wait for a transfer id that would never be returned by DMSTAT.
It was fixed by adding the indexing to ``next_id``. The indexing was also added to the ready signal ``idma_fe_req_ready``.