### PR TITLE
frontend: Expose the reg frontend as a native APB slave

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -44,16 +44,6 @@ packages:
     dependencies:
     - common_cells
     - common_verification
-  register_interface:
-    revision: d6e1d4cdaab7870f4faf3f88a1c788eaf5ac129d
-    version: 0.4.7
-    source:
-      Git: https://github.com/pulp-platform/register_interface.git
-    dependencies:
-    - apb
-    - axi
-    - common_cells
-    - common_verification
   tech_cells_generic:
     revision: 7968dd6e6180df2c644636bc6d2908a49f2190cf
     version: 0.2.13

--- a/Bender.yml
+++ b/Bender.yml
@@ -18,7 +18,6 @@ dependencies:
   axi_stream:          { git: "https://github.com/pulp-platform/axi_stream.git",          version: 0.1.1  }
   common_cells:        { git: "https://github.com/pulp-platform/common_cells.git",        version: 1.39.0 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.5  }
-  register_interface:  { git: "https://github.com/pulp-platform/register_interface.git",  version: 0.4.7  }
   apb:                 { git: "https://github.com/pulp-platform/apb.git",                 version: 0.2.4  }
   obi:                 { git: "https://github.com/pulp-platform/obi.git",                 version: 0.1.7  }
 

--- a/doc/site/src/content/docs/guides/system-integration.md
+++ b/doc/site/src/content/docs/guides/system-integration.md
@@ -63,14 +63,14 @@ The following skeleton shows how the three layers connect. Signal types come fro
 idma_reg64_2d #(
     .NumRegs    ( 1          ),
     .NumStreams  ( 1          ),
-    .reg_req_t  ( reg_req_t  ),
-    .reg_rsp_t  ( reg_rsp_t  ),
+    .apb_req_t  ( apb_req_t  ),
+    .apb_rsp_t  ( apb_rsp_t  ),
     .dma_req_t  ( idma_nd_req_t )
 ) i_frontend (
     .clk_i,
     .rst_ni,
-    .reg_req_i     ( dma_reg_req  ),
-    .reg_rsp_o     ( dma_reg_rsp  ),
+    .dma_ctrl_req_i ( dma_apb_req  ),
+    .dma_ctrl_rsp_o ( dma_apb_rsp  ),
     .dma_req_o     ( fe_req       ),
     .req_valid_o   ( fe_valid     ),
     .req_ready_i   ( fe_ready     ),
@@ -208,4 +208,4 @@ Shows multi-core DMA sharing and the mchan/iDMA selection mechanism. The PULP cl
 
 ## Dependency Management
 
-iDMA uses [Bender](https://github.com/pulp-platform/bender) for RTL dependency management. Add iDMA to your `Bender.yml` and run `bender update` to pull it and its transitive dependencies (`axi`, `common_cells`, `register_interface`, `obi`). Bender resolves the source file list for your build system — use `bender script vsim` for Questa or `bender script vcs` for VCS.
+iDMA uses [Bender](https://github.com/pulp-platform/bender) for RTL dependency management. Add iDMA to your `Bender.yml` and run `bender update` to pull it and its transitive dependencies (`axi`, `common_cells`, `apb`, `obi`). Bender resolves the source file list for your build system — use `bender script vsim` for Questa or `bender script vcs` for VCS.

--- a/src/frontend/reg/tpl/idma_reg.sv.tpl
+++ b/src/frontend/reg/tpl/idma_reg.sv.tpl
@@ -6,8 +6,6 @@
 // - Michael Rogenmoser <michaero@iis.ee.ethz.ch>
 // - Thomas Benz <tbenz@iis.ee.ethz.ch>
 
-`include "apb/typedef.svh"
-
 /// Description: Register-based front-end for iDMA
 module idma_${identifier} #(
   /// Number of configuration register ports
@@ -18,10 +16,10 @@ module idma_${identifier} #(
   parameter int unsigned IdCounterWidth = 32'd32,
   /// Dependent parameter: Stream Idx
   parameter int unsigned StreamWidth    = cf_math_pkg::idx_width(NumStreams),
-  /// Register_interface request type
-  parameter type         reg_req_t      = logic,
-  /// Register_interface response type
-  parameter type         reg_rsp_t      = logic,
+  /// APB request type. Use the APB_TYPEDEF macros to define it
+  parameter type         apb_req_t      = logic,
+  /// APB response type. Use the APB_TYPEDEF macros to define it
+  parameter type         apb_rsp_t      = logic,
   /// DMA 1d or ND burst request type
   parameter type         dma_req_t      = logic,
   /// Dependent type for IdCounterWidth
@@ -31,9 +29,9 @@ module idma_${identifier} #(
 ) (
   input  logic clk_i,
   input  logic rst_ni,
-  /// Register interface control slave
-  input  reg_req_t [NumRegs-1:0] dma_ctrl_req_i,
-  output reg_rsp_t [NumRegs-1:0] dma_ctrl_rsp_o,
+  /// APB control slave
+  input  apb_req_t [NumRegs-1:0] dma_ctrl_req_i,
+  output apb_rsp_t [NumRegs-1:0] dma_ctrl_rsp_o,
   /// Request signals
   output dma_req_t   dma_req_o,
   output logic       req_valid_o,
@@ -51,11 +49,6 @@ module idma_${identifier} #(
   localparam int unsigned MaxNumStreams = 32'd16;
   localparam int unsigned RegAddrWidth  = idma_${identifier}_reg_pkg::IDMA_${identifier.upper()}_REG_TOP_MIN_ADDR_WIDTH;
 
-  `APB_TYPEDEF_ALL(apb, logic[31:0], logic[31:0], logic[3:0])
-  apb_req_t  [NumRegs-1:0] apb_req;
-  apb_resp_t [NumRegs-1:0] apb_rsp;
-
-
   // register connections
   idma_${identifier}_reg_pkg::idma_reg__out_t dma_reg2hw [NumRegs-1:0];
   idma_${identifier}_reg_pkg::idma_reg__in_t  dma_hw2reg [NumRegs-1:0];
@@ -64,9 +57,6 @@ module idma_${identifier} #(
   dma_req_t [NumRegs-1:0] arb_dma_req;
   logic     [NumRegs-1:0] arb_valid;
   logic     [NumRegs-1:0] arb_ready;
-
-  // register signals
-  reg_rsp_t [NumRegs-1:0] dma_ctrl_rsp;
 
   always_comb begin
       stream_idx_o = '0;
@@ -82,50 +72,28 @@ module idma_${identifier} #(
   // generate the registers
   for (genvar i = 0; i < NumRegs; i++) begin : gen_core_regs
 
-
-    reg_to_apb #(
-      .reg_req_t  ( reg_req_t ),
-      .reg_rsp_t  ( reg_rsp_t ),
-      .apb_req_t  ( apb_req_t ),
-      .apb_rsp_t  ( apb_resp_t )
-    ) chs_regs_reg_to_apb (
-      .clk_i,
-      .rst_ni,
-      .reg_req_i ( dma_ctrl_req_i   [i] ),
-      .reg_rsp_o ( dma_ctrl_rsp     [i] ),
-      .apb_req_o ( apb_req          [i] ),
-      .apb_rsp_i ( apb_rsp          [i] )
-    );
-
     idma_${identifier}_reg_top i_idma_${identifier}_reg_top (
       .clk    ( clk_i ),
       .arst_n ( rst_ni ),
 
-      .s_apb_psel    (apb_req[i].psel),
-      .s_apb_penable (apb_req[i].penable),
-      .s_apb_pwrite  (apb_req[i].pwrite),
-      .s_apb_pprot   (apb_req[i].pprot),
-      .s_apb_paddr   (apb_req[i].paddr[RegAddrWidth-1:0]),
-      .s_apb_pwdata  (apb_req[i].pwdata),
-      .s_apb_pstrb   (apb_req[i].pstrb),
-      .s_apb_pready  (apb_rsp[i].pready),
-      .s_apb_prdata  (apb_rsp[i].prdata),
-      .s_apb_pslverr (apb_rsp[i].pslverr),
+      .s_apb_psel    (dma_ctrl_req_i[i].psel),
+      .s_apb_penable (dma_ctrl_req_i[i].penable),
+      .s_apb_pwrite  (dma_ctrl_req_i[i].pwrite),
+      .s_apb_pprot   (dma_ctrl_req_i[i].pprot),
+      .s_apb_paddr   (dma_ctrl_req_i[i].paddr[RegAddrWidth-1:0]),
+      .s_apb_pwdata  (dma_ctrl_req_i[i].pwdata),
+      .s_apb_pstrb   (dma_ctrl_req_i[i].pstrb),
+      .s_apb_pready  (dma_ctrl_rsp_o[i].pready),
+      .s_apb_prdata  (dma_ctrl_rsp_o[i].prdata),
+      .s_apb_pslverr (dma_ctrl_rsp_o[i].pslverr),
 
       .hwif_out  ( dma_reg2hw       [i] ),
       .hwif_in   ( dma_hw2reg       [i] )
     );
 
+    // A read of `next_id` launches a transfer; stall the APB read (via the
+    // external register `rd_ack`) until the arbiter accepts the request.
     logic read_happens;
-    // DMA backpressure
-    always_comb begin : proc_dma_backpressure
-      // ready signal
-      dma_ctrl_rsp_o[i]       = dma_ctrl_rsp[i];
-      dma_ctrl_rsp_o[i].ready = read_happens ? arb_ready[i] : dma_ctrl_rsp[i];
-    end
-
-    // valid signals
-
     always_comb begin : proc_launch
         read_happens = 1'b0;
         for (int c = 0; c < NumStreams; c++) begin
@@ -207,7 +175,7 @@ module idma_${identifier} #(
         assign dma_hw2reg[i].status[c].rd_data.busy  = {midend_busy_i[c], busy_i[c]};
         assign dma_hw2reg[i].status[c].rd_ack = 1'b1;
         assign dma_hw2reg[i].next_id[c].rd_data.next_id = next_id_i;
-        assign dma_hw2reg[i].next_id[c].rd_ack = 1'b1;
+        assign dma_hw2reg[i].next_id[c].rd_ack = arb_ready[i];
         assign dma_hw2reg[i].done_id[c].rd_data.done_id = done_id_i[c];
         assign dma_hw2reg[i].done_id[c].rd_ack = 1'b1;
     end

--- a/src/frontend/reg/tpl/idma_reg.sv.tpl
+++ b/src/frontend/reg/tpl/idma_reg.sv.tpl
@@ -173,11 +173,15 @@ module idma_${identifier} #(
     // observational registers
     for (genvar c = 0; c < NumStreams; c++) begin : gen_hw2reg_connections
         assign dma_hw2reg[i].status[c].rd_data.busy  = {midend_busy_i[c], busy_i[c]};
-        assign dma_hw2reg[i].status[c].rd_ack = 1'b1;
+        assign dma_hw2reg[i].status[c].rd_ack = dma_reg2hw[i].status[c].req
+                                              & ~dma_reg2hw[i].status[c].req_is_wr;
         assign dma_hw2reg[i].next_id[c].rd_data.next_id = next_id_i;
-        assign dma_hw2reg[i].next_id[c].rd_ack = arb_ready[i];
+        assign dma_hw2reg[i].next_id[c].rd_ack = dma_reg2hw[i].next_id[c].req
+                                               & ~dma_reg2hw[i].next_id[c].req_is_wr
+                                               & arb_ready[i];
         assign dma_hw2reg[i].done_id[c].rd_data.done_id = done_id_i[c];
-        assign dma_hw2reg[i].done_id[c].rd_ack = 1'b1;
+        assign dma_hw2reg[i].done_id[c].rd_ack = dma_reg2hw[i].done_id[c].req
+                                               & ~dma_reg2hw[i].done_id[c].req_is_wr;
     end
 
     // tie-off unused channels


### PR DESCRIPTION
## What

The register-based frontend (`idma_reg32_*`/`idma_reg64_*`) now exposes a **native APB4 slave** instead of a register_interface reg_bus slave. The `reg_to_apb` shim is deleted and `register_interface` is dropped from `Bender.yml`.

## Why

Since the SystemRDL/PeakRDL migration (#73), the generated `idma_*_reg_top` is **already an APB4 block** (`--cpuif apb4-flat`). The reg frontend wrapped that APB block behind a reg_bus port + a `reg_to_apb` shim purely to keep the old port type — i.e. it converted reg_bus → APB to reach a register file that is APB anyway. The desc64 frontend is already native-APB; this brings the reg frontend in line so **every iDMA register interface is PeakRDL-native APB**, with no register_interface idiom left.

`reg_to_apb` was the *only* consumer of `register_interface` in the whole repo, so the dependency goes away entirely (no transitive fallout — nothing else pulls it).

## How the launch backpressure is preserved

Reading `next_id` launches a transfer, and the read must stall until the backend accepts it. Previously this rode on the reg_bus `.ready` field (via a `read_happens ? arb_ready : ...` trick on the shim's response). `next_id` is an `external` SystemRDL register, so the PeakRDL APB CPUIF holds `s_apb_pready` low until `hwif_in.next_id.rd_ack` is asserted. The stall now lives on that ack:

```systemverilog
assign dma_hw2reg[i].next_id[c].rd_ack = arb_ready[i];
```

The old `proc_dma_backpressure` block (which also had a latent struct-into-scalar assignment in its false branch) is removed.

## Breaking change

This is a **port-level breaking change** for integrators wiring the reg frontend over reg_bus — they now connect APB (`apb_req_t`/`apb_rsp_t`, define via `APB_TYPEDEF_ALL`) or place their own bridge. Appropriate for the breaking 0.7.0 line; the integration guide is updated. APB-native SoCs (e.g. pulp_cluster) connect straight through.

## Verification

- `make idma_hw_all` regenerates all four reg frontends clean; no residual `reg_to_apb`/`reg_req_t`.
- Full-design elaboration with `slang` over `bender script flist-plus` (whole iDMA + deps + generated reg32_3d frontend driven by APB types) passes with **0 errors**.
- `register_interface` no longer appears in `Bender.lock`.

Part of the iDMA 0.7.0 release (#129).