### PR TITLE
backend: Support OBI buses without rready (#48)

### DIFF
--- a/src/backend/tpl/idma_backend.sv.tpl
+++ b/src/backend/tpl/idma_backend.sv.tpl
@@ -44,6 +44,10 @@ module idma_backend_${name_uniqueifier} #(
 %endif
     /// Mask invalid data on the manager interface
     parameter bit MaskInvalidData            = 1'b1,
+% if 'obi' in used_protocols:
+    /// Set to `0` if the OBI bus has no `rready`; inserts a response converter
+    parameter bit ObiUseRReady               = 1'b1,
+% endif
     /// Should hardware legalization be present? (recommended)
     /// If not, software legalization is required to ensure the transfers are
     /// AXI4-conformal
@@ -705,6 +709,9 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
         .DataWidth                   ( DataWidth                   ),
         .BufferDepth                 ( BufferDepth                 ),
         .MaskInvalidData             ( MaskInvalidData             ),
+% if 'obi' in used_protocols:
+        .ObiUseRReady                ( ObiUseRReady                ),
+% endif
         .PrintFifoInfo               ( PrintFifoInfo               ),
         .r_dp_req_t                  ( r_dp_req_t                  ),
         .w_dp_req_t                  ( w_dp_req_t                  ),

--- a/src/backend/tpl/idma_transport_layer.sv.tpl
+++ b/src/backend/tpl/idma_transport_layer.sv.tpl
@@ -21,6 +21,10 @@ module idma_transport_layer_${name_uniqueifier} #(
     parameter int unsigned BufferDepth = 32'd3,
     /// Mask invalid data on the manager interface
     parameter bit MaskInvalidData = 1'b1,
+% if 'obi' in used_protocols:
+    /// Set to `0` if the OBI bus has no `rready`; inserts a response converter
+    parameter bit ObiUseRReady = 1'b1,
+% endif
     /// Print the info of the FIFO configuration
     parameter bit PrintFifoInfo = 1'b0,
     /// `r_dp_req_t` type:

--- a/src/db/idma_obi.yml
+++ b/src/db/idma_obi.yml
@@ -63,6 +63,7 @@ legalizer_write_meta_channel: |
         a_optional: '0
     };
 read_template: |
+    if (ObiUseRReady) begin : gen_obi_read${mh}
     idma_obi_read #(
         .StrbWidth        ( StrbWidth           ),
         .byte_t           ( byte_t              ),
@@ -90,7 +91,64 @@ read_template: |
         .buffer_in_valid_o ( ${buffer_in_valid} ),
         .buffer_in_ready_i ( buffer_in_ready )
     );
+    end else begin : gen_obi_read_rready_conv${mh}
+    // Insert a response converter so the OBI subordinate is never back-pressured
+    typedef type(${read_request}.a) obi_read_a_chan_t;
+    typedef type(${read_response}.r) obi_read_r_chan_t;
+    ${req_t} obi_read_req_conv;
+    ${rsp_t} obi_read_rsp_conv;
+    idma_obi_read #(
+        .StrbWidth        ( StrbWidth           ),
+        .byte_t           ( byte_t              ),
+        .strb_t           ( strb_t              ),
+        .r_dp_req_t       ( r_dp_req_t          ),
+        .r_dp_rsp_t       ( r_dp_rsp_t          ),
+        .read_meta_chan_t ( read_meta_channel_t ),
+        .read_req_t       ( ${req_t}           ),
+        .read_rsp_t       ( ${rsp_t}           )
+    ) i_idma_obi_read${mh} (
+        .r_dp_req_i        ( r_dp_req_i ),
+        .r_dp_valid_i      ( ${r_dp_valid_i} ),
+        .r_dp_ready_o      ( ${r_dp_ready_o} ),
+        .r_dp_rsp_o        ( ${r_dp_rsp_o} ),
+        .r_dp_valid_o      ( ${r_dp_valid_o} ),
+        .r_dp_ready_i      ( ${r_dp_ready_i} ),
+        .read_meta_req_i   ( ${read_meta_request} ),
+        .read_meta_valid_i ( ${read_meta_valid} ),
+        .read_meta_ready_o ( ${read_meta_ready} ),
+        .read_req_o        ( obi_read_req_conv ),
+        .read_rsp_i        ( obi_read_rsp_conv ),
+        .r_chan_valid_o    ( ${r_chan_valid} ),
+        .r_chan_ready_o    ( ${r_chan_ready} ),
+        .buffer_in_o       ( ${buffer_in} ),
+        .buffer_in_valid_o ( ${buffer_in_valid} ),
+        .buffer_in_ready_i ( buffer_in_ready )
+    );
+    obi_rready_converter #(
+        .obi_a_chan_t ( obi_read_a_chan_t ),
+        .obi_r_chan_t ( obi_read_r_chan_t ),
+        .Depth        ( NumAxInFlight     ),
+        .CombRspReq   ( 1'b0              )
+    ) i_obi_read_rready_converter${mh} (
+        .clk_i        ( clk_i      ),
+        .rst_ni       ( rst_ni     ),
+        .test_mode_i  ( testmode_i ),
+        .sbr_a_chan_i ( obi_read_req_conv.a      ),
+        .req_i        ( obi_read_req_conv.req    ),
+        .gnt_o        ( obi_read_rsp_conv.gnt    ),
+        .sbr_r_chan_o ( obi_read_rsp_conv.r      ),
+        .rvalid_o     ( obi_read_rsp_conv.rvalid ),
+        .rready_i     ( obi_read_req_conv.rready ),
+        .mgr_a_chan_o ( ${read_request}.a        ),
+        .req_o        ( ${read_request}.req      ),
+        .gnt_i        ( ${read_response}.gnt     ),
+        .mgr_r_chan_i ( ${read_response}.r       ),
+        .rvalid_i     ( ${read_response}.rvalid  )
+    );
+    assign ${read_request}.rready = 1'b1;
+    end
 write_template: |
+    if (ObiUseRReady) begin : gen_obi_write${mh}
     idma_obi_write #(
         .StrbWidth            ( StrbWidth            ),
         .MaskInvalidData      ( MaskInvalidData      ),
@@ -119,6 +177,63 @@ write_template: |
         .buffer_out_valid_i ( buffer_out_valid_shifted ),
         .buffer_out_ready_o ( ${buffer_out_ready} )
     );
+    end else begin : gen_obi_write_rready_conv${mh}
+    // Insert a response converter so the OBI subordinate is never back-pressured
+    typedef type(${write_request}.a) obi_write_a_chan_t;
+    typedef type(${write_response}.r) obi_write_r_chan_t;
+    ${req_t} obi_write_req_conv;
+    ${rsp_t} obi_write_rsp_conv;
+    idma_obi_write #(
+        .StrbWidth            ( StrbWidth            ),
+        .MaskInvalidData      ( MaskInvalidData      ),
+        .byte_t               ( byte_t               ),
+        .data_t               ( data_t               ),
+        .strb_t               ( strb_t               ),
+        .w_dp_req_t           ( w_dp_req_t           ),
+        .w_dp_rsp_t           ( w_dp_rsp_t           ),
+        .write_meta_channel_t ( write_meta_channel_t ),
+        .write_req_t          ( ${req_t}            ),
+        .write_rsp_t          ( ${rsp_t}            )
+    ) i_idma_obi_write${mh} (
+        .w_dp_req_i         ( w_dp_req_i ),
+        .w_dp_valid_i       ( ${w_dp_valid_i} ),
+        .w_dp_ready_o       ( ${w_dp_ready_o} ),
+        .dp_poison_i        ( dp_poison_i ),
+        .w_dp_rsp_o         ( ${w_dp_rsp_o} ),
+        .w_dp_valid_o       ( ${w_dp_valid_o} ),
+        .w_dp_ready_i       ( ${w_dp_ready_i} ),
+        .aw_req_i           ( ${write_meta_request} ),
+        .aw_valid_i         ( ${write_meta_valid} ),
+        .aw_ready_o         ( ${write_meta_ready}  ),
+        .write_req_o        ( obi_write_req_conv ),
+        .write_rsp_i        ( obi_write_rsp_conv ),
+        .buffer_out_i       ( buffer_out_shifted ),
+        .buffer_out_valid_i ( buffer_out_valid_shifted ),
+        .buffer_out_ready_o ( ${buffer_out_ready} )
+    );
+    obi_rready_converter #(
+        .obi_a_chan_t ( obi_write_a_chan_t ),
+        .obi_r_chan_t ( obi_write_r_chan_t ),
+        .Depth        ( NumAxInFlight      ),
+        .CombRspReq   ( 1'b0               )
+    ) i_obi_write_rready_converter${mh} (
+        .clk_i        ( clk_i      ),
+        .rst_ni       ( rst_ni     ),
+        .test_mode_i  ( testmode_i ),
+        .sbr_a_chan_i ( obi_write_req_conv.a      ),
+        .req_i        ( obi_write_req_conv.req    ),
+        .gnt_o        ( obi_write_rsp_conv.gnt    ),
+        .sbr_r_chan_o ( obi_write_rsp_conv.r      ),
+        .rvalid_o     ( obi_write_rsp_conv.rvalid ),
+        .rready_i     ( obi_write_req_conv.rready ),
+        .mgr_a_chan_o ( ${write_request}.a        ),
+        .req_o        ( ${write_request}.req      ),
+        .gnt_i        ( ${write_response}.gnt     ),
+        .mgr_r_chan_i ( ${write_response}.r       ),
+        .rvalid_i     ( ${write_response}.rvalid  )
+    );
+    assign ${write_request}.rready = 1'b1;
+    end
 synth_wrapper_ports_write: |
     output logic                   obi_write_req_a_req_o,
     output addr_t                  obi_write_req_a_addr_o,


### PR DESCRIPTION
Closes #48.

## Problem
Some OBI configurations omit the optional `rready` signal (`obi_cfg_t.UseRReady = 0`), so the subordinate cannot be back-pressured on the R channel. iDMA's OBI read/write managers drive and rely on `rready` to throttle responses (`idma_obi_read.sv:120`, `idma_obi_write.sv:168`), making them incompatible with such buses — exactly as reported in #48.

## Approach
Reuse the upstream, already-verified **`obi_rready_converter`** (OBI package) rather than reworking iDMA's datapath:

- New backend parameter **`ObiUseRReady`** (default `1'b1`), threaded `idma_backend` → `idma_transport_layer` → the OBI DB template. Emitted only for variants that use OBI.
- `ObiUseRReady = 1` → **byte-identical** to today (direct connect; existing users and tests unaffected).
- `ObiUseRReady = 0` → a generate branch inserts `obi_rready_converter` on each OBI manager port. It buffers responses in a `FALL_THROUGH` FIFO (depth `NumAxInFlight`) and credit-throttles the A channel, so the subordinate is **never back-pressured**, while iDMA's managers keep using `rready` internally (left completely untouched).
- The converter's `obi_a_chan_t`/`obi_r_chan_t` are derived locally via the SV `type()` operator, so no new type parameters leak into the backend interface (no break for integrators).

Why the converter and not a credit counter inside the iDMA managers: an in-manager credit that returns on buffer *push* over-issues (the buffer may still hold undrained data, dropping a later response). The converter buffers the raw response *before* the byte-masking stage, which is correct regardless of buffer occupancy — and it's already verified upstream.

## Verification
- `make idma_hw_all` regenerates all OBI variants; the `ObiUseRReady = 1` branch is the previous instantiation verbatim.
- **Elaboration (slang, full design via `bender script flist-plus`)**:
  - default path: `idma_backend_synth_{rw_obi,r_obi_w_axi,r_axi_w_obi}` → 0 errors;
  - `ObiUseRReady = 0` path (converter live): 0 errors — `obi_rready_converter`, `credit_counter`, and the `type()`-derived channel types all resolve.
- `obi_rready_converter`/`credit_counter` are pulled from the existing `obi`/`common_cells` deps — no `Bender.yml` change.

## Remaining before merge (why this is a draft)
- Directed simulation against a **no-rready subordinate**. The OBI backend TB currently bridges the OBI port to AXI (`obi2axi_bridge` → `axi_sim_mem`); the proper test threads `ObiUseRReady = 0` to the DUT and drives it from `obi_sim_mem` configured `UseRReady = 0` (upstream-supported), checking data integrity + no dropped responses across the `simple`/`medium`/`error_simple` jobs. The converter itself is upstream-verified, but iDMA should prove the integration in sim.

Part of the iDMA 0.7.0 enhancement set; additive and default-off, so it does not gate the release.