### PR TITLE
frontend: Model status/done_id as internal status registers

### DIFF
--- a/src/frontend/reg/idma_reg.rdl
+++ b/src/frontend/reg/idma_reg.rdl
@@ -153,9 +153,9 @@ addrmap idma_reg #(
     };
 
              conf     conf;
-    external status   status[16];
+             status   status[16];
     external next_id  next_id[16];
-    external done_id  done_id[16];
+             done_id  done_id[16];
              dst_addr dst_addr[SysAddrWidth/32] @ 0xD0;
              src_addr src_addr[SysAddrWidth/32];
              length   length[SysAddrWidth/32];

--- a/src/frontend/reg/tpl/idma_reg.sv.tpl
+++ b/src/frontend/reg/tpl/idma_reg.sv.tpl
@@ -203,27 +203,24 @@ module idma_${identifier} #(
     end
 
     // observational registers
+    // status and done_id are internal hw=w regs (no read side-effect): drive the
+    // registered value. next_id is external (read launches a transfer): ack only
+    // on request, held until the arbiter accepts (read back-pressure).
     for (genvar c = 0; c < NumStreams; c++) begin : gen_hw2reg_connections
-        assign dma_hw2reg[i].status[c].rd_data.busy  = {midend_busy_i[c], busy_i[c]};
-        assign dma_hw2reg[i].status[c].rd_ack = dma_reg2hw[i].status[c].req
-                                              & ~dma_reg2hw[i].status[c].req_is_wr;
+        assign dma_hw2reg[i].status[c].busy.next = {midend_busy_i[c], busy_i[c]};
         assign dma_hw2reg[i].next_id[c].rd_data.next_id = next_id_i;
         assign dma_hw2reg[i].next_id[c].rd_ack = dma_reg2hw[i].next_id[c].req
                                                & ~dma_reg2hw[i].next_id[c].req_is_wr
                                                & arb_ready[i];
-        assign dma_hw2reg[i].done_id[c].rd_data.done_id = done_id_i[c];
-        assign dma_hw2reg[i].done_id[c].rd_ack = dma_reg2hw[i].done_id[c].req
-                                               & ~dma_reg2hw[i].done_id[c].req_is_wr;
+        assign dma_hw2reg[i].done_id[c].done_id.next = done_id_i[c];
     end
 
     // tie-off unused channels
     for (genvar c = NumStreams; c < MaxNumStreams; c++) begin : gen_hw2reg_unused
-        assign dma_hw2reg[i].status[c].rd_data = '0;
-        assign dma_hw2reg[i].status[c].rd_ack  = '0;
+        assign dma_hw2reg[i].status[c].busy.next = '0;
         assign dma_hw2reg[i].next_id[c].rd_data.next_id = '0;
         assign dma_hw2reg[i].next_id[c].rd_ack = '0;
-        assign dma_hw2reg[i].done_id[c].rd_data.done_id = '0;
-        assign dma_hw2reg[i].done_id[c].rd_ack = '0;
+        assign dma_hw2reg[i].done_id[c].done_id.next = '0;
     end
 
   end


### PR DESCRIPTION
Refines the external-register read-ack fix (#134) by modeling the two observational registers correctly instead of gating their ack.

\`status\` (busy) and \`done_id\` have **no read side-effect**, so they need not be \`external\`. This drops \`external\` on them in the RDL and drives the registered value through the PeakRDL \`hwif .next\` input; PeakRDL then emits plain internal storage with **no external read handshake and no \`assert_bad_ext_rd_ack\`** for those registers. \`next_id\` keeps its external read-launch interface with the \`arb_ready\`-gated ack from #134 (its read launches a transfer and must back-pressure).

**Net effect:** the external read handshake/assertion now governs only \`next_id\` (the one register that genuinely needs it); the change removes logic rather than gating it.

**Trade-off:** \`status\`/\`done_id\` reads are now registered (≤1-cycle-delayed) rather than live-combinational. This is benign for busy/done polling (you never read a value that was not true, just up to a cycle late) and the **SW-facing register map is unchanged** (offsets, width, \`sw=r\` access identical).

**Status:** verified structurally — regenerates cleanly, the generated reg block elaborates (slang, 0 errors), and \`external_rd_ack\` now ORs only \`next_id\`. Draft pending the same cluster/UVM sim validation #134 had (assertion clears + a SW polling read returns the expected registered value).