### PR TITLE
deps: Bump all bender dependencies to latest

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -1,9 +1,0 @@
-# Copyright 2023 ETH Zurich and University of Bologna.
-# Solderpad Hardware License, Version 0.51, see LICENSE for details.
-# SPDX-License-Identifier: SHL-0.51
-
-# Authors:
-# - Thomas Benz <tbenz@iis.ee.ethz.ch>
-
-overrides:
-  axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.39.1 }

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,13 +14,13 @@ package:
     - "Axel Vanoni <axvanoni@ethz.ch>"
 
 dependencies:
-  axi:                 { git: "https://github.com/pulp-platform/axi.git",                 version: 0.39.1 }
+  axi:                 { git: "https://github.com/pulp-platform/axi.git",                 version: 0.39.9 }
   axi_stream:          { git: "https://github.com/pulp-platform/axi_stream.git",          version: 0.1.1  }
-  common_cells:        { git: "https://github.com/pulp-platform/common_cells.git",        version: 1.33.0 }
-  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.3  }
-  register_interface:  { git: "https://github.com/pulp-platform/register_interface.git",  version: 0.4.3  }
+  common_cells:        { git: "https://github.com/pulp-platform/common_cells.git",        version: 1.39.0 }
+  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.5  }
+  register_interface:  { git: "https://github.com/pulp-platform/register_interface.git",  version: 0.4.7  }
   apb:                 { git: "https://github.com/pulp-platform/apb.git",                 version: 0.2.4  }
-  obi:                 { git: "https://github.com/pulp-platform/obi.git",                 version: 0.1.2  }
+  obi:                 { git: "https://github.com/pulp-platform/obi.git",                 version: 0.1.7  }
 
 export_include_dirs:
   - src/include


### PR DESCRIPTION
Raises the declared version floors in `Bender.yml` to the latest releases ahead of the 0.7.0 cut.

| dependency | old | new |
|---|---|---|
| axi | 0.39.1 | 0.39.9 |
| common_cells | 1.33.0 | 1.39.0 |
| common_verification | 0.2.3 | 0.2.5 |
| register_interface | 0.4.3 | 0.4.7 |
| obi | 0.1.2 | 0.1.7 |

`axi_stream` (0.1.1) and `apb` (0.2.4) are already at their latest tags.