### PR TITLE
frontend: Gate external register read-ack

### DIFF
--- a/src/frontend/reg/tpl/idma_reg.sv.tpl
+++ b/src/frontend/reg/tpl/idma_reg.sv.tpl
@@ -205,11 +205,15 @@ module idma_${identifier} #(
     // observational registers
     for (genvar c = 0; c < NumStreams; c++) begin : gen_hw2reg_connections
         assign dma_hw2reg[i].status[c].rd_data.busy  = {midend_busy_i[c], busy_i[c]};
-        assign dma_hw2reg[i].status[c].rd_ack = 1'b1;
+        assign dma_hw2reg[i].status[c].rd_ack = dma_reg2hw[i].status[c].req
+                                              & ~dma_reg2hw[i].status[c].req_is_wr;
         assign dma_hw2reg[i].next_id[c].rd_data.next_id = next_id_i;
-        assign dma_hw2reg[i].next_id[c].rd_ack = 1'b1;
+        assign dma_hw2reg[i].next_id[c].rd_ack = dma_reg2hw[i].next_id[c].req
+                                               & ~dma_reg2hw[i].next_id[c].req_is_wr
+                                               & arb_ready[i];
         assign dma_hw2reg[i].done_id[c].rd_data.done_id = done_id_i[c];
-        assign dma_hw2reg[i].done_id[c].rd_ack = 1'b1;
+        assign dma_hw2reg[i].done_id[c].rd_ack = dma_reg2hw[i].done_id[c].req
+                                               & ~dma_reg2hw[i].done_id[c].req_is_wr;
     end
 
     // tie-off unused channels


### PR DESCRIPTION
The SystemRDL reg block (PR #73) drives `status`/`next_id`/`done_id` as external reads. Acking unconditionally (`rd_ack = 1'b1`) violates the PeakRDL external-read handshake and trips `assert_bad_ext_rd_ack` every idle cycle (millions of errors in long sims). Gate each ack on the block's read request; `next_id` launches a transfer on read, so it additionally holds the ack until the arbiter accepts (`arb_ready`), preserving read back-pressure. Verified to clear the assertion in a downstream cluster sim.