### PR TITLE
ci: Cache the bender git database keyed on the lockfile

### DIFF
--- a/.github/actions/bender-db-cache/action.yml
+++ b/.github/actions/bender-db-cache/action.yml
@@ -1,0 +1,18 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Cache Bender database
+description: Relocate bender's bare-repo git database to a cached path
+# A committed .bender.yml setting db_dir would silently override BENDER_DB_DIR.
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: echo "BENDER_DB_DIR=$HOME/.cache/bender-db" >> "$GITHUB_ENV"
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/bender-db
+        key: bender-db-${{ runner.os }}-${{ hashFiles('Bender.lock') }}
+        restore-keys: |
+          bender-db-${{ runner.os }}-

--- a/.github/actions/bender-db-cache/action.yml
+++ b/.github/actions/bender-db-cache/action.yml
@@ -2,9 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Authors:
+# - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
 name: Cache Bender database
 description: Relocate bender's bare-repo git database to a cached path
-# A committed .bender.yml setting db_dir would silently override BENDER_DB_DIR.
 runs:
   using: composite
   steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
+        name: Cache Bender database
+        uses: ./.github/actions/bender-db-cache
+      -
         name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ jobs:
       with:
           fetch-depth: 0
     -
+      name: Cache Bender database
+      uses: ./.github/actions/bender-db-cache
+    -
       name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,9 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
+        name: Cache Bender database
+        uses: ./.github/actions/bender-db-cache
+      -
         name: Install uv
         uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
- `BENDER_DB_DIR` relocates bender's bare-repo database to a cacheable path; `actions/cache` keys it on `Bender.lock` with a restore-key fallback, so a stale cache self-heals via incremental fetch instead of a full re-clone.
- Warm checkouts need no network (~0.09 s vs ~2 s cold locally; cache is ~18 MB), removing github.com clone flakiness from build/docs/deploy.
- The database (bare repos) is cached rather than the project-local `.bender/`: it is smaller (18 MB vs 26 MB), position-independent, and reusable across lock bumps, while `.bender/` checkouts carry absolute-path alternates into the database and are rebuilt from it in 0.08 s anyway.

Note: a committed `.bender.yml` setting `db_dir` would silently override the env var — none exists today.