### PR TITLE
build: Rename the pickle output directory to target/pickle

### DIFF
--- a/idma.mk
+++ b/idma.mk
@@ -220,7 +220,7 @@ $(IDMA_FULL_TB): $(IDMA_TB_ALL)
 
 .PHONY: idma_pickle_clean
 
-IDMA_PICKLE_DIR     := $(IDMA_ROOT)/target/morty
+IDMA_PICKLE_DIR     := $(IDMA_ROOT)/target/pickle
 IDMA_PICKLE_TARGETS := -t rtl -t synth -t asic -t snitch_cluster
 IDMA_PICKLE_ARGS    ?=
 

--- a/target/.gitignore
+++ b/target/.gitignore
@@ -1,3 +1,3 @@
 doc
-morty
+pickle
 sim/verilator


### PR DESCRIPTION
- Renames the pickle output from `target/morty` to `target/pickle` now that morty is gone.

Stacked on #110 (do not merge before it; retargets to `devel` once #110 lands). Requires the matching internal flow update to land in lockstep — prepared, pending merge coordination.