### PR TITLE
fix: Illegal semicolons

### DIFF
--- a/src/frontend/desc64/idma_desc64_ar_gen.sv
+++ b/src/frontend/desc64/idma_desc64_ar_gen.sv
@@ -122,9 +122,9 @@ always_comb begin : proc_ar
     axi_ar_chan_o.burst = axi_pkg::BURST_INCR;
 end
 
-`FF(inflight_q, inflight_d, 1'b0);
-`FF(next_addr_from_desc_valid_q, next_addr_from_desc_valid_d, 1'b0);
-`FF(next_addr_q, next_addr_d, '1);
+`FF(inflight_q, inflight_d, 1'b0)
+`FF(next_addr_from_desc_valid_q, next_addr_from_desc_valid_d, 1'b0)
+`FF(next_addr_q, next_addr_d, '1)
 
 assign feedback_addr_o       = ar_addr;
 assign feedback_addr_valid_o = axi_ar_chan_ready_i && axi_ar_chan_valid_o;

--- a/src/frontend/desc64/idma_desc64_ar_gen_prefetch.sv
+++ b/src/frontend/desc64/idma_desc64_ar_gen_prefetch.sv
@@ -231,11 +231,11 @@ end
 
 assign queued_address_ready_o = !take_from_next && (!base_valid_q || next_addr_valid_this_cycle);
 
-`FF(inflight_counter_q, inflight_counter_d, '0);
-`FF(base_addr_q, base_addr_d, '0);
-`FF(next_addr_valid_q, next_addr_valid_d, 1'b0);
-`FF(base_valid_q, base_valid_d, 1'b0);
-`FF(flush_q, flush_d, 1'b0);
+`FF(inflight_counter_q, inflight_counter_d, '0)
+`FF(base_addr_q, base_addr_d, '0)
+`FF(next_addr_valid_q, next_addr_valid_d, 1'b0)
+`FF(base_valid_q, base_valid_d, 1'b0)
+`FF(flush_q, flush_d, 1'b0)
 assign flush_d = flush;
 
 stream_fifo #(

--- a/src/frontend/desc64/idma_desc64_reader.sv
+++ b/src/frontend/desc64/idma_desc64_reader.sv
@@ -97,8 +97,8 @@ end else if (DataWidth == 128) begin : gen_128_data_path
         end
     end
 
-    `FF(first_half_of_descriptor_q, first_half_of_descriptor_d, 128'b0);
-    `FF(irq_addr_valid_q, irq_addr_valid_d, 1'b0);
+    `FF(first_half_of_descriptor_q, first_half_of_descriptor_d, 128'b0)
+    `FF(irq_addr_valid_q, irq_addr_valid_d, 1'b0)
 end else if (DataWidth == 64) begin : gen_64_data_path
     logic [1:0]       fetch_counter_q, fetch_counter_d;
     logic [2:0][63:0] descriptor_data_q, descriptor_data_d;
@@ -128,8 +128,8 @@ end else if (DataWidth == 64) begin : gen_64_data_path
         end
     end
 
-    `FF(descriptor_data_q, descriptor_data_d, 192'b0);
-    `FF(fetch_counter_q, fetch_counter_d, 2'b0);
+    `FF(descriptor_data_q, descriptor_data_d, 192'b0)
+    `FF(fetch_counter_q, fetch_counter_d, 2'b0)
 end else if (DataWidth == 32) begin : gen_32_data_path
     logic [2:0]       fetch_counter_q, fetch_counter_d;
     logic [6:0][31:0] descriptor_data_q, descriptor_data_d;

--- a/src/frontend/desc64/idma_desc64_reader_gater.sv
+++ b/src/frontend/desc64/idma_desc64_reader_gater.sv
@@ -50,8 +50,8 @@ always_comb begin
     end
 end
 
-`FF(n_to_flush_q, n_to_flush_d, 'b0);
-`FF(engage_q, engage_d, 'b0);
+`FF(n_to_flush_q, n_to_flush_d, 'b0)
+`FF(engage_q, engage_d, 'b0)
 
 assign r_valid_o = flush ? 1'b0 : r_valid_i;
 assign r_ready_o = flush ? 1'b1 : r_ready_i;

--- a/src/frontend/desc64/idma_desc64_reg_wrapper.sv
+++ b/src/frontend/desc64/idma_desc64_reg_wrapper.sv
@@ -79,6 +79,6 @@ import idma_desc64_reg_pkg::idma_desc64_hw2reg_t; #(
             input_addr_valid_d = '0;
         end
     end
-    `FF(input_addr_valid_q, input_addr_valid_d, '0);
+    `FF(input_addr_valid_q, input_addr_valid_d, '0)
 
 endmodule

--- a/src/frontend/desc64/idma_desc64_top.sv
+++ b/src/frontend/desc64/idma_desc64_top.sv
@@ -458,7 +458,7 @@ stream_fifo #(
     .ready_i   (master_rsp_i.aw_ready)
 );
 
-`FF(w_counter_q, w_counter_d, '0);
+`FF(w_counter_q, w_counter_d, '0)
 
 
 assign idma_rsp_ready_o = next_wb_addr_ready && next_wb_addr_valid;
@@ -468,8 +468,8 @@ assign irq_o            = do_irq_out && master_req_o.b_ready && master_rsp_i.b_v
 // and empty in lockstep. Capacity is tested at the idma_req fifo, the
 // other two ready signals are ignored.
 // pragma translate_off
-`ASSERT_IF(NoIrqDropped, do_irq_ready, do_irq_valid);
-`ASSERT_IF(NoAddrDropped, feedback_addr_ready, feedback_addr_valid);
+`ASSERT_IF(NoIrqDropped, do_irq_ready, do_irq_valid)
+`ASSERT_IF(NoAddrDropped, feedback_addr_ready, feedback_addr_valid)
 // pragma translate_on
 
 endmodule


### PR DESCRIPTION
The macros are inferred as standard SystemVerilog code, and the use of semicolons is illegal. This is shown as a warning in EDA tools.