### PR TITLE
backend: Fix multi-head datapath bugs and add a verification testbench

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -131,7 +131,6 @@ sources:
       - target/rtl/tb_idma_generated.sv
 
   # Multi-head directed backend testbenches
-  # (need IDMA_ADD_IDS="2r_axi_w_axi 2rw_axi" at gen time)
   - target: multihead
     files:
       - test/tb_idma_backend_multihead.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -129,3 +129,8 @@ sources:
   - target: idma_test
     files:
       - target/rtl/tb_idma_generated.sv
+
+  # Multi-head directed backend testbench (needs IDMA_ADD_IDS=2r_axi_w_axi at gen time)
+  - target: multihead
+    files:
+      - test/tb_idma_backend_multihead.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -130,7 +130,9 @@ sources:
     files:
       - target/rtl/tb_idma_generated.sv
 
-  # Multi-head directed backend testbench (needs IDMA_ADD_IDS=2r_axi_w_axi at gen time)
+  # Multi-head directed backend testbenches
+  # (need IDMA_ADD_IDS="2r_axi_w_axi 2rw_axi" at gen time)
   - target: multihead
     files:
       - test/tb_idma_backend_multihead.sv
+      - test/tb_idma_backend_multihead_rw.sv

--- a/src/backend/tpl/idma_backend.sv.tpl
+++ b/src/backend/tpl/idma_backend.sv.tpl
@@ -486,7 +486,7 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
         // assemble write datapath request
         assign w_req.w_dp_req = '{
             dst_protocol: idma_req_i.opt.dst_protocol,
-            dst_head:     idma_req_i.opt.src_head,
+            dst_head:     idma_req_i.opt.dst_head,
             offset:       idma_req_i.dst_addr[OffsetWidth-1:0],
             tailer:       OffsetWidth'(idma_req_i.length + idma_req_i.dst_addr[OffsetWidth-1:0]),
             shift:        OffsetWidth'(- idma_req_i.dst_addr[OffsetWidth-1:0]),

--- a/src/backend/tpl/idma_transport_layer.sv.tpl
+++ b/src/backend/tpl/idma_transport_layer.sv.tpl
@@ -217,7 +217,7 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     // shifted data flowing into the buffer
 % if not one_read_port:
     % for p in used_read_protocols:
-    byte_t [StrbWidth-1:0] ${mh_format['ar'][p]}${p}_buffer_in;
+    byte_t ${mh_format['ar'][p]}[StrbWidth-1:0] ${p}_buffer_in;
     % endfor
 % endif
     byte_t [StrbWidth-1:0] buffer_in;
@@ -487,7 +487,7 @@ ${rendered_write_ports[write_port]}
         .data_i     ( w_dp_req_i.dst_head                            ),
         .valid_i    ( w_resp_fifo_in_valid && w_resp_fifo_in_ready   ),
         .ready_o    ( /* NOT CONNECTED */                            ),
-        .data_o     ( w_resp_fifo_out_multihead                      ),
+        .data_o     ( w_resp_fifo_out_head                      ),
         .valid_o    ( /* NOT CONNECTED */                            ),
         .ready_i    ( w_resp_fifo_out_ready && w_resp_fifo_out_valid )
     );
@@ -517,9 +517,9 @@ ${rendered_write_ports[write_port]}
                 w_dp_rsp_mux       = ${wp}_w_dp_rsp;
                 ${wp}_w_dp_rsp_ready = w_dp_rsp_mux_ready;
     % else:
-                w_dp_rsp_mux_valid = ${wp}_w_dp_rsp_valid [w_resp_fifo_out_multihead];
-                w_dp_rsp_mux       = ${wp}_w_dp_rsp [w_resp_fifo_out_multihead];
-                ${wp}_w_dp_rsp_ready [w_resp_fifo_out_multihead] = w_dp_rsp_mux_ready;
+                w_dp_rsp_mux_valid = ${wp}_w_dp_rsp_valid [w_resp_fifo_out_head];
+                w_dp_rsp_mux       = ${wp}_w_dp_rsp [w_resp_fifo_out_head];
+                ${wp}_w_dp_rsp_ready [w_resp_fifo_out_head] = w_dp_rsp_mux_ready;
     % endif
             end
 % endfor

--- a/test/idma_test.sv
+++ b/test/idma_test.sv
@@ -687,16 +687,17 @@ package idma_test;
             input logic [2:0] dst_max_llen,
             input logic       src_reduce_len,
             input logic       dst_reduce_len,
-            input id_t        id
+            input id_t        id,
+            input idma_pkg::multihead_t src_head = '0,
+            input idma_pkg::multihead_t dst_head = '0
         );
             idma.req.length                 <= #TA length;
-            idma.req.src_addr               <= #TA src_addr;
             idma.req.src_addr               <= #TA src_addr;
             idma.req.dst_addr               <= #TA dst_addr;
             idma.req.opt.src_protocol       <= #TA src_protocol;
             idma.req.opt.dst_protocol       <= #TA dst_protocol;
-            idma.req.opt.src_head           <= #TA '0;
-            idma.req.opt.dst_head           <= #TA '0;
+            idma.req.opt.src_head           <= #TA src_head;
+            idma.req.opt.dst_head           <= #TA dst_head;
             idma.req.opt.axi_id             <= #TA id;
             idma.req.opt.beo.decouple_aw    <= #TA decouple_aw;
             idma.req.opt.beo.decouple_rw    <= #TA decouple_rw;

--- a/test/tb_idma_backend_multihead.sv
+++ b/test/tb_idma_backend_multihead.sv
@@ -1,0 +1,246 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// Directed self-checking testbench for the multi-head AXI backend
+// (idma_backend_2r_axi_w_axi: 2 read heads, 1 write head). Each read head drives
+// its own axi_sim_mem so read-head routing is observable: src_head selects which
+// read memory a transfer sources from, while all writes land in the single write
+// memory. Preloading distinct data per read head and checking the write memory
+// catches a backend that ignores or mis-routes src_head. Recycles the per-head
+// memory harness pattern from the vidma inst64 verification harness.
+
+`timescale 1ns/1ns
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+
+module tb_idma_backend_multihead import idma_pkg::*; #(
+    parameter int unsigned NumReadHeads = 2,
+    parameter int unsigned BufferDepth  = 3,
+    parameter int unsigned NumAxInFlight = 3,
+    parameter int unsigned DataWidth    = 32,
+    parameter int unsigned AddrWidth    = 32,
+    parameter int unsigned UserWidth    = 1,
+    parameter int unsigned AxiIdWidth   = 12,
+    parameter int unsigned TFLenWidth   = 32,
+    parameter int unsigned MemSysDepth  = 0,
+    parameter bit          CombinedShifter   = 1'b0,
+    parameter int unsigned WatchDogNumCycles = 1000
+);
+
+    localparam time TA  = 1ns;
+    localparam time TT  = 9ns;
+    localparam time TCK = 10ns;
+
+    localparam int unsigned StrbWidth   = DataWidth / 8;
+    localparam int unsigned OffsetWidth = $clog2(StrbWidth);
+    localparam idma_pkg::error_cap_e ErrorCap = idma_pkg::NO_ERROR_HANDLING;
+
+    typedef logic [7:0]             byte_t;
+    typedef logic [AddrWidth-1:0]   addr_t;
+    typedef logic [DataWidth-1:0]   data_t;
+    typedef logic [StrbWidth-1:0]   strb_t;
+    typedef logic [UserWidth-1:0]   user_t;
+    typedef logic [AxiIdWidth-1:0]  id_t;
+    typedef logic [TFLenWidth-1:0]  tf_len_t;
+
+    `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, addr_t, id_t, user_t)
+    `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, data_t, strb_t, user_t)
+    `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, id_t, user_t)
+    `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, addr_t, id_t, user_t)
+    `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, data_t, id_t, user_t)
+    `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_chan_t, axi_w_chan_t, axi_ar_chan_t)
+    `AXI_TYPEDEF_RESP_T(axi_rsp_t, axi_b_chan_t, axi_r_chan_t)
+
+    `IDMA_TYPEDEF_FULL_REQ_T(idma_req_t, id_t, addr_t, tf_len_t)
+    `IDMA_TYPEDEF_FULL_RSP_T(idma_rsp_t, addr_t)
+
+    typedef struct packed { axi_ar_chan_t ar_chan; } axi_read_meta_channel_t;
+    typedef struct packed { axi_read_meta_channel_t axi; } read_meta_channel_t;
+    typedef struct packed { axi_aw_chan_t aw_chan; } axi_write_meta_channel_t;
+    typedef struct packed { axi_write_meta_channel_t axi; } write_meta_channel_t;
+
+    // clock / reset
+    logic clk;
+    logic rst_n;
+
+    // dma request / response
+    idma_req_t idma_req;
+    logic req_valid, req_ready;
+    idma_rsp_t idma_rsp;
+    logic rsp_valid, rsp_ready;
+    idma_eh_req_t idma_eh_req;
+    logic eh_req_valid, eh_req_ready;
+    idma_busy_t busy;
+
+    // 2 read master buses (one per read head), 1 write master bus
+    axi_req_t [NumReadHeads-1:0] axi_read_req;
+    axi_rsp_t [NumReadHeads-1:0] axi_read_rsp;
+    axi_req_t axi_write_req;
+    axi_rsp_t axi_write_rsp;
+
+    // driver
+    IDMA_DV #(
+        .DataWidth (DataWidth), .AddrWidth (AddrWidth), .UserWidth (UserWidth),
+        .AxiIdWidth (AxiIdWidth), .TFLenWidth (TFLenWidth)
+    ) idma_dv (clk);
+
+    typedef idma_test::idma_driver #(
+        .DataWidth (DataWidth), .AddrWidth (AddrWidth), .UserWidth (UserWidth),
+        .AxiIdWidth (AxiIdWidth), .TFLenWidth (TFLenWidth), .TA (TA), .TT (TT)
+    ) drv_t;
+    drv_t drv = new(idma_dv);
+
+    assign idma_req         = idma_dv.req;
+    assign req_valid        = idma_dv.req_valid;
+    // TB never inspects the completion response, only the written memory; keep
+    // rsp_ready asserted so the AXI read datapath can drain R into the buffer.
+    assign rsp_ready        = 1'b1;
+    assign idma_eh_req      = idma_dv.eh_req;
+    assign eh_req_valid     = idma_dv.eh_req_valid;
+    assign idma_dv.req_ready    = req_ready;
+    assign idma_dv.rsp          = idma_rsp;
+    assign idma_dv.rsp_valid    = rsp_valid;
+    assign idma_dv.eh_req_ready = eh_req_ready;
+
+    clk_rst_gen #(.ClkPeriod (TCK), .RstClkCycles (1)) i_clk_rst_gen (
+        .clk_o (clk), .rst_no (rst_n)
+    );
+
+    // one dedicated read memory per read head
+    for (genvar h = 0; h < NumReadHeads; h++) begin : gen_rmem
+        axi_sim_mem #(
+            .AddrWidth (AddrWidth), .DataWidth (DataWidth), .IdWidth (AxiIdWidth),
+            .UserWidth (UserWidth), .axi_req_t (axi_req_t), .axi_rsp_t (axi_rsp_t),
+            .WarnUninitialized (1'b0), .ClearErrOnAccess (1'b1),
+            .ApplDelay (TA), .AcqDelay (TT)
+        ) i_axi_sim_mem (
+            .clk_i (clk), .rst_ni (rst_n),
+            .axi_req_i (axi_read_req[h]), .axi_rsp_o (axi_read_rsp[h]),
+            .mon_r_last_o (), .mon_r_beat_count_o (), .mon_r_user_o (), .mon_r_id_o (),
+            .mon_r_data_o (), .mon_r_addr_o (), .mon_r_valid_o (),
+            .mon_w_last_o (), .mon_w_beat_count_o (), .mon_w_user_o (), .mon_w_id_o (),
+            .mon_w_data_o (), .mon_w_addr_o (), .mon_w_valid_o ()
+        );
+    end
+
+    // single write memory
+    axi_sim_mem #(
+        .AddrWidth (AddrWidth), .DataWidth (DataWidth), .IdWidth (AxiIdWidth),
+        .UserWidth (UserWidth), .axi_req_t (axi_req_t), .axi_rsp_t (axi_rsp_t),
+        .WarnUninitialized (1'b0), .ClearErrOnAccess (1'b1),
+        .ApplDelay (TA), .AcqDelay (TT)
+    ) i_write_mem (
+        .clk_i (clk), .rst_ni (rst_n),
+        .axi_req_i (axi_write_req), .axi_rsp_o (axi_write_rsp),
+        .mon_r_last_o (), .mon_r_beat_count_o (), .mon_r_user_o (), .mon_r_id_o (),
+        .mon_r_data_o (), .mon_r_addr_o (), .mon_r_valid_o (),
+        .mon_w_last_o (), .mon_w_beat_count_o (), .mon_w_user_o (), .mon_w_id_o (),
+        .mon_w_data_o (), .mon_w_addr_o (), .mon_w_valid_o ()
+    );
+
+    idma_backend_2r_axi_w_axi #(
+        .CombinedShifter (CombinedShifter), .DataWidth (DataWidth), .AddrWidth (AddrWidth),
+        .AxiIdWidth (AxiIdWidth), .UserWidth (UserWidth), .TFLenWidth (TFLenWidth),
+        .BufferDepth (BufferDepth), .RAWCouplingAvail (1'b0), .MaskInvalidData (1'b1),
+        .HardwareLegalizer (1'b1), .RejectZeroTransfers (1'b1), .ErrorCap (ErrorCap),
+        .PrintFifoInfo (1'b0), .NumAxInFlight (NumAxInFlight), .MemSysDepth (MemSysDepth),
+        .idma_req_t (idma_req_t), .idma_rsp_t (idma_rsp_t), .idma_eh_req_t (idma_eh_req_t),
+        .idma_busy_t (idma_busy_t), .axi_req_t (axi_req_t), .axi_rsp_t (axi_rsp_t),
+        .write_meta_channel_t (write_meta_channel_t), .read_meta_channel_t (read_meta_channel_t)
+    ) i_idma_backend (
+        .clk_i (clk), .rst_ni (rst_n), .testmode_i (1'b0),
+        .idma_req_i (idma_req), .req_valid_i (req_valid), .req_ready_o (req_ready),
+        .idma_rsp_o (idma_rsp), .rsp_valid_o (rsp_valid), .rsp_ready_i (rsp_ready),
+        .idma_eh_req_i (idma_eh_req), .eh_req_valid_i (eh_req_valid), .eh_req_ready_o (eh_req_ready),
+        .axi_read_req_o (axi_read_req), .axi_read_rsp_i (axi_read_rsp),
+        .axi_write_req_o (axi_write_req), .axi_write_rsp_i (axi_write_rsp),
+        .busy_o (busy)
+    );
+
+    // ----------------------------------------------------------------------
+    // Stimulus
+    // ----------------------------------------------------------------------
+    int unsigned errors = 0;
+
+    // Generate-block instances cannot be variable-indexed; 2 read heads here.
+    task automatic rmem_set (input int unsigned head, input addr_t a, input byte_t d);
+        case (head)
+            0: gen_rmem[0].i_axi_sim_mem.mem[a] = d;
+            1: gen_rmem[1].i_axi_sim_mem.mem[a] = d;
+            default: $fatal(1, "read head %0d out of range", head);
+        endcase
+    endtask
+
+    // preload `len` bytes into read head `head`'s memory at `base`
+    task automatic preload (input int unsigned head, input addr_t base,
+                            input int unsigned len, input byte_t seed);
+        for (int unsigned i = 0; i < len; i++)
+            rmem_set(head, base + i, seed + i[7:0]);
+    endtask
+
+    // check the single write memory at `base` holds the seeded pattern
+    task automatic check (input string label, input addr_t base,
+                          input int unsigned len, input byte_t seed);
+        byte_t got, exp;
+        for (int unsigned i = 0; i < len; i++) begin
+            exp = seed + i[7:0];
+            got = i_write_mem.mem.exists(base + i) ? i_write_mem.mem[base + i] : 8'hxx;
+            if (got !== exp) begin
+                errors++;
+                $error("[%s] wmem @0x%h: got 0x%h exp 0x%h", label, base + i, got, exp);
+                if (i > 4) return;
+            end
+        end
+        $display("[%s] wmem @0x%h len %0d: OK", label, base, len);
+    endtask
+
+    // launch one copy (read head = src_head, single write head) and wait
+    task automatic do_copy (input int unsigned len, input addr_t src, input addr_t dst,
+                            input multihead_t src_head, input id_t id);
+        drv.launch_tf(len, src, dst, idma_pkg::AXI, idma_pkg::AXI, 1'b0, 1'b0,
+                      3'd0, 3'd0, 1'b1, 1'b1, id, src_head, '0);
+        @(posedge clk);
+        while (busy != '0) @(posedge clk);
+        repeat (5) @(posedge clk);
+    endtask
+
+    localparam int unsigned LEN = 64;
+
+    initial begin
+        automatic byte_t s0 = 8'h10;
+        automatic byte_t s1 = 8'ha0;
+        drv.reset_driver();
+        @(posedge rst_n);
+        repeat (4) @(posedge clk);
+
+        // distinct source data per read head, same source address
+        preload(0, 32'h0000_1000, LEN, s0);
+        preload(1, 32'h0000_1000, LEN, s1);
+
+        // read head 0 -> write memory: data must be head-0's pattern
+        do_copy(LEN, 32'h0000_1000, 32'h0000_2000, 0, 'd1);
+        check("rhead0", 32'h0000_2000, LEN, s0);
+
+        // read head 1 -> write memory: data must be head-1's pattern.
+        // If src_head routing is broken, this reads head 0 and the check fails.
+        do_copy(LEN, 32'h0000_1000, 32'h0000_3000, 1, 'd2);
+        check("rhead1", 32'h0000_3000, LEN, s1);
+
+        if (errors == 0)
+            $display("[tb_idma_backend_multihead] ALL CHECKS PASSED");
+        else
+            $fatal(1, "[tb_idma_backend_multihead] %0d byte mismatches", errors);
+        $finish;
+    end
+
+    // global watchdog
+    initial begin
+        repeat (WatchDogNumCycles * 5) @(posedge clk);
+        $fatal(1, "[tb_idma_backend_multihead] watchdog timeout");
+    end
+
+endmodule

--- a/test/tb_idma_backend_multihead_rw.sv
+++ b/test/tb_idma_backend_multihead_rw.sv
@@ -1,0 +1,250 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// Directed self-checking testbench for the symmetric multi-head AXI backend
+// (idma_backend_2rw_axi: 2 read + 2 write heads). Each head owns a read+write
+// joined axi_sim_mem so both src_head and dst_head routing are observable. A
+// cross-head transfer (src_head != dst_head) reads one head's memory and must
+// land in the other head's memory, which also exercises the write-response head
+// FIFO. Recycles the per-head memory harness pattern from the vidma inst64
+// verification harness.
+
+`timescale 1ns/1ns
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+
+module tb_idma_backend_multihead_rw import idma_pkg::*; #(
+    parameter int unsigned NumHeads    = 2,
+    parameter int unsigned BufferDepth = 3,
+    parameter int unsigned NumAxInFlight = 3,
+    parameter int unsigned DataWidth   = 32,
+    parameter int unsigned AddrWidth   = 32,
+    parameter int unsigned UserWidth   = 1,
+    parameter int unsigned AxiIdWidth  = 12,
+    parameter int unsigned TFLenWidth  = 32,
+    parameter int unsigned MemSysDepth = 0,
+    parameter bit          CombinedShifter   = 1'b0,
+    parameter int unsigned WatchDogNumCycles = 1000
+);
+
+    localparam time TA  = 1ns;
+    localparam time TT  = 9ns;
+    localparam time TCK = 10ns;
+
+    localparam int unsigned StrbWidth   = DataWidth / 8;
+    localparam int unsigned OffsetWidth = $clog2(StrbWidth);
+    localparam idma_pkg::error_cap_e ErrorCap = idma_pkg::NO_ERROR_HANDLING;
+
+    typedef logic [7:0]             byte_t;
+    typedef logic [AddrWidth-1:0]   addr_t;
+    typedef logic [DataWidth-1:0]   data_t;
+    typedef logic [StrbWidth-1:0]   strb_t;
+    typedef logic [UserWidth-1:0]   user_t;
+    typedef logic [AxiIdWidth-1:0]  id_t;
+    typedef logic [TFLenWidth-1:0]  tf_len_t;
+
+    `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, addr_t, id_t, user_t)
+    `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, data_t, strb_t, user_t)
+    `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, id_t, user_t)
+    `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, addr_t, id_t, user_t)
+    `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, data_t, id_t, user_t)
+    `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_chan_t, axi_w_chan_t, axi_ar_chan_t)
+    `AXI_TYPEDEF_RESP_T(axi_rsp_t, axi_b_chan_t, axi_r_chan_t)
+
+    `IDMA_TYPEDEF_FULL_REQ_T(idma_req_t, id_t, addr_t, tf_len_t)
+    `IDMA_TYPEDEF_FULL_RSP_T(idma_rsp_t, addr_t)
+
+    typedef struct packed { axi_ar_chan_t ar_chan; } axi_read_meta_channel_t;
+    typedef struct packed { axi_read_meta_channel_t axi; } read_meta_channel_t;
+    typedef struct packed { axi_aw_chan_t aw_chan; } axi_write_meta_channel_t;
+    typedef struct packed { axi_write_meta_channel_t axi; } write_meta_channel_t;
+
+    // clock / reset
+    logic clk;
+    logic rst_n;
+
+    // dma request / response
+    idma_req_t idma_req;
+    logic req_valid, req_ready;
+    idma_rsp_t idma_rsp;
+    logic rsp_valid, rsp_ready;
+    idma_eh_req_t idma_eh_req;
+    logic eh_req_valid, eh_req_ready;
+    idma_busy_t busy;
+
+    // per-head read / write master buses
+    axi_req_t [NumHeads-1:0] axi_read_req, axi_write_req, axi_mem_req;
+    axi_rsp_t [NumHeads-1:0] axi_read_rsp, axi_write_rsp, axi_mem_rsp;
+
+    // driver
+    IDMA_DV #(
+        .DataWidth (DataWidth), .AddrWidth (AddrWidth), .UserWidth (UserWidth),
+        .AxiIdWidth (AxiIdWidth), .TFLenWidth (TFLenWidth)
+    ) idma_dv (clk);
+
+    typedef idma_test::idma_driver #(
+        .DataWidth (DataWidth), .AddrWidth (AddrWidth), .UserWidth (UserWidth),
+        .AxiIdWidth (AxiIdWidth), .TFLenWidth (TFLenWidth), .TA (TA), .TT (TT)
+    ) drv_t;
+    drv_t drv = new(idma_dv);
+
+    assign idma_req         = idma_dv.req;
+    assign req_valid        = idma_dv.req_valid;
+    // TB only inspects the written memory; keep rsp_ready asserted so the read
+    // datapath can drain R into the buffer.
+    assign rsp_ready        = 1'b1;
+    assign idma_eh_req      = idma_dv.eh_req;
+    assign eh_req_valid     = idma_dv.eh_req_valid;
+    assign idma_dv.req_ready    = req_ready;
+    assign idma_dv.rsp          = idma_rsp;
+    assign idma_dv.rsp_valid    = rsp_valid;
+    assign idma_dv.eh_req_ready = eh_req_ready;
+
+    clk_rst_gen #(.ClkPeriod (TCK), .RstClkCycles (1)) i_clk_rst_gen (
+        .clk_o (clk), .rst_no (rst_n)
+    );
+
+    // per-head read/write join + dedicated sim memory
+    for (genvar h = 0; h < NumHeads; h++) begin : gen_head
+        axi_rw_join #(
+            .axi_req_t (axi_req_t), .axi_resp_t (axi_rsp_t)
+        ) i_axi_rw_join (
+            .clk_i (clk), .rst_ni (rst_n),
+            .slv_read_req_i (axi_read_req[h]),  .slv_read_resp_o (axi_read_rsp[h]),
+            .slv_write_req_i (axi_write_req[h]), .slv_write_resp_o (axi_write_rsp[h]),
+            .mst_req_o (axi_mem_req[h]), .mst_resp_i (axi_mem_rsp[h])
+        );
+
+        axi_sim_mem #(
+            .AddrWidth (AddrWidth), .DataWidth (DataWidth), .IdWidth (AxiIdWidth),
+            .UserWidth (UserWidth), .axi_req_t (axi_req_t), .axi_rsp_t (axi_rsp_t),
+            .WarnUninitialized (1'b0), .ClearErrOnAccess (1'b1),
+            .ApplDelay (TA), .AcqDelay (TT)
+        ) i_axi_sim_mem (
+            .clk_i (clk), .rst_ni (rst_n),
+            .axi_req_i (axi_mem_req[h]), .axi_rsp_o (axi_mem_rsp[h]),
+            .mon_r_last_o (), .mon_r_beat_count_o (), .mon_r_user_o (), .mon_r_id_o (),
+            .mon_r_data_o (), .mon_r_addr_o (), .mon_r_valid_o (),
+            .mon_w_last_o (), .mon_w_beat_count_o (), .mon_w_user_o (), .mon_w_id_o (),
+            .mon_w_data_o (), .mon_w_addr_o (), .mon_w_valid_o ()
+        );
+    end
+
+    idma_backend_2rw_axi #(
+        .CombinedShifter (CombinedShifter), .DataWidth (DataWidth), .AddrWidth (AddrWidth),
+        .AxiIdWidth (AxiIdWidth), .UserWidth (UserWidth), .TFLenWidth (TFLenWidth),
+        .BufferDepth (BufferDepth), .RAWCouplingAvail (1'b0), .MaskInvalidData (1'b1),
+        .HardwareLegalizer (1'b1), .RejectZeroTransfers (1'b1), .ErrorCap (ErrorCap),
+        .PrintFifoInfo (1'b0), .NumAxInFlight (NumAxInFlight), .MemSysDepth (MemSysDepth),
+        .idma_req_t (idma_req_t), .idma_rsp_t (idma_rsp_t), .idma_eh_req_t (idma_eh_req_t),
+        .idma_busy_t (idma_busy_t), .axi_req_t (axi_req_t), .axi_rsp_t (axi_rsp_t),
+        .write_meta_channel_t (write_meta_channel_t), .read_meta_channel_t (read_meta_channel_t)
+    ) i_idma_backend (
+        .clk_i (clk), .rst_ni (rst_n), .testmode_i (1'b0),
+        .idma_req_i (idma_req), .req_valid_i (req_valid), .req_ready_o (req_ready),
+        .idma_rsp_o (idma_rsp), .rsp_valid_o (rsp_valid), .rsp_ready_i (rsp_ready),
+        .idma_eh_req_i (idma_eh_req), .eh_req_valid_i (eh_req_valid), .eh_req_ready_o (eh_req_ready),
+        .axi_read_req_o (axi_read_req), .axi_read_rsp_i (axi_read_rsp),
+        .axi_write_req_o (axi_write_req), .axi_write_rsp_i (axi_write_rsp),
+        .busy_o (busy)
+    );
+
+    // ----------------------------------------------------------------------
+    // Stimulus
+    // ----------------------------------------------------------------------
+    int unsigned errors = 0;
+
+    // Generate-block instances cannot be variable-indexed; 2 heads here.
+    task automatic mem_set (input int unsigned head, input addr_t a, input byte_t d);
+        case (head)
+            0: gen_head[0].i_axi_sim_mem.mem[a] = d;
+            1: gen_head[1].i_axi_sim_mem.mem[a] = d;
+            default: $fatal(1, "head %0d out of range", head);
+        endcase
+    endtask
+
+    function automatic byte_t mem_get (input int unsigned head, input addr_t a);
+        case (head)
+            0: return gen_head[0].i_axi_sim_mem.mem.exists(a) ? gen_head[0].i_axi_sim_mem.mem[a] : 8'hxx;
+            1: return gen_head[1].i_axi_sim_mem.mem.exists(a) ? gen_head[1].i_axi_sim_mem.mem[a] : 8'hxx;
+            default: return 8'hxx;
+        endcase
+    endfunction
+
+    task automatic preload (input int unsigned head, input addr_t base,
+                            input int unsigned len, input byte_t seed);
+        for (int unsigned i = 0; i < len; i++)
+            mem_set(head, base + i, seed + i[7:0]);
+    endtask
+
+    // check that write head `head`'s memory at `base` holds the seeded pattern
+    task automatic check (input string label, input int unsigned head, input addr_t base,
+                          input int unsigned len, input byte_t seed);
+        byte_t got, exp;
+        for (int unsigned i = 0; i < len; i++) begin
+            exp = seed + i[7:0];
+            got = mem_get(head, base + i);
+            if (got !== exp) begin
+                errors++;
+                $error("[%s] head %0d @0x%h: got 0x%h exp 0x%h", label, head, base + i, got, exp);
+                if (i > 4) return;
+            end
+        end
+        $display("[%s] head %0d @0x%h len %0d: OK", label, head, base, len);
+    endtask
+
+    task automatic do_copy (input int unsigned len, input addr_t src, input addr_t dst,
+                            input multihead_t src_head, input multihead_t dst_head, input id_t id);
+        drv.launch_tf(len, src, dst, idma_pkg::AXI, idma_pkg::AXI, 1'b0, 1'b0,
+                      3'd0, 3'd0, 1'b1, 1'b1, id, src_head, dst_head);
+        @(posedge clk);
+        while (busy != '0) @(posedge clk);
+        repeat (5) @(posedge clk);
+    endtask
+
+    localparam int unsigned LEN = 64;
+
+    initial begin
+        automatic byte_t s0 = 8'h10;
+        automatic byte_t s1 = 8'ha0;
+        drv.reset_driver();
+        @(posedge rst_n);
+        repeat (4) @(posedge clk);
+
+        // distinct source data per head
+        preload(0, 32'h0000_1000, LEN, s0);
+        preload(1, 32'h0000_1000, LEN, s1);
+
+        // same-head copies (baseline)
+        do_copy(LEN, 32'h0000_1000, 32'h0000_2000, 0, 0, 'd1);
+        check("same0", 0, 32'h0000_2000, LEN, s0);
+        do_copy(LEN, 32'h0000_1000, 32'h0000_2000, 1, 1, 'd2);
+        check("same1", 1, 32'h0000_2000, LEN, s1);
+
+        // cross-head: read head 0, write head 1 -> data must land in head 1's memory.
+        // With the dst_head<-src_head bug it lands in head 0 instead, so this fails.
+        do_copy(LEN, 32'h0000_1000, 32'h0000_3000, 0, 1, 'd3);
+        check("cross0to1", 1, 32'h0000_3000, LEN, s0);
+
+        // cross-head: read head 1, write head 0.
+        do_copy(LEN, 32'h0000_1000, 32'h0000_3000, 1, 0, 'd4);
+        check("cross1to0", 0, 32'h0000_3000, LEN, s1);
+
+        if (errors == 0)
+            $display("[tb_idma_backend_multihead_rw] ALL CHECKS PASSED");
+        else
+            $fatal(1, "[tb_idma_backend_multihead_rw] %0d byte mismatches", errors);
+        $finish;
+    end
+
+    // global watchdog
+    initial begin
+        repeat (WatchDogNumCycles * 5) @(posedge clk);
+        $fatal(1, "[tb_idma_backend_multihead_rw] watchdog timeout");
+    end
+
+endmodule

--- a/util/mario/backend.py
+++ b/util/mario/backend.py
@@ -36,9 +36,11 @@ def render_backend(prot_ids: dict, db: dict, tpl_file: str) -> str:
         used_read_prots = prot_ids[prot_id]['ar']
         used_write_prots = prot_ids[prot_id]['aw']
 
-        # single port IPs?
-        srp = len(used_read_prots) == 1
-        swp = len(used_write_prots) == 1
+        # single port IPs? a multi-head protocol still needs the tagged (per-head) path
+        any_mh_r = any(n > 1 for n in prot_ids[prot_id]['multihead']['r'].values())
+        any_mh_w = any(n > 1 for n in prot_ids[prot_id]['multihead']['w'].values())
+        srp = len(used_read_prots) == 1 and not any_mh_r
+        swp = len(used_write_prots) == 1 and not any_mh_w
 
         # create context
         context = {

--- a/util/mario/transport_layer.py
+++ b/util/mario/transport_layer.py
@@ -106,7 +106,7 @@ ar_valid_i\
                 else:
                     read_meta_valid = f'''\
 (ar_req_i.src_protocol == idma_pkg::{db[rp]["protocol_enum"]}) & \
-(r_dp_req_i.src_head == {curr_head}) & \
+(ar_req_i.src_head == {curr_head}) & \
 ar_valid_i\
 '''
                 read_meta_ready = f'{rp}_ar_ready{mh_bus}'
@@ -127,8 +127,8 @@ ar_valid_i\
                 'read_meta_request': read_meta_request,
                 'read_meta_valid': read_meta_valid,
                 'read_meta_ready': read_meta_ready,
-                'read_request': f'{rp}_read_req_{read_port_dir_req_str}',
-                'read_response': f'{rp}_read_rsp_{read_port_dir_rsp_str}',
+                'read_request': f'{rp}_read_req_{read_port_dir_req_str}{mh_bus}',
+                'read_response': f'{rp}_read_rsp_{read_port_dir_rsp_str}{mh_bus}',
                 'r_chan_valid': r_chan_valid,
                 'r_chan_ready': r_chan_ready,
                 'buffer_in': buffer_in,
@@ -204,7 +204,7 @@ w_dp_req_valid\
                 else:
                     write_dp_valid_in = f'''\
 (w_dp_req_i.dst_protocol == idma_pkg::{db[wp]["protocol_enum"]}) & \
-(r_dp_req_i.dst_head == {curr_head}) & \
+(w_dp_req_i.dst_head == {curr_head}) & \
 w_dp_req_valid\
 '''
                 write_dp_ready_out = f'{wp}_w_dp_ready{mh_bus}'
@@ -220,7 +220,7 @@ aw_valid_i\
                 else:
                     write_meta_valid = f'''\
 (aw_req_i.dst_protocol == idma_pkg::{db[wp]["protocol_enum"]}) & \
-(r_dp_req_i.dst_head == {curr_head}) & \
+(aw_req_i.dst_head == {curr_head}) & \
 aw_valid_i\
 '''
                 write_meta_ready = f'{wp}_aw_ready{mh_bus}'
@@ -238,8 +238,8 @@ aw_valid_i\
                 'write_meta_request': write_meta_request,
                 'write_meta_valid': write_meta_valid,
                 'write_meta_ready': write_meta_ready,
-                'write_request': f'{wp}_write_req_o',
-                'write_response': f'{wp}_write_rsp_i',
+                'write_request': f'{wp}_write_req_o{mh_bus}',
+                'write_response': f'{wp}_write_rsp_i{mh_bus}',
                 'buffer_out_ready': buffer_out_ready,
                 'mh': mh
             }


### PR DESCRIPTION
The multi-head capability (#85) was merged but **never elaborated** — the only backend testbench pins both heads to 0, so a multi-head variant was never built or simulated. Generating and compiling a 2-read-head + 1-write-head AXI backend (`2r_axi_w_axi`) surfaced several real bugs in the generated transport layer and backend:

- write datapath `dst_head` was sourced from `src_head`
- write/aw head gating dereferenced `dst_head` on the **read** datapath request
- per-head read/write instances drove the whole master-port array instead of their `[head]` slice (missing the per-head bus index)
- the write-response head FIFO drove an undeclared signal
- a single-protocol multi-head read was treated as a single (untagged) port → meta-channel type mismatch
- the per-head read buffer packed dimensions were inverted (32 vs 16-bit)
- the AR meta valid gated on the read-datapath head, not the AR head

## Verification

Adds `test/tb_idma_backend_multihead.sv` — a directed, self-checking testbench for the 2-read-head/1-write-head AXI backend that gives **each read head its own memory** and verifies `src_head` routing (head 0 reads its memory, head 1 reads its own). It reuses the per-head-memory harness pattern from the vidma inst64 verification harness. Result in Questa: `ALL CHECKS PASSED`.

## Impact

Existing single-head variants are unaffected: the only change to their generated RTL is the `dst_head` fix, which is a no-op at head 0. Verified by diffing generated RTL before/after across all default variants. The new testbench is behind a dedicated `multihead` Bender target and is exercised only by the internal CI multi-head job (off by default in public builds).


## Test scope / caveats (independently verified)

The two testbenches instantiate the backend with `HardwareLegalizer=1` (the recommended/default config), so they exercise the **hardware-legalizer datapath**. Independent reproduction confirms head routing is genuinely checked (cross-head transfers read one head's preloaded memory and verify the *other* head's memory).

Two honest limitations:
- The `idma_backend.sv.tpl` `dst_head ← src_head` one-liner lives in the **SW-legalizer / bypass** path (`gen_no_hw_legalizer`), which these TBs do **not** exercise — with `HardwareLegalizer=1`, `w_dp_req` comes from the legalizer (already correct). The fix is correct by inspection but is **not** covered by these TBs.
- The multi-head **bypass** path (`HardwareLegalizer=0`) appears to have separate issues (a directed run there does not reach a pass) and is left as a **follow-up** — out of scope for this bring-up, which targets the default legalizer config.

All other fixes (per-head bus index, AR/AW/`w_dp` head gating, read-buffer packing, write-response head FIFO) are exercised and necessary for elaboration + routing.
