### PR TITLE
ci: Add branch policy enforcement and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!--
+Thanks for contributing to iDMA. Please target this PR at `devel`, not
+`master`. External PRs against `master` are auto-retargeted to `devel`.
+See CONTRIBUTING.md for the branch policy.
+-->
+
+## Description
+
+<!-- What does this PR change and why? Link related issues. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation
+- [ ] Build / CI
+
+## Checklist
+
+- [ ] This PR targets `devel` (not `master`).
+- [ ] Commits follow [Chris Beams style](https://chris.beams.io/posts/git-commit/) (≤100-char imperative subject, optional `area:` prefix).
+- [ ] `make idma_hw_all` and the relevant lints pass locally.
+- [ ] No AI-attribution lines on commits (e.g. `Co-authored-by:` for AI tools).
+- [ ] Related issues are referenced.
+
+## Notes for reviewers
+
+<!-- Anything to call out: tricky areas, follow-ups, dependencies on other PRs. -->

--- a/.github/workflows/promote-to-master.yml
+++ b/.github/workflows/promote-to-master.yml
@@ -6,11 +6,15 @@ name: promote-to-master
 
 on:
   workflow_run:
-    workflows: ["gitlab-ci"]
+    workflows: ["ci"]
     types: [completed]
 
 permissions:
   contents: read
+
+concurrency:
+  group: promote-to-master
+  cancel-in-progress: false
 
 jobs:
   promote:
@@ -43,7 +47,7 @@ jobs:
             }
 
             const body = [
-              'Auto-opened/refreshed after `gitlab-ci` passed on `devel`.',
+              'Auto-opened/refreshed after `ci` (incl. `gitlab-ci`) passed on `devel`.',
               '',
               `\`devel\` is ${cmp.data.ahead_by} commit(s) ahead of \`master\`.`,
               `Last verified commit: \`${short}\` ✅`,
@@ -81,7 +85,10 @@ jobs:
               });
               core.info(`Opened promotion PR #${created.data.number}.`);
             } catch (err) {
-              if (err.status === 422) {
+              const alreadyExists = err.status === 422
+                && (err.response?.data?.errors || []).some(e =>
+                     (e.message || '').toLowerCase().includes('pull request already exists'));
+              if (alreadyExists) {
                 core.info('Promotion PR already exists (race with a concurrent run); nothing to do.');
                 return;
               }

--- a/.github/workflows/promote-to-master.yml
+++ b/.github/workflows/promote-to-master.yml
@@ -70,12 +70,20 @@ jobs:
               return;
             }
 
-            const created = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo:  context.repo.repo,
-              title: 'Promote verified devel to master',
-              head:  'devel',
-              base:  'master',
-              body,
-            });
-            core.info(`Opened promotion PR #${created.data.number}.`);
+            try {
+              const created = await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                title: 'Promote verified devel to master',
+                head:  'devel',
+                base:  'master',
+                body,
+              });
+              core.info(`Opened promotion PR #${created.data.number}.`);
+            } catch (err) {
+              if (err.status === 422) {
+                core.info('Promotion PR already exists (race with a concurrent run); nothing to do.');
+                return;
+              }
+              throw err;
+            }

--- a/.github/workflows/promote-to-master.yml
+++ b/.github/workflows/promote-to-master.yml
@@ -1,0 +1,81 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: promote-to-master
+
+on:
+  workflow_run:
+    workflows: ["gitlab-ci"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    name: Open or refresh promotion PR
+    if: >
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.head_branch == 'devel'
+      && github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Open or update devel -> master PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha   = context.payload.workflow_run.head_sha;
+            const short = sha.substring(0, 7);
+
+            const cmp = await github.rest.repos.compareCommits({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              base:  'master',
+              head:  'devel',
+            });
+            if (cmp.data.ahead_by === 0) {
+              core.info('devel is not ahead of master; nothing to promote.');
+              return;
+            }
+
+            const body = [
+              'Auto-opened/refreshed after `gitlab-ci` passed on `devel`.',
+              '',
+              `\`devel\` is ${cmp.data.ahead_by} commit(s) ahead of \`master\`.`,
+              `Last verified commit: \`${short}\` ✅`,
+              '',
+              'Merge this PR to ship the verified `devel` snapshot to `master`.',
+            ].join('\n');
+
+            const existing = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              base:  'master',
+              head:  `${context.repo.owner}:devel`,
+              state: 'open',
+            });
+
+            if (existing.data.length > 0) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                pull_number: existing.data[0].number,
+                body,
+              });
+              core.info(`Updated existing promotion PR #${existing.data[0].number}.`);
+              return;
+            }
+
+            const created = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              title: 'Promote verified devel to master',
+              head:  'devel',
+              base:  'master',
+              body,
+            });
+            core.info(`Opened promotion PR #${created.data.number}.`);

--- a/.github/workflows/promote-to-master.yml
+++ b/.github/workflows/promote-to-master.yml
@@ -25,7 +25,7 @@ jobs:
       && github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     steps:
       - name: Open or update devel -> master PR

--- a/.github/workflows/retarget-to-devel.yml
+++ b/.github/workflows/retarget-to-devel.yml
@@ -6,7 +6,7 @@ name: retarget-to-devel
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, edited]
 
 permissions:
   contents: read

--- a/.github/workflows/retarget-to-devel.yml
+++ b/.github/workflows/retarget-to-devel.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: retarget-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   retarget:
     name: Retarget external PRs targeting master
@@ -29,7 +33,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = context.payload.pull_request.number;
+            const pr      = context.payload.pull_request.number;
+            const repoUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}`;
             await github.rest.pulls.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -43,7 +48,7 @@ jobs:
               body: [
                 '👋 Thanks for the contribution! This PR has been automatically retargeted to the `devel` branch.',
                 '',
-                'All external contributions land on `devel` first, where they go through internal verification (proprietary EDA flows) before being promoted to `master` by a maintainer. See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#branch-policy) for the full policy.',
+                `All external contributions land on \`devel\` first, where they go through internal verification (proprietary EDA flows) before being promoted to \`master\` by a maintainer. See [CONTRIBUTING.md](${repoUrl}/blob/master/CONTRIBUTING.md#branch-policy) for the full policy.`,
                 '',
                 'No action needed from you — please continue reviewing changes here.'
               ].join('\n')

--- a/.github/workflows/retarget-to-devel.yml
+++ b/.github/workflows/retarget-to-devel.yml
@@ -1,0 +1,50 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: retarget-to-devel
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  retarget:
+    name: Retarget external PRs targeting master
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.base.ref == 'master'
+      && !(github.event.pull_request.head.ref == 'devel'
+           && github.event.pull_request.head.repo.full_name == github.repository)
+      && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                   github.event.pull_request.author_association)
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Retarget to devel and comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request.number;
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr,
+              base: 'devel'
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body: [
+                '👋 Thanks for the contribution! This PR has been automatically retargeted to the `devel` branch.',
+                '',
+                'All external contributions land on `devel` first, where they go through internal verification (proprietary EDA flows) before being promoted to `master` by a maintainer. See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#branch-policy) for the full policy.',
+                '',
+                'No action needed from you — please continue reviewing changes here.'
+              ].join('\n')
+            });

--- a/.github/workflows/retarget-to-devel.yml
+++ b/.github/workflows/retarget-to-devel.yml
@@ -35,21 +35,40 @@ jobs:
           script: |
             const pr      = context.payload.pull_request.number;
             const repoUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}`;
+            const MARKER  = '<!-- retarget-to-devel -->';
+
             await github.rest.pulls.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pr,
               base: 'devel'
             });
-            await github.rest.issues.createComment({
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr,
-              body: [
-                '👋 Thanks for the contribution! This PR has been automatically retargeted to the `devel` branch.',
-                '',
-                `All external contributions land on \`devel\` first, where they go through internal verification (proprietary EDA flows) before being promoted to \`master\` by a maintainer. See [CONTRIBUTING.md](${repoUrl}/blob/master/CONTRIBUTING.md#branch-policy) for the full policy.`,
-                '',
-                'No action needed from you — please continue reviewing changes here.'
-              ].join('\n')
+              per_page: 100,
             });
+            if (comments.some(c => (c.body || '').includes(MARKER))) {
+              core.info('Retarget comment already posted; skipping.');
+              return;
+            }
+
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body: [
+                  MARKER,
+                  '👋 Thanks for the contribution! This PR has been automatically retargeted to the `devel` branch.',
+                  '',
+                  `All external contributions land on \`devel\` first, where they go through internal verification (proprietary EDA flows) before being promoted to \`master\` by a maintainer. See [CONTRIBUTING.md](${repoUrl}/blob/master/CONTRIBUTING.md#branch-policy) for the full policy.`,
+                  '',
+                  'No action needed from you — please continue reviewing changes here.'
+                ].join('\n')
+              });
+            } catch (err) {
+              core.warning(`Failed to post retarget comment: ${err.message}. PR was retargeted; contributor was not notified.`);
+            }

--- a/.gitlint
+++ b/.gitlint
@@ -19,7 +19,7 @@ line-length=100
 # Valid:   "backend: Fix bug in AXI read path"
 # Invalid: "fixup! something"  "lowercase start"
 [title-match-regex]
-regex=^([a-zA-Z_\-]+(/[a-zA-Z_\-]+)*: )?[A-Z]
+regex=^([a-zA-Z_\-]+(/[a-zA-Z_\-]+)*: )?[A-Z][^:]*$
 
 # Body: second line must be blank
 [body-first-line-empty]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,19 @@ We are happy to accept pull requests and issues from any contributors. Please
 note that we try to maintain a consistent quality standard. For a quick overview
 please find some of the most important points below.
 
+## Branch Policy
+
+* **All external PRs must target the `devel` branch, not `master`.** PRs opened
+  against `master` by non-maintainers are automatically retargeted to `devel`.
+* `master` only receives changes that have passed the full GitLab CI pipeline
+  (which runs the proprietary internal verification flow, including the
+  `nonfree/` child pipeline). When that pipeline passes on `devel`, a rolling
+  `devel → master` promotion PR is opened (or refreshed) automatically.
+* Maintainers merge the promotion PR when they want to ship the verified
+  `devel` snapshot to `master`.
+* For urgent fixes that should bypass the staging step, note "needs
+  fast-track to master" in the PR description and ping a maintainer.
+
 ## Quick Overview
 
 * Keep a clean commit history. This means no merge commits, and no long series
@@ -19,6 +32,7 @@ please find some of the most important points below.
   separated by a slash. For example "hw/vendor: Add patch directory".
 * Create pull requests from a fork rather than making new branches in
   `github.com/pulp_platform/iDMA`.
+* Target PRs at `devel`, not `master` (see [Branch Policy](#branch-policy)).
 * Do not force push.
 * Do not attempt to commit code with a non-Solderpad license without discussing
   first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ please find some of the most important points below.
 * Areas which are not clear by their name alone (e.g., "vendor") should be
   separated by a slash. For example "hw/vendor: Add patch directory".
 * Create pull requests from a fork rather than making new branches in
-  `github.com/pulp_platform/iDMA`.
+  `github.com/pulp-platform/iDMA`.
 * Target PRs at `devel`, not `master` (see [Branch Policy](#branch-policy)).
 * Do not force push.
 * Do not attempt to commit code with a non-Solderpad license without discussing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ please find some of the most important points below.
 * `master` only receives changes that have passed the full GitLab CI pipeline
   (which runs the proprietary internal verification flow, including the
   `nonfree/` child pipeline). When that pipeline passes on `devel`, a rolling
-  `devel → master` promotion PR is opened (or refreshed) automatically.
+  `devel -> master` promotion PR is opened (or refreshed) automatically.
 * Maintainers merge the promotion PR when they want to ship the verified
   `devel` snapshot to `master`.
 * For urgent fixes that should bypass the staging step, note "needs


### PR DESCRIPTION
## Description

Adds a staging-branch workflow so that all external contributions land on `devel` first, are verified by the existing `gitlab-ci` pipeline (which already includes the proprietary `nonfree/` child pipeline running on the internal GitLab mirror), and only then get promoted to `master` automatically.

## What's included

| File | Purpose |
|---|---|
| `.github/workflows/retarget-to-devel.yml` | Auto-retargets PRs from non-maintainers (`author_association ∉ {OWNER, MEMBER, COLLABORATOR}`) that aim at `master`, redirecting them to `devel` with a polite comment. Maintainers can still PR `master` directly. |
| `.github/workflows/promote-to-master.yml` | Listens for `ci` workflow_run completions. On success+push+devel, opens (or refreshes) a single rolling `devel → master` promotion PR. |
| `.github/pull_request_template.md` | Surfaces the branch policy + a short checklist. |
| `CONTRIBUTING.md` | Documents the policy with rationale and the fast-track escape hatch. |
| `.gitlint` | Tightened to reject extra colons in the subject (matches `util/lint-commits.py`). |

## ⚠️ Repo-level setting required before this can fully work

Tested end-to-end on a sandbox (`DanielKellerM/iDMA-policy-sandbox`). Found that the promote workflow fails with:

```
GitHub Actions is not permitted to create or approve pull requests.
```

unless the repo setting is enabled at:

**Settings → Actions → General → Workflow permissions → ☑ "Allow GitHub Actions to create and approve pull requests"**

The retarget workflow does not need this (it uses `pulls.update`, which is covered by the existing `pull-requests: write` token scope). Only the promote workflow's `pulls.create` is gated by this org/repo setting.

## How promotion works end-to-end

1. Contributor opens PR — gets auto-retargeted to `devel` if it pointed at `master`.
2. PR review + `ci` runs (lint, build, analyze, gitlab-ci, etc.); `gitlab-ci` includes the `nonfree/` child pipeline.
3. PR merges into `devel`.
4. Push to `devel` re-triggers `ci`.
5. When `ci` completes green, `promote-to-master.yml` fires and opens/refreshes the rolling `devel → master` PR.
6. A maintainer merges the promotion PR.

## Caveat — fork PRs

`gitlab-ci.yml` skips on fork PRs (no secrets). To verify a fork PR, push its branch as an internal branch first (e.g. `git push origin pr-NNN:pr-NNN-internal`) so `gitlab-ci` runs.

## Validation done before this PR

- `actionlint`-style static review (workflow YAML, permission scopes, expression syntax)
- `act -n` gating tests across 11 scenarios (7 retarget + 4 promote — all match expected)
- Node-based unit tests of the `actions/github-script` bodies with mocked Octokit (10/10 pass) — covers dedup marker, comment-failure tolerance, 422 narrow-swallow, idempotent update vs. create
- Two rounds of adversarial agent review — all findings addressed
- End-to-end sandbox test (`DanielKellerM/iDMA-policy-sandbox`): real `ci → promote-to-master` chain produces correct `devel → master` PR with correct body, head, base.

## Test plan after merge

- [ ] Maintainer enables the Actions PR-creation setting on `pulp-platform/iDMA` (one-time, see above)
- [ ] Open a test fork PR targeting `master`; verify auto-retarget to `devel` with explanatory comment
- [ ] Land a small PR on `devel`; verify the rolling `devel → master` promotion PR is opened by the bot after `ci` goes green
- [ ] Land a second PR on `devel`; verify the same promotion PR is refreshed (body updated), not duplicated

## Notes

- `master` remains the default branch.
- Maintainers retain the ability to push to `master` directly when needed.
- No existing CI is touched.
