### PR TITLE
test: Drop internal codename from multihead TB comments

### DIFF
--- a/test/tb_idma_backend_multihead.sv
+++ b/test/tb_idma_backend_multihead.sv
@@ -10,8 +10,8 @@
 // its own axi_sim_mem so read-head routing is observable: src_head selects which
 // read memory a transfer sources from, while all writes land in the single write
 // memory. Preloading distinct data per read head and checking the write memory
-// catches a backend that ignores or mis-routes src_head. Recycles the per-head
-// memory harness pattern from the vidma inst64 verification harness.
+// catches a backend that ignores or mis-routes src_head. Uses a per-head
+// memory harness pattern.
 
 `timescale 1ns/1ns
 `include "axi/typedef.svh"

--- a/test/tb_idma_backend_multihead_rw.sv
+++ b/test/tb_idma_backend_multihead_rw.sv
@@ -10,8 +10,7 @@
 // joined axi_sim_mem so both src_head and dst_head routing are observable. A
 // cross-head transfer (src_head != dst_head) reads one head's memory and must
 // land in the other head's memory, which also exercises the write-response head
-// FIFO. Recycles the per-head memory harness pattern from the vidma inst64
-// verification harness.
+// FIFO. Uses a per-head memory harness pattern.
 
 `timescale 1ns/1ns
 `include "axi/typedef.svh"


### PR DESCRIPTION
The per-head memory harness comments in the multi-head backend testbenches named an internal verification harness by codename. Reword to describe the pattern generically — no functional change.