### PR TITLE
build: Self-bootstrap the uv environment for make idma_hw_all

### DIFF
--- a/idma.mk
+++ b/idma.mk
@@ -17,6 +17,24 @@ VERILATOR   ?= verilator
 VLOGAN      ?= vlogan
 VSIM        ?= vsim
 
+# Provision a local uv venv when the generator deps are not already available.
+IDMA_VENV_PY := $(IDMA_ROOT)/.venv/bin/python
+ifeq ($(shell $(PYTHON) -c 'import mako' >/dev/null 2>&1 && echo ok),ok)
+else ifeq ($(shell $(IDMA_VENV_PY) -c 'import mako' >/dev/null 2>&1 && echo ok),ok)
+  PYTHON      := $(IDMA_VENV_PY)
+  export PATH := $(IDMA_ROOT)/.venv/bin:$(PATH)
+else ifeq ($(shell command -v uv >/dev/null 2>&1 && echo ok),ok)
+  $(info iDMA: provisioning the generator environment (uv sync --locked) ...)
+  _idma_uv_sync := $(shell cd $(IDMA_ROOT) && uv sync --locked 1>&2 || echo FAIL)
+  ifeq ($(_idma_uv_sync),FAIL)
+    $(error iDMA: 'uv sync --locked' failed; see output above)
+  endif
+  PYTHON      := $(IDMA_VENV_PY)
+  export PATH := $(IDMA_ROOT)/.venv/bin:$(PATH)
+else
+  $(error iDMA RTL generation needs 'uv' (https://docs.astral.sh/uv) on PATH, or a venv with the pyproject.toml deps activated)
+endif
+
 # Shell
 SHELL := /bin/bash
 


### PR DESCRIPTION
## What

`make idma_hw_all` (and the other generators) now provision their own Python environment. If Mako/peakrdl are not importable, a local `.venv` is created via `uv sync --locked` and prepended to PATH. An already-activated venv or `uv run make …` (as in CI) is detected and left untouched, so existing flows are unchanged.

## Why

Downstream SoCs that pull iDMA via Bender (e.g. pulp_cluster) had to replicate the env setup — `uv sync` + `source .venv/bin/activate` — before calling `make -C $(bender path idma) idma_hw_all`. With this, the low-level handling lives in the IP and a consumer just calls:

```make
generate_idma_rtl:
	$(MAKE) -C $(shell bender path idma) idma_hw_all
```

## Notes

- Requires `uv` on PATH when cold; otherwise it errors with the install hint (no silent `curl | sh`). uv is already a documented prerequisite.
- Tested locally: cold (no venv, mako-less python) provisions and generates all variants; idempotent re-run reuses the `.venv`; `uv run make idma_hw_all` unchanged.

Docs follow-up: simplify the quickstart build snippet (#119) to the bare `make idma_hw_all` once this lands.