### PR TITLE
feature: Add multicast capabilities to Snitch DMA

### DIFF
--- a/src/backend/tpl/idma_backend.sv.tpl
+++ b/src/backend/tpl/idma_backend.sv.tpl
@@ -299,6 +299,7 @@ _rsp_t ${protocol}_write_rsp_i,
         addr_t   addr;
         logic    valid;
         addr_t   base_addr;
+        addr_t   mask;
     } idma_mut_tf_t;
 
 

--- a/src/backend/tpl/idma_legalizer.sv.tpl
+++ b/src/backend/tpl/idma_legalizer.sv.tpl
@@ -460,14 +460,16 @@ w_num_bytes_to_pb = w_page_num_bytes_to_pb;
                 length: req_i.length,
                 addr:   req_i.src_addr,
                 valid:   1'b1,
-                base_addr: req_i.src_addr
+                base_addr: req_i.src_addr,
+                default: '0
             };
             // destination or write
             w_tf_d = '{
                 length: req_i.length,
                 addr:   req_i.dst_addr,
                 valid:   1'b1,
-                base_addr: req_i.dst_addr
+                base_addr: req_i.dst_addr,
+                mask: req_i.dst_mask
             };
             // options
             opt_tf_d = '{

--- a/src/db/idma_axi.yml
+++ b/src/db/idma_axi.yml
@@ -56,7 +56,7 @@ legalizer_write_meta_channel: |
         prot: opt_tf_q.dst_axi_opt.prot,
         qos: opt_tf_q.dst_axi_opt.qos,
         region: opt_tf_q.dst_axi_opt.region,
-        user: '0,
+        user: w_tf_q.mask,
         atop: '0
     };
 legalizer_write_data_path: |

--- a/src/frontend/inst64/idma_inst64_snitch_pkg.sv
+++ b/src/frontend/inst64/idma_inst64_snitch_pkg.sv
@@ -17,5 +17,6 @@ package idma_inst64_snitch_pkg;
   localparam logic [31:0] DMSTAT             = 32'b0000101?????00000000?????0101011;
   localparam logic [31:0] DMSTR              = 32'b0000110??????????000000000101011;
   localparam logic [31:0] DMREP              = 32'b000011100000?????000000000101011;
+  localparam logic [31:0] DMMCAST            = 32'b000100000000?????000000000101011;
 
 endpackage

--- a/src/frontend/inst64/idma_inst64_top.sv
+++ b/src/frontend/inst64/idma_inst64_top.sv
@@ -433,9 +433,9 @@ module idma_inst64_top #(
                     end
                 end
 
-              // status of the DMA
-              idma_inst64_snitch_pkg::DMSTATI,
-              idma_inst64_snitch_pkg::DMSTAT: begin
+                // status of the DMA
+                idma_inst64_snitch_pkg::DMSTATI,
+                idma_inst64_snitch_pkg::DMSTAT: begin
                     // Parse the status index from the register or immediate.
                     unique casez (acc_req_i.data_op)
                         idma_inst64_snitch_pkg::DMSTATI : begin
@@ -469,27 +469,35 @@ module idma_inst64_top #(
                         acc_res_valid   = 1'b1;
                         acc_req_ready_o = 1'b1;
                     end
-              end
+                end
 
-              // manipulate the strides
-              idma_inst64_snitch_pkg::DMSTR : begin
-                  idma_fe_req_d.d_req[0].src_strides = acc_req_i.data_arga;
-                  idma_fe_req_d.d_req[0].dst_strides = acc_req_i.data_argb;
-                  acc_req_ready_o = 1'b1;
-                  is_dma_op       = 1'b1;
-                  dma_op_name     = "DMSTR";
-              end
+                // manipulate the strides
+                idma_inst64_snitch_pkg::DMSTR : begin
+                    idma_fe_req_d.d_req[0].src_strides = acc_req_i.data_arga;
+                    idma_fe_req_d.d_req[0].dst_strides = acc_req_i.data_argb;
+                    acc_req_ready_o = 1'b1;
+                    is_dma_op       = 1'b1;
+                    dma_op_name     = "DMSTR";
+                end
 
-              // manipulate the strides
-              idma_inst64_snitch_pkg::DMREP : begin
-                  idma_fe_req_d.d_req[0].reps = acc_req_i.data_arga;
-                  acc_req_ready_o = 1'b1;
-                  is_dma_op       = 1'b1;
-                  dma_op_name     = "DMREP";
-              end
+                // manipulate the repetitions
+                idma_inst64_snitch_pkg::DMREP : begin
+                    idma_fe_req_d.d_req[0].reps = acc_req_i.data_arga;
+                    acc_req_ready_o = 1'b1;
+                    is_dma_op       = 1'b1;
+                    dma_op_name     = "DMREP";
+                end
 
-              default:;
-          endcase
+                // write the multicast mask in the destination user signal
+                idma_inst64_snitch_pkg::DMMCAST : begin
+                    idma_fe_req_d.burst_req.dst_mask[31:0] = acc_req_i.data_arga[31:0];
+                    acc_req_ready_o = 1'b1;
+                    is_dma_op       = 1'b1;
+                    dma_op_name     = "DMMCAST";
+                end
+
+                default:;
+            endcase
         end
     end
 

--- a/src/include/idma/typedef.svh
+++ b/src/include/idma/typedef.svh
@@ -39,6 +39,7 @@
         tf_len_t   length;                                               \
         axi_addr_t src_addr;                                             \
         axi_addr_t dst_addr;                                             \
+        axi_addr_t dst_mask;                                             \
         options_t  opt;                                                  \
     } idma_req_t;
 `define IDMA_TYPEDEF_RSP_T(idma_rsp_t, err_payload_t)                    \


### PR DESCRIPTION
This PR implements multicast support for write transactions in the Snitch iDMA. The implementation was tested in Occamy.

The way this feature is currently implemented is not the most generic, and there may be better options. In particular, perhaps we want to consider implementing a more general mechanism to inject user-defined values in the AWUSER field.
Then it should be possible to implement multicast support simply on top of this more generic feature.
