### PR TITLE
CODEOWNERS: Add DanielKellerM and fix path typos

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,5 @@
 # Global owners
-* @thommythomaso
+* @thommythomaso @DanielKellerM
 
 # Frontends
-src/frontends @micprog
-
-# Systems
-src/systems @micprog
+src/frontend @micprog


### PR DESCRIPTION
- Add @DanielKellerM as a global code owner alongside @thommythomaso.
- Fix `src/frontends` → `src/frontend`
- Drop the `src/systems` entry, dir no longer exists