### PR TITLE
Fix OBI deadlock for L1-to-L1 DMA transfers

### DIFF
--- a/src/frontend/inst64/idma_inst64_top.sv
+++ b/src/frontend/inst64/idma_inst64_top.sv
@@ -294,8 +294,13 @@ module idma_inst64_top #(
 
         assign init_read_rsp[c].rsp_chan.init = {{StrbWidth}{init_read_req_byte[c]}};
 
-        // prefer read request if both were valid (but shouldn't happen)
-        assign obi_we_d[c] = (~obi_read_req[c].req & obi_write_req[c].req);
+        always_comb begin : gen_obi_rw_arbitration
+            if (obi_write_req[c].req) begin
+                obi_we_d[c] = '1;
+            end else begin
+                obi_we_d[c] = '0;
+            end
+        end
 
         `FF(obi_we_q[c], obi_we_d[c], '0, clk_i, rst_ni)
         stream_mux #(


### PR DESCRIPTION
**Summary**
This PR (together with [PR #322](https://github.com/pulp-platform/snitch_cluster/pull/322)) solves a deadlock in the Snitch cluster when L1-to-L1 DMA transfers are handled via the iDMA OBI interface.

**Description**
Local L1-to-L1 cluster transfers are handled via a single OBI interface, where read and write transactions must be arbitrated. The previous implementation prioritized reads, potentially leading to a deadlock due to write starvation given the limited internal request buffer depth (hardcoded). Prioritizing writes instead enforces a strict read-write interleaving, since the DMA always reads from a source before writing to a destination.