### PR TITLE
requirements: Pin setuptools<81 to keep regtool working

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ sphinx-rtd-theme
 recommonmark
 sphinxcontrib-svg2pdfconverter
 pylint
+setuptools<81


### PR DESCRIPTION
The vendored lowRISC `regtool` (`register_interface/vendor/lowrisc_opentitan/util/regtool.py`) imports `pkg_resources`, which was deprecated in setuptools 81.0 and removed in 82.0 (Feb 2026). Fresh installs of `requirements.txt` now break `make idma_hw_all` with:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

Pin `setuptools<81` as a stopgap until #73 (PeakRDL migration) lands or upstream regtool drops `pkg_resources`.

Resolves #94.