### PR TITLE
requirements: Tighten setuptools pin to <79

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ sphinx-rtd-theme
 recommonmark
 sphinxcontrib-svg2pdfconverter
 pylint
-setuptools<81
+setuptools<79


### PR DESCRIPTION
## Description

Follow-up to #100. The `setuptools<81` pin we just landed is directionally correct but too loose: pip resolves to `setuptools 79.0.1` (already in `/home/gitlabci/.local/` on dolent runners) which still has the broken vendored `jaraco/context.py`:

```python
# line 18 of setuptools 79.0.1's vendored jaraco/context.py:
from backports import tarfile
```

Anaconda's stub `backports/__init__.py` doesn't expose tarfile, so the import fails. Same failure as before the `<81` pin.

## Fix

Tighten the pin to `setuptools<79`. This forces pip to install setuptools 78.x, whose vendored jaraco doesn't have the `backports.tarfile` import.

## Verification

Locally reproduced the failure on anaconda Python 3.11 and confirmed the import chain works with `setuptools<79`:

| setuptools | vendored jaraco/context.py has `backports.tarfile` import? |
|---|---|
| 79.0.1 | yes (broken) |
| 78.0.0 | no (works) |
| 77.0.0 | no (works) |

## Test plan

- [ ] CI on master after merge: `gitlab-ci/check` should go green this time
- [ ] If still failing: investigate whether dolent runner's `/home/gitlabci/.local` has additional cached envs

Targets `devel` per branch policy.