### PR TITLE
ci: Add a scheduled prune for stale deploy branches

### DIFF
--- a/.github/workflows/prune-deploy-branches.yml
+++ b/.github/workflows/prune-deploy-branches.yml
@@ -43,15 +43,15 @@ jobs:
         run: |
           set -euo pipefail
           latest_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -vE -- '-' | sort -V | tail -n1)"
-          keep_branch=""
-          if [ -n "$latest_tag" ]; then
-            # The vX.Y.Z tag sits on the deploy commit; its parent is the -src commit,
-            # whose short hash names the deploy branch __deploy__<src7>__master.
-            src7="$(git rev-parse --short=7 "${latest_tag}^" 2>/dev/null || true)"
-            [ -n "$src7" ] && keep_branch="__deploy__${src7}__master"
+          if [ -z "$latest_tag" ]; then
+            echo "::error::no vX.Y.Z release tag found; refusing to prune"; exit 1
           fi
+          # The vX.Y.Z tag sits on the deploy commit; its parent is the -src commit,
+          # whose first 7 hex chars name __deploy__<src7>__master (deploy.py uses [0:7]).
+          src7="$(git rev-parse "${latest_tag}^" | cut -c1-7)"
+          keep_branch="__deploy__${src7}__master"
           echo "keep_branch=${keep_branch}" >> "$GITHUB_OUTPUT"
-          echo "latest release: ${latest_tag:-<none>} | protected deploy branch: ${keep_branch:-<none>}"
+          echo "latest release: ${latest_tag} | protected deploy branch: ${keep_branch}"
 
       - name: Prune deploy branches
         env:
@@ -77,8 +77,13 @@ jobs:
             fi
 
             target="${br#__deploy__*__}"
-            sha="$(gh api "/repos/${repo}/branches/${br}" --jq '.commit.sha')"
-            cepoch="$(date -u -d "$(gh api "/repos/${repo}/commits/${sha}" --jq '.commit.committer.date')" +%s)"
+            # Skip (do not delete) on any transient API/parse failure for this branch.
+            sha="$(gh api "/repos/${repo}/branches/${br}" --jq '.commit.sha')" \
+              || { echo "SKIP  (api error)        $br"; continue; }
+            cdate="$(gh api "/repos/${repo}/commits/${sha}" --jq '.commit.committer.date')" \
+              || { echo "SKIP  (api error)        $br"; continue; }
+            cepoch="$(date -u -d "$cdate" +%s)" \
+              || { echo "SKIP  (bad date)         $br"; continue; }
             age=$(( (now - cepoch) / 86400 ))
 
             # Feature-branch deploys are pure CI cruft: always prune. Mainline deploys

--- a/.github/workflows/prune-deploy-branches.yml
+++ b/.github/workflows/prune-deploy-branches.yml
@@ -34,7 +34,7 @@ jobs:
       RETENTION_DAYS: '60'
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/prune-deploy-branches.yml
+++ b/.github/workflows/prune-deploy-branches.yml
@@ -1,0 +1,101 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author:
+# - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+name: prune-deploy-branches
+
+on:
+  schedule:
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List deletions without deleting'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: prune-deploy-branches
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    if: github.repository == 'pulp-platform/iDMA'
+    runs-on: ubuntu-latest
+    env:
+      # Scheduled runs prune for real; manual runs honour the dry_run input.
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+      RETENTION_DAYS: '60'
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Identify the latest release deploy branch
+        id: keep
+        run: |
+          set -euo pipefail
+          latest_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -vE -- '-' | sort -V | tail -n1)"
+          keep_branch=""
+          if [ -n "$latest_tag" ]; then
+            # The vX.Y.Z tag sits on the deploy commit; its parent is the -src commit,
+            # whose short hash names the deploy branch __deploy__<src7>__master.
+            src7="$(git rev-parse --short=7 "${latest_tag}^" 2>/dev/null || true)"
+            [ -n "$src7" ] && keep_branch="__deploy__${src7}__master"
+          fi
+          echo "keep_branch=${keep_branch}" >> "$GITHUB_OUTPUT"
+          echo "latest release: ${latest_tag:-<none>} | protected deploy branch: ${keep_branch:-<none>}"
+
+      - name: Prune deploy branches
+        env:
+          KEEP_BRANCH: ${{ steps.keep.outputs.keep_branch }}
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          now="$(date -u +%s)"
+          cutoff=$(( now - RETENTION_DAYS * 86400 ))
+          kept=0; deleted=0; total=0
+          echo "mode: $([ "$DRY_RUN" = 'true' ] && echo DRY-RUN || echo DELETE) | cutoff: $(date -u -d "@${cutoff}" '+%Y-%m-%d')"
+
+          gh api --paginate "/repos/${repo}/branches?per_page=100" --jq '.[].name' > branches.txt
+
+          while IFS= read -r br; do
+            # Hard allow-list: only __deploy__ refs are ever touchable.
+            case "$br" in __deploy__*) : ;; *) continue ;; esac
+            total=$((total+1))
+
+            # Keep the latest release's deploy branch unconditionally.
+            if [ -n "$KEEP_BRANCH" ] && [ "$br" = "$KEEP_BRANCH" ]; then
+              echo "KEEP  (latest release)  $br"; kept=$((kept+1)); continue
+            fi
+
+            target="${br#__deploy__*__}"
+            sha="$(gh api "/repos/${repo}/branches/${br}" --jq '.commit.sha')"
+            cepoch="$(date -u -d "$(gh api "/repos/${repo}/commits/${sha}" --jq '.commit.committer.date')" +%s)"
+            age=$(( (now - cepoch) / 86400 ))
+
+            # Feature-branch deploys are pure CI cruft: always prune. Mainline deploys
+            # follow the retention window.
+            if [ "$target" = "master" ] || [ "$target" = "devel" ]; then
+              if [ "$cepoch" -ge "$cutoff" ]; then
+                echo "KEEP  (${age}d, mainline) $br"; kept=$((kept+1)); continue
+              fi
+            fi
+
+            if [ "$DRY_RUN" = 'true' ]; then
+              echo "WOULD-DELETE (${age}d) $br"
+            else
+              gh api -X DELETE "/repos/${repo}/git/refs/heads/${br}" || echo "  (already gone) $br"
+              echo "DELETED (${age}d) $br"
+            fi
+            deleted=$((deleted+1))
+          done < branches.txt
+
+          echo "scanned __deploy__: $total | kept: $kept | pruned: $deleted"


### PR DESCRIPTION
## Why

`util/deploy.py` commits one `__deploy__<src7>__<branch>` branch of generated RTL per push (`make -B idma_hw_all` regenerates from scratch each time). These accumulated to **120+ refs**, and the gitlab-ci action's `git push --mirror` re-syncs **every** branch to the GitLab CI mirror — with `auto_cancel_pending_pipelines` enabled, that mass re-sync cancels PR child pipelines (the "all jobs skipped" failures we've been seeing).

## What

A weekly (`workflow_dispatch`-able) prune with the retention policy:
- **Keep** the latest release's deploy branch (`__deploy__<src7>__master`, derived from the newest `vX.Y.Z` tag's `-src` parent).
- **Keep** any `devel`/`master` deploy branch newer than **60 days**.
- **Prune** everything else — and **always** prune feature-branch deploys (pure CI cruft).

Safety:
- **Allow-listed**: a `case __deploy__*` guard makes `devel`/`master`/non-deploy refs structurally untouchable.
- **Dry-run by default** on manual runs (`workflow_dispatch`); scheduled runs prune for real.
- Idempotent + paginated.

Nothing references `__deploy__` branches — downstream Bender deps pin the **`vX.Y.Z` tag** (the deploy commit the branch tip carries), which is untouched. Deploy regenerates from scratch, so pruning can't break a future deploy.

## Companion changes
- #125 scopes the `deploy` job to mainlines, stopping *new* feature-branch deploy refs at the source.
- I've already manually deleted the 67 existing feature-branch deploy branches (one protected straggler, `__deploy__d15cf7e__neopxdma-tbenz`, was rejected by a branch-protection hook).