### PR TITLE
docs: Align Starlight site with generated hierarchy graphs

### DIFF
--- a/doc/site/.gitignore
+++ b/doc/site/.gitignore
@@ -1,0 +1,2 @@
+# Generated hierarchy graphs (copied in by `make idma_doc_site`)
+public/fig/graph/

--- a/doc/site/src/content/docs/architecture/hierarchy.md
+++ b/doc/site/src/content/docs/architecture/hierarchy.md
@@ -1,0 +1,27 @@
+---
+title: Module Hierarchy
+description: Generated module-hierarchy graphs for the synthesizable iDMA tops.
+---
+
+These graphs are generated from the bender-pickle syntax tree (`util/ast2dot.py`)
+for each synthesizable top, so they always reflect the current RTL. Regenerate
+them with `make idma_doc_all`, then `make idma_doc_site` copies them into this
+site under `public/fig/graph/`.
+
+:::note[Draft]
+This page is a starting point for aligning the site with the regenerated
+hierarchy graphs — the figures and prose are still being brought up to date with
+the latest repository state.
+:::
+
+## Backend — `rw_axi`
+
+![idma_backend_synth_rw_axi](/fig/graph/idma_backend_synth_rw_axi.png)
+
+## ND Midend
+
+![idma_nd_midend_synth](/fig/graph/idma_nd_midend_synth.png)
+
+## Descriptor Frontend
+
+![idma_desc64_synth](/fig/graph/idma_desc64_synth.png)

--- a/doc/site/src/content/docs/guides/quickstart.md
+++ b/doc/site/src/content/docs/guides/quickstart.md
@@ -7,6 +7,25 @@ description: Minimal steps to integrate iDMA and run a transfer.
 
 This guide shows the shortest path to an end-to-end iDMA transfer: choose a backend, define types, wire modules, and launch a request. It assumes a single clock domain and a 1D transfer flow.
 
+## Build the Generated RTL
+
+iDMA's SystemVerilog is generated from templates, so the first step in any checkout is to render it.
+
+**Prerequisites:** [`bender >= 0.32.0`](https://github.com/pulp-platform/bender) and [`Python >= 3.11`](https://www.python.org/downloads/) with [`uv`](https://docs.astral.sh/uv/).
+
+```bash
+uv sync                    # install the generator deps (mako, peakrdl, …) into .venv
+uv run make idma_hw_all    # render the templates into target/rtl/
+```
+
+`uv run` executes inside the synced environment, so no manual `source .venv/bin/activate` is needed. The generated sources land in `target/rtl/` and are what Bender exposes through its `rtl` and `synth` targets.
+
+When iDMA is pulled as a Bender dependency, regenerate its RTL from the consuming repo with the same environment, e.g.:
+
+```bash
+make -C $(bender path idma) idma_hw_all
+```
+
 ## 1. Choose a Backend Variant
 
 Pick the backend variant that matches your read/write protocols. For AXI-to-AXI systems, start with `rw_axi`.

--- a/doc/site/src/content/docs/guides/quickstart.md
+++ b/doc/site/src/content/docs/guides/quickstart.md
@@ -14,13 +14,12 @@ iDMA's SystemVerilog is generated from templates, so the first step in any check
 **Prerequisites:** [`bender >= 0.32.0`](https://github.com/pulp-platform/bender) and [`Python >= 3.11`](https://www.python.org/downloads/) with [`uv`](https://docs.astral.sh/uv/).
 
 ```bash
-uv sync                    # install the generator deps (mako, peakrdl, …) into .venv
-uv run make idma_hw_all    # render the templates into target/rtl/
+make idma_hw_all
 ```
 
-`uv run` executes inside the synced environment, so no manual `source .venv/bin/activate` is needed. The generated sources land in `target/rtl/` and are what Bender exposes through its `rtl` and `synth` targets.
+On first run this provisions a local `uv` environment (`uv sync --locked`) — no manual venv setup or activation needed — and renders the templates into `target/rtl/`, which Bender exposes through its `rtl` and `synth` targets.
 
-When iDMA is pulled as a Bender dependency, regenerate its RTL from the consuming repo with the same environment, e.g.:
+When iDMA is pulled as a Bender dependency, regenerate its RTL from the consuming repo the same way:
 
 ```bash
 make -C $(bender path idma) idma_hw_all

--- a/idma.mk
+++ b/idma.mk
@@ -626,6 +626,14 @@ idma_spinx_doc: $(IDMA_RTL_DOC_ALL)
 idma_spinx_doc_clean:
 	rm -rf $(IDMA_DOC_OUT_DIR)
 
+.PHONY: idma_doc_site
+
+IDMA_SITE_DIR := $(IDMA_ROOT)/doc/site
+
+idma_doc_site: $(IDMA_RTL_DOC_ALL)
+	mkdir -p $(IDMA_SITE_DIR)/public/fig/graph
+	cp -f $(IDMA_DOC_FIG_DIR)/graph/*.png $(IDMA_SITE_DIR)/public/fig/graph/
+
 
 # --------------
 # Nonfree


### PR DESCRIPTION
**Draft — work in progress.** A single workspace to bring the new Starlight docs site (#103) and the regenerated module-hierarchy graphs (#117) into alignment, and to refresh the docs to the current state of the repo.

### Starter in this PR
- New `architecture/hierarchy.md` page wired to the `ast2dot`-generated graphs (`/fig/graph/*.png`).
- `make idma_doc_site` target that copies the generated `doc/fig/graph/*.png` into the site's `public/fig/graph/`.
- `.gitignore` so the generated graphs aren't committed.

### TODO (to be filled in)
- [ ] Regenerate the hierarchy graphs from the current RTL (`make idma_doc_all`) and verify they render in the site.
- [ ] Bring the architecture/guide pages up to date with the latest repo (post pickle/uv/rename changes).
- [ ] Decide whether/how to build + deploy the Starlight site in CI (currently Pages serves the Sphinx docs).
- [ ] Reconcile the static SVGs (`public/fig/*.svg`) vs the generated graphs.

Preview of the current site: https://danielkellerm.github.io/iDMA/ (fork).