### PR TITLE
ci: Clear stale runner locks before checkout in the init pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,10 @@
 
 default:
   interruptible: true
+  hooks:
+    pre_get_sources_script:
+      - rm -rf "${CI_PROJECT_DIR}.tmp/git-template"
+      - find "${CI_PROJECT_DIR}.tmp" -name '*.lock' -delete 2>/dev/null || true
 
 stages:
   - init


### PR DESCRIPTION
The IIS shared runners intermittently wedge a build slot with a stale git lock under `${CI_PROJECT_DIR}.tmp` — observed as both `git-template/config` and `.gitlab-runner.ext.conf.lock` failing the public `init` job at **git checkout** with `could not lock config file …: File exists`, before any job script runs. It reproduces on unrelated refs and self-resolves on the next push to a clean slot — a per-slot infra race, not a code issue.

The nonfree child pipeline already clears the `git-template` lock via its own `pre_get_sources_script`; this adds the equivalent to the **public** `init`/`idma` pipeline (which had no cleanup hook), generalized to any stale `*.lock` under `.tmp`. Scoped to `*.lock` + `git-template` so the CA bundle (`CI_SERVER_TLS_CA_FILE`) under `.tmp` is preserved (removing the whole `.tmp` breaks cert verification).