### PR TITLE
feature: add user field support at snitch iDMA

### DIFF
--- a/src/backend/tpl/idma_backend.sv.tpl
+++ b/src/backend/tpl/idma_backend.sv.tpl
@@ -299,7 +299,7 @@ _rsp_t ${protocol}_write_rsp_i,
         addr_t   addr;
         logic    valid;
         addr_t   base_addr;
-        addr_t   mask;
+        user_t   user;
     } idma_mut_tf_t;
 
 

--- a/src/backend/tpl/idma_legalizer.sv.tpl
+++ b/src/backend/tpl/idma_legalizer.sv.tpl
@@ -469,7 +469,8 @@ w_num_bytes_to_pb = w_page_num_bytes_to_pb;
                 addr:   req_i.dst_addr,
                 valid:   1'b1,
                 base_addr: req_i.dst_addr,
-                mask: req_i.dst_mask
+                user: req_i.user,
+                default: '0
             };
             // options
             opt_tf_d = '{

--- a/src/db/idma_axi.yml
+++ b/src/db/idma_axi.yml
@@ -56,7 +56,7 @@ legalizer_write_meta_channel: |
         prot: opt_tf_q.dst_axi_opt.prot,
         qos: opt_tf_q.dst_axi_opt.qos,
         region: opt_tf_q.dst_axi_opt.region,
-        user: w_tf_q.mask,
+        user: w_tf_q.user,
         atop: '0
     };
 legalizer_write_data_path: |

--- a/src/frontend/inst64/idma_inst64_snitch_pkg.sv
+++ b/src/frontend/inst64/idma_inst64_snitch_pkg.sv
@@ -17,6 +17,6 @@ package idma_inst64_snitch_pkg;
   localparam logic [31:0] DMSTAT             = 32'b0000101?????00000000?????0101011;
   localparam logic [31:0] DMSTR              = 32'b0000110??????????000000000101011;
   localparam logic [31:0] DMREP              = 32'b000011100000?????000000000101011;
-  localparam logic [31:0] DMMCAST            = 32'b000100000000?????000000000101011;
+  localparam logic [31:0] DMUSER             = 32'b0001000??????????000000000101011;
 
 endpackage

--- a/src/include/idma/typedef.svh
+++ b/src/include/idma/typedef.svh
@@ -34,12 +34,12 @@
         idma_pkg::err_type_t err_type;                                   \
         axi_addr_t           burst_addr;                                 \
     } err_payload_t;
-`define IDMA_TYPEDEF_REQ_T(idma_req_t, tf_len_t, axi_addr_t, options_t)  \
+`define IDMA_TYPEDEF_REQ_T(idma_req_t, tf_len_t, axi_addr_t, options_t, user_t = logic)  \
     typedef struct packed {                                              \
         tf_len_t   length;                                               \
         axi_addr_t src_addr;                                             \
         axi_addr_t dst_addr;                                             \
-        axi_addr_t dst_mask;                                             \
+        user_t     user;                                                 \
         options_t  opt;                                                  \
     } idma_req_t;
 `define IDMA_TYPEDEF_RSP_T(idma_rsp_t, err_payload_t)                    \

--- a/test/frontend/tb_idma_desc64_bench.sv
+++ b/test/frontend/tb_idma_desc64_bench.sv
@@ -462,7 +462,7 @@ module tb_idma_desc64_bench
                 // overwrite protocols
                 current_stimulus.burst.opt.src_protocol = idma_pkg::AXI;
                 current_stimulus.burst.opt.dst_protocol = idma_pkg::AXI;
-                current_stimulus.burst.dst_mask = '0;
+                current_stimulus.burst.user = '0;
 
                 current_stimulus.base = base_current;
                 current_stimuli_group.push_back(current_stimulus);
@@ -503,7 +503,7 @@ module tb_idma_desc64_bench
                     // overwrite protocols
                     current_stimulus.burst.opt.src_protocol = idma_pkg::AXI;
                     current_stimulus.burst.opt.dst_protocol = idma_pkg::AXI;
-                    current_stimulus.burst.dst_mask = '0;
+                    current_stimulus.burst.user = '0;
 
                     current_stimulus.base = base_current;
                     contiguous += 1;

--- a/test/frontend/tb_idma_desc64_top.sv
+++ b/test/frontend/tb_idma_desc64_top.sv
@@ -271,7 +271,7 @@ module tb_idma_desc64_top
                 // overwrite protocols
                 current_stimulus.burst.opt.src_protocol = idma_pkg::AXI;
                 current_stimulus.burst.opt.dst_protocol = idma_pkg::AXI;
-                current_stimulus.burst.dst_mask = '0;
+                current_stimulus.burst.user = '0;
 
                 current_stimuli_group.push_back(current_stimulus);
                 golden_queue.push_back('{
@@ -303,7 +303,7 @@ module tb_idma_desc64_top
                     // overwrite protocols
                     current_stimulus.burst.opt.src_protocol = idma_pkg::AXI;
                     current_stimulus.burst.opt.dst_protocol = idma_pkg::AXI;
-                    current_stimulus.burst.dst_mask = '0;
+                    current_stimulus.burst.user = '0;
 
                     // chain descriptor
                     current_stimuli_group[$].next = current_stimulus.base;


### PR DESCRIPTION
This PR replaces the prior multicast supports with a more generic AXI user field injection. It supports up to 64 Bit for the user field.