### PR TITLE
ci: Bump pulp-platform/pulp-actions from v2 to v2.5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,14 +38,14 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v2
       -
         name: Install RISC-V GCC toolchain
-        uses: pulp-platform/pulp-actions/riscv-gcc-install@v2
+        uses: pulp-platform/pulp-actions/riscv-gcc-install@v2.5.0
         with:
           distro: ubuntu-22.04
           nightly-date: '2023.03.14'
           target: riscv64-elf
       -
         name: Install Bender
-        uses: pulp-platform/pulp-actions/bender-install@v2
+        uses: pulp-platform/pulp-actions/bender-install@v2.5.0
         with:
           version: 0.27.3
       -

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       run: pip install -r requirements.txt
     -
       name: Install Bender
-      uses: pulp-platform/pulp-actions/bender-install@v2
+      uses: pulp-platform/pulp-actions/bender-install@v2.5.0
       with:
         version: 0.27.3
     -

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,14 +37,14 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v2
       -
         name: Install RISC-V GCC toolchain
-        uses: pulp-platform/pulp-actions/riscv-gcc-install@v2
+        uses: pulp-platform/pulp-actions/riscv-gcc-install@v2.5.0
         with:
           distro: ubuntu-22.04
           nightly-date: '2023.03.14'
           target: riscv64-elf
       -
         name: Install Bender
-        uses: pulp-platform/pulp-actions/bender-install@v2
+        uses: pulp-platform/pulp-actions/bender-install@v2.5.0
         with:
           version: 0.27.3
       -

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Mirror and check
-        uses: pulp-platform/pulp-actions/gitlab-ci@v2
+        uses: pulp-platform/pulp-actions/gitlab-ci@v2.5.0
         # Skip on forks or pull requests from forks due to missing secrets.
         if: >
           github.repository == 'pulp-platform/idma' &&

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v4
     -
       name: Check license
-      uses: pulp-platform/pulp-actions/lint-license@v2
+      uses: pulp-platform/pulp-actions/lint-license@v2.5.0
       with:
         license: |
           Copyright (\d{4}(-\d{4})?\s)?(ETH Zurich and University of Bologna|lowRISC contributors).


### PR DESCRIPTION
## Description

The `@v2` tag in our workflows resolves to a 2+ year-old release. Pin to the explicit `v2.5.0` tag (released 2026-03-31).

## What changes

Bumps 7 references across 5 workflow files. No behavioral change beyond what the upstream actions release notes promise:

- `gitlab-ci`: Python 3.9 → 3.12, `pip` → `uv` for dependency management, removed redundant recursive checkout, added `flush=True` for live log output, added clickable pipeline link.
- `riscv-gcc-install`: probe multiple asset name formats so recent compiler releases are found.
- (New action available: `slang`, not used here.)

## Test plan

- [ ] CI passes on this PR with the new pinned action versions
- [ ] No surprise behavior differences (action-side only changes)

## Notes

- Targets `devel` per the branch policy from #102.
- Separate PR from anything else.