### PR TITLE
ci: Run push CI on mainlines only to stop double-triggering PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ name: ci
 
 on:
   push:
-    branches-ignore:
-      - '__deploy__**'
+    branches:
+      - devel
+      - master
   pull_request:
     branches-ignore:
       - '__deploy__**'


### PR DESCRIPTION
## Problem

An open same-repo PR fires **both** the `push` and `pull_request` events. The `gitlab-ci` job then mirrors the same commit to GitLab **twice**, and the second mirror cancels the first GitLab pipeline — observed as a child pipeline with **all jobs skipped** (the `100 skipped` / `unknown_failure` signature), failing `gitlab-ci / check` on every PR while `devel` (single push event) stays healthy.

## Fix

Scope `push` to `devel`/`master`. Feature branches validate via their PR:
- **Open PR + push a commit** → `pull_request: synchronize` reruns the full CI (incl. `gitlab-ci`) **once**. Push-to-retrigger still works.
- **Re-run** → `gh run rerun` / Actions UI / `workflow_dispatch`, unchanged.
- A branch with **no** open PR no longer auto-runs on push — open the PR or use `workflow_dispatch`.

Bonus: also stops the spurious `__deploy__<sha>__<feature-branch>` pipelines the `deploy` job created on every feature-branch push (`deploy` is `if: github.event_name == 'push'`, now mainline-only).