### PR TITLE
test: Harden transpose testbenches (fatal-on-fail + midend coverage)

### DIFF
--- a/idma.mk
+++ b/idma.mk
@@ -398,6 +398,13 @@ idma_sim_tb_idma_transpose_b2b: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_transpose_b2b -do "run -all; quit"
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_transpose_b2b -do "run -all; quit"
 
+.PHONY: idma_sim_tb_idma_transpose_midend
+idma_sim_tb_idma_transpose_midend: $(IDMA_VSIM_DIR)/compile.tcl
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
+	# the TB sweeps the geometry list internally; one run per bus width
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64  tb_idma_transpose_midend -do "run -all; quit"
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=512 tb_idma_transpose_midend -do "run -all; quit"
+
 .PHONY: idma_sim_tb_idma_rt_midend
 
 idma_sim_tb_idma_rt_midend: $(IDMA_VSIM_DIR)/compile.tcl

--- a/test/midend/tb_idma_transpose_midend.sv
+++ b/test/midend/tb_idma_transpose_midend.sv
@@ -9,23 +9,22 @@
 
 /// Unit check for idma_transpose_midend: the expanded NumDim=4 ND request must
 /// match the golden geometry that tb_idma_transpose_nd hand-builds, and a
-/// non-transpose request must pass through unchanged.
+/// non-transpose request must pass through unchanged. Sweeps a geometry list
+/// internally (one elaboration per bus width).
 module tb_idma_transpose_midend #(
   parameter int unsigned DataWidth = 512,
-  parameter int unsigned AddrWidth = 64,
-  parameter int unsigned M  = 40,
-  parameter int unsigned N  = 24,
-  parameter int unsigned EB = 1
+  parameter int unsigned AddrWidth = 64
 );
   import idma_pkg::*;
 
   localparam int unsigned StrbWidth = DataWidth/8;
-  localparam int unsigned NE   = StrbWidth/EB;
-  localparam int unsigned MODE = (EB==4) ? 2 : (EB==2) ? 1 : 0;
-  localparam int unsigned YT   = (M + NE - 1)/NE;
-  localparam int unsigned NT   = (N + NE - 1)/NE;
-  localparam int unsigned MP   = YT*NE;
   localparam int unsigned NumDim = 4;
+
+  // Geometry cases (M, N, EB); EB>StrbWidth cases skip.
+  localparam int unsigned NCases = 7;
+  localparam int unsigned Cases [NCases][3] = '{
+    '{8, 8, 1}, '{16, 16, 1}, '{40, 24, 1}, '{13, 19, 2}, '{5, 7, 1}, '{9, 5, 4}, '{6, 10, 1}
+  };
 
   typedef logic [AddrWidth-1:0] addr_t;
   typedef logic [31:0]          tf_len_t;
@@ -55,8 +54,43 @@ module tb_idma_transpose_midend #(
     end
   endtask
 
+  // Check the expanded geometry for one m x n transpose of eb-byte elements.
+  task automatic chk_geom(input int unsigned m, input int unsigned n, input int unsigned eb);
+    automatic int unsigned ne   = StrbWidth/eb;
+    automatic int unsigned mode = (eb==4) ? 2 : (eb==2) ? 1 : 0;
+    automatic int unsigned yt   = (m + ne - 1)/ne;
+    automatic int unsigned nt   = (n + ne - 1)/ne;
+    automatic int unsigned mp   = yt*ne;
+    nd_in = '0;
+    nd_in.burst_req.src_addr = 64'h1000;
+    nd_in.burst_req.dst_addr = 64'h2000;
+    nd_in.burst_req.opt.compute.enable                    = 1'b1;
+    nd_in.burst_req.opt.compute.op                        = COMPUTE_TRANSPOSE;
+    nd_in.burst_req.opt.compute.params.transpose.mode     = 2'(mode);
+    nd_in.burst_req.opt.compute.params.transpose.tensor_m = 12'(m);
+    nd_in.burst_req.opt.compute.params.transpose.tensor_n = 12'(n);
+    #1;
+    // golden geometry (same formulas as tb_idma_transpose_nd)
+    chk("length",  nd_out.burst_req.length,     ne*eb);
+    chk("d0.reps", nd_out.d_req[0].reps,        ne);
+    chk("d0.src",  nd_out.d_req[0].src_strides, addr_t'(n*eb));
+    chk("d0.dst",  nd_out.d_req[0].dst_strides, addr_t'(mp*eb));
+    chk("d1.reps", nd_out.d_req[1].reps,        yt);
+    chk("d1.src",  nd_out.d_req[1].src_strides, addr_t'(n*eb));
+    chk("d1.dst",  nd_out.d_req[1].dst_strides, addr_t'(int'(ne*eb) - int'((ne-1)*mp*eb)));
+    chk("d2.reps", nd_out.d_req[2].reps,        nt);
+    chk("d2.src",  nd_out.d_req[2].src_strides, addr_t'(int'(ne*eb) - int'((yt*ne-1)*n*eb)));
+    chk("d2.dst",  nd_out.d_req[2].dst_strides, addr_t'(int'(mp*eb) - int'((yt-1)*ne*eb)));
+    // addresses + compute must survive untouched
+    chk("src_addr", nd_out.burst_req.src_addr, 64'h1000);
+    chk("dst_addr", nd_out.burst_req.dst_addr, 64'h2000);
+    chk("cmp_en",   nd_out.burst_req.opt.compute.enable, 1);
+    if (errs == 0) $display("[MID] PASS: %0dx%0d EB=%0d golden (NE=%0d YT=%0d NT=%0d MP=%0d)",
+                            m, n, eb, ne, yt, nt, mp);
+  endtask
+
   initial begin
-    // --- passthrough case ---
+    // --- passthrough case: a non-transpose request must be untouched ---
     nd_in = '0;
     nd_in.burst_req.src_addr = 64'hDEAD;
     nd_in.burst_req.dst_addr = 64'hBEEF;
@@ -67,36 +101,13 @@ module tb_idma_transpose_midend #(
       $display("[MID] passthrough altered a non-transpose request");
     end
 
-    // --- transpose case ---
-    nd_in = '0;
-    nd_in.burst_req.src_addr = 64'h1000;
-    nd_in.burst_req.dst_addr = 64'h2000;
-    nd_in.burst_req.opt.compute.enable                  = 1'b1;
-    nd_in.burst_req.opt.compute.op                      = COMPUTE_TRANSPOSE;
-    nd_in.burst_req.opt.compute.params.transpose.mode     = 2'(MODE);
-    nd_in.burst_req.opt.compute.params.transpose.tensor_m = 12'(M);
-    nd_in.burst_req.opt.compute.params.transpose.tensor_n = 12'(N);
-    #1;
+    // --- transpose cases ---
+    for (int unsigned k = 0; k < NCases; k++) begin
+      if (Cases[k][2] > StrbWidth) continue;   // element must fit the bus
+      chk_geom(Cases[k][0], Cases[k][1], Cases[k][2]);
+    end
 
-    // golden geometry (same formulas as tb_idma_transpose_nd)
-    chk("length",  nd_out.burst_req.length,     NE*EB);
-    chk("d0.reps", nd_out.d_req[0].reps,        NE);
-    chk("d0.src",  nd_out.d_req[0].src_strides, addr_t'(N*EB));
-    chk("d0.dst",  nd_out.d_req[0].dst_strides, addr_t'(MP*EB));
-    chk("d1.reps", nd_out.d_req[1].reps,        YT);
-    chk("d1.src",  nd_out.d_req[1].src_strides, addr_t'(N*EB));
-    chk("d1.dst",  nd_out.d_req[1].dst_strides, addr_t'(int'(NE*EB) - int'((NE-1)*MP*EB)));
-    chk("d2.reps", nd_out.d_req[2].reps,        NT);
-    chk("d2.src",  nd_out.d_req[2].src_strides, addr_t'(int'(NE*EB) - int'((YT*NE-1)*N*EB)));
-    chk("d2.dst",  nd_out.d_req[2].dst_strides, addr_t'(int'(MP*EB) - int'((YT-1)*NE*EB)));
-    // addresses + compute must survive untouched
-    chk("src_addr", nd_out.burst_req.src_addr, 64'h1000);
-    chk("dst_addr", nd_out.burst_req.dst_addr, 64'h2000);
-    chk("cmp_en",   nd_out.burst_req.opt.compute.enable, 1);
-
-    if (errs == 0)
-      $display("[MID] PASS: %0dx%0d EB=%0d golden (NE=%0d YT=%0d NT=%0d MP=%0d)",
-               M, N, EB, NE, YT, NT, MP);
+    if (errs == 0) $display("[MID] ALL PASS (%0d cases, StrbWidth=%0d)", NCases, StrbWidth);
     else           $fatal(1, "[MID] FAIL: %0d mismatches", errs);
     $finish;
   end

--- a/test/tb_idma_otf_transpose.sv
+++ b/test/tb_idma_otf_transpose.sv
@@ -174,15 +174,14 @@ module tb_idma_otf_transpose #(
     end
 
     if (total == 0) $display("[TB] ALL PASS (%0d cases, StrbWidth=%0d, FullDuplex=%0d)", NCases, StrbWidth, FullDuplex);
-    else            $display("[TB] FAIL: %0d total errors", total);
+    else            $fatal(1, "[TB] FAIL: %0d total errors", total);
     repeat (5) @(posedge clk);
     $finish;
   end
 
   initial begin
     #100000000;
-    $display("[TB] FAIL: timeout");
-    $finish;
+    $fatal(1, "[TB] FAIL: timeout");
   end
 
 endmodule


### PR DESCRIPTION
`tb_idma_otf_transpose` printed `FAIL` but called `$finish` (exit 0) on both a golden mismatch and a timeout, so a failing transpose passed the sim silently. Switch to `$fatal(1, ...)` to match the other transpose testbenches so CI gates on it.