### PR TITLE
frontend: Emit synth-wrapper head ports only for multi-head backends

### DIFF
--- a/src/backend/tpl/idma_backend.sv.tpl
+++ b/src/backend/tpl/idma_backend.sv.tpl
@@ -215,7 +215,7 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     /// - `is_single`: Is this transfer just one beat long? `(len == 0)`
     typedef struct packed {
         idma_pkg::protocol_e  src_protocol;
-        idma_pkg::multihead_t src_head;
+        idma_pkg::multihead_t src_head;  // ignored unless multi-head (one head: tied 0)
         offset_t              offset;
         offset_t              tailer;
         offset_t              shift;
@@ -243,7 +243,7 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     /// - `is_single`: Is this transfer just one beat long? `(len == 0)`
     typedef struct packed {
         idma_pkg::protocol_e  dst_protocol;
-        idma_pkg::multihead_t dst_head;
+        idma_pkg::multihead_t dst_head;  // ignored unless multi-head (one head: tied 0)
         offset_t              offset;
         offset_t              tailer;
         offset_t              shift;

--- a/src/backend/tpl/idma_backend_synth.sv.tpl
+++ b/src/backend/tpl/idma_backend_synth.sv.tpl
@@ -97,8 +97,10 @@ module idma_backend_synth_${name_uniqueifier} #(
     input  addr_t                  req_dst_addr_i,
     input  idma_pkg::protocol_e    req_src_protocol_i,
     input  idma_pkg::protocol_e    req_dst_protocol_i,
+% if any_mh:
     input  idma_pkg::multihead_t   req_src_head_i,
     input  idma_pkg::multihead_t   req_dst_head_i,
+% endif
     input  id_t                    req_axi_id_i,
     input  axi_pkg::burst_t        req_src_burst_i,
     input  axi_pkg::cache_t        req_src_cache_i,
@@ -369,8 +371,13 @@ ${p}_${database[p]['write_meta_channel']}_width\
     assign idma_req.length                 = req_length_i;
     assign idma_req.opt.src_protocol       = req_src_protocol_i;
     assign idma_req.opt.dst_protocol       = req_dst_protocol_i;
+% if any_mh:
     assign idma_req.opt.src_head           = req_src_head_i;
     assign idma_req.opt.dst_head           = req_dst_head_i;
+% else:
+    assign idma_req.opt.src_head           = '0;
+    assign idma_req.opt.dst_head           = '0;
+% endif
     assign idma_req.opt.axi_id             = req_axi_id_i;
     assign idma_req.opt.dst.cache          = req_dst_cache_i;
     assign idma_req.opt.dst.burst          = req_dst_burst_i;

--- a/util/mario/synth.py
+++ b/util/mario/synth.py
@@ -29,6 +29,10 @@ def render_synth_wrapper(prot_ids: dict, db: dict, tpl_file: str) -> str:
         srp = len(used_read_prots) == 1
         swp = len(used_write_prots) == 1
 
+        # multi-head head ports are emitted only when a protocol has >1 head
+        any_mh = any(n > 1 for n in prot_ids[prot_id]['multihead']['r'].values()) \
+            or any(n > 1 for n in prot_ids[prot_id]['multihead']['w'].values())
+
         # formatting
         for rp in used_read_prots:
             db[rp]['synth_wrapper_ports_read'] =\
@@ -49,7 +53,8 @@ def render_synth_wrapper(prot_ids: dict, db: dict, tpl_file: str) -> str:
             'used_write_protocols': used_write_prots,
             'used_protocols': prot_ids[prot_id]['used'],
             'one_read_port': srp,
-            'one_write_port': swp
+            'one_write_port': swp,
+            'any_mh': any_mh
         }
 
         # render


### PR DESCRIPTION
The multi-head feature added \`req_src_head_i\`/\`req_dst_head_i\` to **every** backend synth wrapper unconditionally. Single-head integrations (every default variant) therefore gained two dead input ports — left unconnected they raise elaboration warnings and confuse integrators ("do I need to drive these?").

Gate the ports on \`any_mh\` (a protocol with >1 head): single-head wrappers drop the ports and tie \`opt.src_head\`/\`opt.dst_head\` to 0; multi-head wrappers (e.g. \`2r_axi_w_axi\`) are unchanged. Backward compatible for single-head builds.

Verified: regenerated all default (single-head) variants → 0 head ports, \`opt.*_head\` tied to 0, elaborates clean (slang); regenerated \`2r_axi_w_axi\` → head ports still present and driven. The internal \`r_dp_req_t\`/\`w_dp_req_t\` head fields are left in place (dead and constant-propagated for single-head, not integrator-visible); gating those would touch the backend + legalizer for no integration-facing benefit.