### PR TITLE
ci: Install Python deps via per-job venv in init stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,10 @@ stages:
 
 init:
   stage: init
+  before_script:
+    - uv venv .venv
+    - source .venv/bin/activate
+    - uv pip install -r requirements.txt
   script:
     - make idma_nonfree_init
     - make idma_nonfree_ci


### PR DESCRIPTION
## Summary

Adapts iDMA's GitLab CI to the new IIS runners


