### PR TITLE
build: Add per-top trimmed vsim compile scripts

### DIFF
--- a/idma.mk
+++ b/idma.mk
@@ -247,6 +247,19 @@ IDMA_PICKLE_ALL  += $(IDMA_PICKLE_DIR)/idma_rt_midend_synth.sv
 IDMA_PICKLE_ALL  += $(IDMA_PICKLE_DIR)/idma_mp_midend_synth.sv
 
 
+# ---------------
+# Trimmed compile scripts
+# ---------------
+
+# Per-top vsim compile script trimmed via slang (bender >= 0.32.0)
+$(IDMA_VSIM_DIR)/compile_%.tcl: $(IDMA_BENDER_FILES) $(IDMA_FULL_TB) $(IDMA_FULL_RTL) $(IDMA_INCLUDE_ALL) $(IDMA_WAVE_ALL)
+	echo 'set ROOT [file normalize [file dirname [info script]]/../../..]' > $@
+	set -o pipefail; $(BENDER) script vsim --vlog-arg="$(IDMA_VLOG_ARGS)" \
+		-t sim -t test -t idma_test -t synth -t rtl -t asic -t snitch_cluster -t split_rtl \
+		--top $* | grep -v "set ROOT" >> $@
+	echo >> $@
+
+
 # --------------
 # QuestaSim
 # --------------


### PR DESCRIPTION
- `make target/sim/vsim/compile_<top>.tcl` emits a compile script trimmed to files reachable from `<top>` via `bender script --top` (slang-backed): 63 instead of 393 sources for the rw_axi backend TB, verified to compile clean in Questa.
- `pipefail` makes a failed bender invocation fail the rule instead of leaving a header-only script.

Requires `bender >= 0.32.0` at use time (CI bender is bumped by #110 — merge after it). The `systems/` Makefiles can adopt the same `--top` flag in their own PRs (#113 measured 389→37 files for the snitch TB).