### PR TITLE
doc: Regenerate hierarchy graphs from the pickle syntax tree

### DIFF
--- a/.github/authors-cfg.yaml
+++ b/.github/authors-cfg.yaml
@@ -38,6 +38,7 @@ allowed-years:
   - 2023
   - 2024
   - 2025
+  - 2026
 
 allowed-authors:
   Axel Vanoni: axvanoni@ethz.ch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
           nightly-date: '2023.03.14'
           target: riscv64-elf
       -
+        name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
+      -
         name: Install Bender
         uses: pulp-platform/pulp-actions/bender-install@v2.5.0
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,9 @@ jobs:
           nightly-date: '2023.03.14'
           target: riscv64-elf
       -
+        name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
+      -
         name: Install Bender
         uses: pulp-platform/pulp-actions/bender-install@v2.5.0
         with:

--- a/doc/src/frontends/descriptor_fe.rst
+++ b/doc/src/frontends/descriptor_fe.rst
@@ -6,3 +6,6 @@ Frontend for Ariane (CVA6) ready for Linux use.
 .. only:: html
 
 - `descriptor-based frontend <../regs/idma_desc64.html>`_
+
+.. image:: ../../fig/graph/idma_desc64_synth.png
+  :width: 600

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -39,3 +39,13 @@ The main documentation of the submodules is divided into the following sections:
   system_integration.rst
 
 
+.. image:: ../fig/graph/idma_backend_synth_r_axi_w_obi.png
+  :width: 600
+
+.. image:: ../fig/graph/idma_backend_synth_r_obi_w_axi.png
+  :width: 600
+
+.. image:: ../fig/graph/idma_backend_synth_rw_axi.png
+  :width: 600
+
+

--- a/doc/src/midend.rst
+++ b/doc/src/midend.rst
@@ -3,3 +3,6 @@ iDMA Midends
 
 The midends decompose multi-dimensional and real-time transfer requests into 1D transfers
 for the backend.
+
+.. image:: ../fig/graph/idma_nd_midend_synth.png
+  :width: 600

--- a/idma.mk
+++ b/idma.mk
@@ -220,7 +220,7 @@ $(IDMA_FULL_TB): $(IDMA_TB_ALL)
 
 .PHONY: idma_pickle_clean
 
-IDMA_PICKLE_DIR     := $(IDMA_ROOT)/target/morty
+IDMA_PICKLE_DIR     := $(IDMA_ROOT)/target/pickle
 IDMA_PICKLE_TARGETS := -t rtl -t synth -t asic -t snitch_cluster
 IDMA_PICKLE_ARGS    ?=
 

--- a/idma.mk
+++ b/idma.mk
@@ -148,6 +148,7 @@ IDMA_WAVE_ALL    += $(foreach Y,$(IDMA_BACKEND_IDS),$(IDMA_VSIM_DIR)/wave/backen
 .PHONY: idma_reg_clean
 
 IDMA_DOC_SRC_DIR := $(IDMA_ROOT)/doc/src
+IDMA_DOC_FIG_DIR := $(IDMA_ROOT)/doc/fig
 IDMA_DOC_OUT_DIR := $(IDMA_ROOT)/target/doc
 IDMA_HTML_DIR    := $(IDMA_DOC_OUT_DIR)/html
 IDMA_FE_DIR      := $(IDMA_ROOT)/src/frontend
@@ -228,22 +229,41 @@ $(IDMA_PICKLE_DIR)/%.sv: $(IDMA_BENDER_FILES) $(IDMA_FULL_TB) $(IDMA_FULL_RTL) $
 	mkdir -p $(IDMA_PICKLE_DIR)
 	$(BENDER) pickle $(IDMA_PICKLE_TARGETS) --top $* --expand-macros $(IDMA_PICKLE_ARGS) -o $@
 
+# hierarchy graphs
+IDMA_DOT     ?= dot
+IDMA_AST2DOT := $(IDMA_UTIL_DIR)/ast2dot.py
+
+$(IDMA_PICKLE_DIR)/%.dot: $(IDMA_AST2DOT) $(IDMA_BENDER_FILES) $(IDMA_FULL_TB) $(IDMA_FULL_RTL) $(IDMA_INCLUDE_ALL)
+	mkdir -p $(IDMA_PICKLE_DIR)
+	set -o pipefail; $(BENDER) pickle $(IDMA_PICKLE_TARGETS) --top $* --expand-macros --ast-json | \
+		$(PYTHON) $(IDMA_AST2DOT) - --top $* -o $@
+
+$(IDMA_DOC_FIG_DIR)/graph/%.png: $(IDMA_PICKLE_DIR)/%.dot
+	mkdir -p $(IDMA_DOC_FIG_DIR)/graph
+	$(IDMA_DOT) -Tpng $< > $@
+
 idma_pickle_clean:
 	rm -rf $(IDMA_PICKLE_DIR)
+	rm -f  $(IDMA_DOC_FIG_DIR)/graph/*.png
 
 # 1Ds
+IDMA_RTL_DOC_ALL += $(foreach Y,$(IDMA_BACKEND_IDS),$(IDMA_DOC_FIG_DIR)/graph/idma_backend_synth_$Y.png)
 IDMA_PICKLE_ALL  += $(foreach Y,$(IDMA_BACKEND_IDS),$(IDMA_PICKLE_DIR)/idma_backend_synth_$Y.sv)
 
 # nDs
+IDMA_RTL_DOC_ALL += $(IDMA_DOC_FIG_DIR)/graph/idma_nd_midend_synth.png
 IDMA_PICKLE_ALL  += $(IDMA_PICKLE_DIR)/idma_nd_midend_synth.sv
 
 # descriptor-based frontend
+IDMA_RTL_DOC_ALL += $(IDMA_DOC_FIG_DIR)/graph/idma_desc64_synth.png
 IDMA_PICKLE_ALL  += $(IDMA_PICKLE_DIR)/idma_desc64_synth.sv
 
 # RT midend
+IDMA_RTL_DOC_ALL += $(IDMA_DOC_FIG_DIR)/graph/idma_rt_midend_synth.png
 IDMA_PICKLE_ALL  += $(IDMA_PICKLE_DIR)/idma_rt_midend_synth.sv
 
 # Mempool midend
+IDMA_RTL_DOC_ALL += $(IDMA_DOC_FIG_DIR)/graph/idma_mp_midend_synth.png
 IDMA_PICKLE_ALL  += $(IDMA_PICKLE_DIR)/idma_mp_midend_synth.sv
 
 

--- a/target/.gitignore
+++ b/target/.gitignore
@@ -1,3 +1,3 @@
 doc
-morty
+pickle
 sim/verilator

--- a/util/ast2dot.py
+++ b/util/ast2dot.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+# Authors:
+# - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+"""Generate a module-hierarchy DOT graph from `bender pickle --ast-json` output.
+
+The input is a JSON array of slang syntax trees (CST serializer output):
+    [{"kind": "SyntaxTree", "root": {...}}, ...]
+
+Relevant CST node kinds:
+    ModuleDeclaration / InterfaceDeclaration / ProgramDeclaration
+        .header.name.text          -> declared name
+    PackageDeclaration
+        .header.name.text          -> declared package name
+    HierarchyInstantiation
+        .type.text                 -> instantiated module/interface name
+        .parameters                -> present iff parameterized (#(...))
+        .instances[].decl.name     -> instance names
+    PackageImportItem  .package.text     -> imported package
+    ScopedName         .left...text '::' -> package reference
+
+Generate blocks (GenerateBlock/IfGenerate/LoopGenerate) simply nest inside the
+module body, so a recursive walk picks up the instantiations they contain.
+Instantiated names with no matching declaration in the file set (primitives,
+blackboxes, unresolved) are skipped and reported on stderr.
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+
+DECL_KINDS = {
+    'ModuleDeclaration': 'module',
+    'InterfaceDeclaration': 'interface',
+    'ProgramDeclaration': 'program',
+    'PackageDeclaration': 'package',
+}
+
+
+def iter_nodes(root, skip_decls=False):
+    """Iteratively yield all dict nodes (avoids recursion limits on deep CSTs).
+
+    With skip_decls, nested module/interface/package declarations are yielded
+    but not descended into (their bodies belong to the nested scope)."""
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            yield node
+            if skip_decls and node.get('kind') in DECL_KINDS:
+                continue
+            for key, val in node.items():
+                if key != 'trivia':  # comments/whitespace: irrelevant, large
+                    stack.append(val)
+        elif isinstance(node, list):
+            stack.extend(node)
+
+
+def decl_name(node):
+    name = node.get('header', {}).get('name', {})
+    return name.get('text')
+
+
+def collect(trees):
+    """Return (decls, edges) where decls maps name->kind and edges maps
+    parent -> {child: {'params': bool, 'count': int}}."""
+    decls = {}
+    bodies = []  # (name, node)
+    for tree in trees:
+        for node in iter_nodes(tree.get('root', {})):
+            kind = node.get('kind')
+            if kind in DECL_KINDS:
+                name = decl_name(node)
+                if name:
+                    decls[name] = DECL_KINDS[kind]
+                    bodies.append((name, node))
+
+    edges = defaultdict(dict)
+    unresolved = set()
+    for parent, body in bodies:
+        for node in iter_nodes(body.get('members', []), skip_decls=True):
+            kind = node.get('kind')
+            if kind == 'HierarchyInstantiation':
+                child = node.get('type', {}).get('text')
+                if not child:
+                    continue
+                info = edges[parent].setdefault(child, {'params': False, 'count': 0})
+                info['params'] |= node.get('parameters') is not None
+                info['count'] += len(node.get('instances', [])) or 1
+            elif kind == 'PackageImportItem':
+                pkg = node.get('package', {}).get('text')
+                if pkg:
+                    edges[parent].setdefault(pkg, {'params': False, 'count': 0})
+            elif kind == 'ScopedName':
+                # `pkg::name` only; ScopedName also covers dotted hier names
+                if node.get('separator', {}).get('kind') != 'DoubleColon':
+                    continue
+                left = node.get('left', {})
+                if left.get('kind') == 'IdentifierName':
+                    pkg = left.get('identifier', {}).get('text')
+                    if pkg:
+                        edges[parent].setdefault(pkg, {'params': False, 'count': 0})
+
+    # Drop references to names that have no declaration (primitives, $units,
+    # type names misread as scopes, blackboxes).
+    for parent in list(edges):
+        for child in list(edges[parent]):
+            if child not in decls:
+                unresolved.add(child)
+                del edges[parent][child]
+    return decls, edges, unresolved
+
+
+def reachable(edges, top):
+    seen = set()
+    stack = [top]
+    while stack:
+        node = stack.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        stack.extend(edges.get(node, {}))
+    return seen
+
+
+def emit_dot(decls, edges, nodes, out):
+    out.write('digraph {\n')
+    ids = {}
+    for i, name in enumerate(sorted(nodes)):
+        ids[name] = i
+        shape = ' shape = "box"' if decls.get(name) == 'package' else ''
+        out.write(f'    {i} [ label = "\\"{name}\\""{shape} ]\n')
+    for parent in sorted(edges):
+        if parent not in ids:
+            continue
+        for child in sorted(edges[parent]):
+            if child not in ids:
+                continue
+            out.write(f'    {ids[parent]} -> {ids[child]} [ ]\n')
+    out.write('}\n')
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('json_file', help="bender pickle --ast-json output ('-' for stdin)")
+    ap.add_argument('--top', help='restrict graph to nodes reachable from this module')
+    ap.add_argument('-o', '--output', default='-', help='output DOT file (default stdout)')
+    ap.add_argument('--no-packages', action='store_true',
+                    help='omit package nodes and edges')
+    args = ap.parse_args()
+
+    if args.json_file == '-':
+        trees = json.load(sys.stdin)
+    else:
+        with open(args.json_file) as f:
+            trees = json.load(f)
+
+    decls, edges, unresolved = collect(trees)
+
+    if args.no_packages:
+        pkgs = {n for n, k in decls.items() if k == 'package'}
+        decls = {n: k for n, k in decls.items() if k != 'package'}
+        for parent in list(edges):
+            if parent in pkgs:
+                del edges[parent]
+                continue
+            for child in pkgs & edges[parent].keys():
+                del edges[parent][child]
+
+    if args.top:
+        if args.top not in decls:
+            sys.exit(f'error: top module {args.top!r} not found in file set')
+        nodes = reachable(edges, args.top)
+    else:
+        nodes = set(decls)
+
+    if unresolved:
+        print(f'note: skipped unresolved names: {", ".join(sorted(unresolved))}',
+              file=sys.stderr)
+
+    if args.output == '-':
+        emit_dot(decls, edges, nodes, sys.stdout)
+    else:
+        with open(args.output, 'w') as f:
+            emit_dot(decls, edges, nodes, f)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- `util/ast2dot.py` (stdlib-only) walks `bender pickle --ast-json` output and emits the module hierarchy as DOT, restoring the doc figures retired with morty.
- With reachable-from-top filtering the graphs are node- and edge-identical to the old morty output; ~1.5 s per top instead of ~7 s.
- Graphviz returns to the build/docs CI; the JSON never hits disk (piped).

Stacked on #110 → #114 (merge in that order; retargets as they land).