### PR TITLE
fix: Break combinational loop in desc64 speculation FIFO

### DIFF
--- a/src/frontend/desc64/idma_desc64_ar_gen_prefetch.sv
+++ b/src/frontend/desc64/idma_desc64_ar_gen_prefetch.sv
@@ -239,7 +239,7 @@ assign queued_address_ready_o = !take_from_next && (!base_valid_q || next_addr_v
 assign flush_d = flush;
 
 stream_fifo #(
-    .FALL_THROUGH(1'b1),
+    .FALL_THROUGH(1'b0),
     .DEPTH       (NSpeculation),
     .T           (addr_t)
 ) i_speculation_fifo (


### PR DESCRIPTION
## Summary

Fixes #71.

- Disable fall-through (`FALL_THROUGH=0`) on `i_speculation_fifo` in `idma_desc64_ar_gen_prefetch` to break a combinational loop through the speculation check path
- The loop path is: `staging_addr_valid_speculation` → `speculation_valid` (fall-through) → `speculation_check_addr` mux → `speculation_correct` → `flush` → `staging_addr_valid_speculation`
- Under specific conditions (descriptor next-pointer skipping forward within a sequential layout), this reduces to `flush = !flush` — a combinational oscillator
- The fix adds 1 cycle of latency to speculation checking; actual prefetch performance is unaffected since ARs are already in-flight

## Test plan

- [x] `tb_idma_desc64_top` (558 descriptors, 0 errors)
- [x] `tb_idma_desc64_bench` (1000 descriptors, 0 errors)
- [ ] CI (Questa + VCS)