### PR TITLE
ci: Make mirror pipeline jobs interruptible for auto-cancel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,9 @@
 # Authors:
 # - Thomas Benz <tbenz@iis.ee.ethz.ch>
 
+default:
+  interruptible: true
+
 stages:
   - init
   - idma


### PR DESCRIPTION
Set `interruptible: true` at the `default:` level of `.gitlab-ci.yml` so the project's already-enabled `auto_cancel_pending_pipelines` cancels the in-flight devel pipeline (the `init` job and the `idma` trigger, which cascades to the nonfree child) when a newer commit lands, instead of running stale EDA work to completion.

The nonfree CI side was marked interruptible in lockstep (deployed). The GitHub workflows already cancel via `ci.yml`'s `concurrency: cancel-in-progress`.