### PR TITLE
test: Add default arm to writes_in_flight case as defensive guard

### DIFF
--- a/test/tpl/tb_idma_backend.sv.tpl
+++ b/test/tpl/tb_idma_backend.sv.tpl
@@ -1103,6 +1103,7 @@ axi_rsp_mem       )
                 id = now.id[4:0];
         % endif
     % endfor
+                default: $fatal(1, "Unhandled destination protocol (%0d) in writes_in_flight case", now.dst_protocol);
             endcase
             if (now.err_addr.size() == 0) begin
                 while (writes_in_flight[now.dst_protocol][id] > 0) begin


### PR DESCRIPTION
## Summary

Adds a defensive `default: $fatal(...)` arm to the `case(now.dst_protocol)` block in `tb_idma_backend.sv.tpl`. Without it, an out-of-set `dst_protocol` would leave the `id` variable undefined and the subsequent `writes_in_flight[now.dst_protocol][id]` lookup would index with X bits.

## Context

The underlying bug that surfaced the need for this guard — random job-file generator (in nonfree) emitting `src_protocol=0`/`dst_protocol=0` unconditionally, which trips the existing `$fatal` for variants where AXI isn't a valid source/destination — is fixed at the source in a companion nonfree commit (`gen_random_jobs: Emit per-variant protocol IDs, not hardcoded 0`). After that, the existing `$fatal` checks at the request and ack loops are the canonical correctness gate. This PR adds the case-default arm as belt-and-suspenders for any future codepath that bypasses those checks.

## Test plan

- [x] `make idma_hw_all` regenerates `target/rtl/tb_idma_generated.sv` with the new `default:` arm at each `case(now.dst_protocol)` instance
- [ ] Internal CI run: existing variants continue to pass; coverage of the new `default:` arm via deliberately-invalid stimulus (separate testbench task)