### PR TITLE
build: Drop setuptools pin and dead regtool make vars

### DIFF
--- a/idma.mk
+++ b/idma.mk
@@ -40,8 +40,6 @@ IDMA_FE_IDS      := $(IDMA_BASE_FE_IDS) $(IDMA_ADD_FE_IDS)
 
 # iDMA paths
 IDMA_ROOT     ?= $(shell $(BENDER) path idma)
-IDMA_REG_DIR  := $(shell $(BENDER) path register_interface)
-IDMA_REGTOOL  ?= $(IDMA_REG_DIR)/vendor/lowrisc_opentitan/util/regtool.py
 IDMA_UTIL_DIR := $(IDMA_ROOT)/util
 IDMA_RTL_DIR  := $(IDMA_ROOT)/target/rtl
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,4 @@ dependencies = [
     "pylint",
     "peakrdl>=1.5.0",
     "peakrdl-rawheader>=0.2.4",
-    "setuptools<79",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,6 @@ dependencies = [
     { name = "pylint" },
     { name = "pyyaml" },
     { name = "recommonmark" },
-    { name = "setuptools" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-rtd-theme" },
@@ -290,7 +289,6 @@ requires-dist = [
     { name = "pylint" },
     { name = "pyyaml" },
     { name = "recommonmark" },
-    { name = "setuptools", specifier = "<79" },
     { name = "sphinx" },
     { name = "sphinx-rtd-theme" },
     { name = "sphinxcontrib-svg2pdfconverter" },
@@ -749,15 +747,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "78.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/9c/42314ee079a3e9c24b27515f9fbc7a3c1d29992c33451779011c74488375/setuptools-78.1.1.tar.gz", hash = "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d", size = 1368163, upload-time = "2025-04-19T18:23:36.68Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/99/158ad0609729111163fc1f674a5a42f2605371a4cf036d0441070e2f7455/setuptools-78.1.1-py3-none-any.whl", hash = "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561", size = 1256462, upload-time = "2025-04-19T18:23:34.525Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to the SystemRDL/PeakRDL migration (#73).

regtool imported `pkg_resources`, which setuptools 79 removed, so the
build pinned `setuptools<79`. PeakRDL replaced regtool, so the pin is no
longer needed. Also drops the now-unused `IDMA_REGTOOL` / `IDMA_REG_DIR`
make variables.

`uv lock` drops setuptools entirely; `make idma_hw_all` regenerates all
RTL with no drift.