### PR TITLE
ci: Install Python requirements with uv instead of pip

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -21,14 +21,14 @@ jobs:
       name: Checkout
       uses: actions/checkout@v4
     -
-      name: Install Python
-      uses: actions/setup-python@v5
+      name: Install uv
+      uses: astral-sh/setup-uv@v7
       with:
           python-version: '3.9'
-          cache: 'pip'
+          activate-environment: true
     -
       name: Python Requirements
-      run: pip install -r requirements.txt
+      run: uv pip install -r requirements.txt
     -
       name: List contributors
       run: scripts/list-contributors | tee contributions.txt
@@ -48,14 +48,14 @@ jobs:
       name: Checkout
       uses: actions/checkout@v4
     -
-      name: Install Python
-      uses: actions/setup-python@v5
+      name: Install uv
+      uses: astral-sh/setup-uv@v7
       with:
           python-version: '3.9'
-          cache: 'pip'
+          activate-environment: true
     -
       name: Python Requirements
-      run: pip install -r requirements.txt
+      run: uv pip install -r requirements.txt
     -
       name: List todos
       run: scripts/list-todos | tee open_todos.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,14 +25,14 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
-        name: Install Python
-        uses: actions/setup-python@v5
+        name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          python-version: 3.9
-          cache: pip
+          python-version: '3.9'
+          activate-environment: true
       -
         name: Install Python requirements
-        run: pip install -r requirements.txt
+        run: uv pip install -r requirements.txt
       -
         name: Install RISC-V GCC toolchain
         uses: pulp-platform/pulp-actions/riscv-gcc-install@v2.5.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,14 +22,14 @@ jobs:
       with:
           fetch-depth: 0
     -
-      name: Install Python
-      uses: actions/setup-python@v5
+      name: Install uv
+      uses: astral-sh/setup-uv@v7
       with:
           python-version: '3.9'
-          cache: 'pip'
+          activate-environment: true
     -
       name: Python Requirements
-      run: pip install -r requirements.txt
+      run: uv pip install -r requirements.txt
     -
       name: Install Bender
       uses: pulp-platform/pulp-actions/bender-install@v2.5.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,14 +24,14 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
-        name: Install Python
-        uses: actions/setup-python@v5
+        name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          python-version: 3.9
-          cache: pip
+          python-version: '3.9'
+          activate-environment: true
       -
         name: Install Python requirements
-        run: pip install -r requirements.txt
+        run: uv pip install -r requirements.txt
       -
         name: Install RISC-V GCC toolchain
         uses: pulp-platform/pulp-actions/riscv-gcc-install@v2.5.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,13 +119,13 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       -
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.9'
-          cache: 'pip'
+          activate-environment: true
       -
         name: Python Requirements
-        run: python3 -m pip install -r requirements.txt
+        run: uv pip install -r requirements.txt
       -
         name: Lint commits
         run: python3 util/lint-commits.py HEAD
@@ -137,14 +137,14 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
-        name: Install Python
-        uses: actions/setup-python@v5
+        name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
             python-version: '3.9'
-            cache: 'pip'
+            activate-environment: true
       -
         name: Python Requirements
-        run: pip install -r requirements.txt
+        run: uv pip install -r requirements.txt
       -
         name: Lint authors
         run: python3 util/lint-authors.py .github/authors-cfg.yaml

--- a/README.md
+++ b/README.md
@@ -466,8 +466,9 @@ various tools are required.
 - [`bender >= v0.32.0`](https://github.com/pulp-platform/bender)
 - [`Verilator = v4.202`](https://www.veripool.org/verilator)
 - [`Verible >= v0.0-1051-gd4cd328`](https://github.com/chipsalliance/verible)
-- [`Python3 >= 3.8`](https://www.python.org/downloads/) including some the libraries listed
-  in [`requirements.txt`](requirements.txt)
+- [`Python3 >= 3.8`](https://www.python.org/downloads/) with the libraries listed in
+  [`requirements.txt`](requirements.txt), installed e.g. using [`uv`](https://docs.astral.sh/uv/):
+  `uv pip install -r requirements.txt`
 
 ### Building the Documentation
 Use `make doc` to build the documentation. The output is located at `doc/build`.


### PR DESCRIPTION
- All GitHub workflows provision Python via `astral-sh/setup-uv` and install `requirements.txt` with `uv pip install`, matching the internal CI.
- `lint-python`/`lint-yaml` keep `setup-python` (no pip use).

Merge after #110 (adjacent hunks in the same workflow files).