### PR TITLE
idma_rt_midend: track every arbiter handshake in the choice FIFO

### DIFF
--- a/src/midend/idma_rt_midend.sv
+++ b/src/midend/idma_rt_midend.sv
@@ -206,11 +206,11 @@ module idma_rt_midend #(
         .testmode_i ( 1'b0                                  ),
         .usage_o    ( /* NC */                              ),
         .data_i     ( choice                                ),
-        .valid_i    ( nd_req_valid_i & nd_req_ready_o       ),
+        .valid_i    ( nd_req_valid_o & nd_req_ready_i       ),
         .ready_o    ( /* HACK: NC */                        ),
         .data_o     ( choice_head                           ),
         .valid_o    ( /* HACK: NC */                        ),
-        .ready_i    ( burst_rsp_valid_o & burst_rsp_ready_i )
+        .ready_i    ( burst_rsp_valid_i & burst_rsp_ready_o )
     );
 
     // arbitration of responses


### PR DESCRIPTION
Hi!

If I understand correctly, the FIFO currently records only external bypass handshakes, but downstream responses can correspond to either external or internal requests. When the two interleave, the FIFO loses alignment and responses may be misrouted or dropped. This changes FIFO push/pop to use the unified downstream request and response handshakes, so every issued request pushes once and every returned response pops once. The bug was missed because the existing testbench ties off bypass input and does not exercise mixed traffic.

Please double check.

Thanks!
Flavien