### PR TITLE
Regs/Transpose: Add compute parameter register to register frontend and fix transpose to/from misaligned addresses

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,11 @@ on:
         required: false
         type: string
         default: "rw_axi r_obi_w_axi r_axi_w_obi rw_axi_rw_axis rw_obi r_obi_rw_init_w_axi r_axi_rw_init_rw_obi rw_axi_rw_init_rw_obi"
+      IDMA_ADD_FE_IDS:
+        description: Register frontend variants to generate.
+        required: false
+        type: string
+        default: "reg32_4d reg64_4d"
       IDMA_REG_CPUIF:
         description: PeakRDL CPU interface used for generated register frontends.
         required: false
@@ -27,6 +32,11 @@ on:
         required: false
         type: string
         default: "rw_axi r_obi_w_axi r_axi_w_obi rw_axi_rw_axis rw_obi r_obi_rw_init_w_axi r_axi_rw_init_rw_obi rw_axi_rw_init_rw_obi"
+      IDMA_ADD_FE_IDS:
+        description: Register frontend variants to generate.
+        required: false
+        type: string
+        default: "reg32_4d reg64_4d"
       IDMA_REG_CPUIF:
         description: PeakRDL CPU interface used for generated register frontends.
         required: false
@@ -63,7 +73,8 @@ jobs:
       run: |
         uv run --locked make -B idma_hw_all idma_sw_all \
           IDMA_BACKEND_IDS="${{ inputs.IDMA_BACKEND_IDS }}" \
-          IDMA_REG_CPUIF="${{ inputs.IDMA_REG_CPUIF }}"
+          IDMA_REG_CPUIF="${{ inputs.IDMA_REG_CPUIF }}" \
+          IDMA_ADD_FE_IDS="${{ inputs.IDMA_ADD_FE_IDS }}"
     -
       name: Deploy generated files
       run: |

--- a/src/backend/idma_otf_transpose.sv
+++ b/src/backend/idma_otf_transpose.sv
@@ -27,7 +27,7 @@ module idma_otf_transpose #(
   input  logic rst_ni,
   input  logic clear_i,
 
-  /// Element size select: 0->1B, 1->2B, 2->4B (E = 1<<transp_mode_i)
+  /// Element size select: 0->1B, 1->2B, 2->4B, 3->8B (E = 1<<transp_mode_i)
   input  logic [1:0]  transp_mode_i,
   /// Matrix dimensions in elements
   input  logic [DimWidth-1:0] tensor_size_m_i,

--- a/src/frontend/reg/idma_reg.rdl
+++ b/src/frontend/reg/idma_reg.rdl
@@ -151,6 +151,31 @@ addrmap idma_reg #(
         } reps [31:0] = 0;
     };
 
+    reg compute_cfg {
+        name = "compute_cfg";
+        desc = "Per-transfer on-the-fly compute configuration. The fields are sampled when next_id is read to launch a transfer.";
+        default sw = rw;
+        default hw = r;
+        field {
+            desc = "Enable on-the-fly compute for the launched transfer.";
+        } compute_enable [0:0] = 0;
+        field {
+            desc = "Compute operation selector. Currently, 1 selects transpose.";
+        } compute_op [4:1] = 0;
+        field {
+            desc = "Transpose element-size mode. The element size is 1 << transpose_mode bytes, encoding 8b, 16b, 32b, and 64b elements.";
+        } transpose_mode [6:5] = 0;
+        field {
+            desc = "Transpose tensor M dimension in elements. Must be non-zero when transpose is enabled.";
+        } transpose_tensor_m [18:7] = 0;
+        field {
+            desc = "Transpose tensor N dimension in elements. Must be non-zero when transpose is enabled.";
+        } transpose_tensor_n [30:19] = 0;
+        field {
+            desc = "Reserved.";
+        } reserved [31:31] = 0;
+    };
+
     regfile dim {
         dst_stride dst_stride[SysAddrWidth/32];
         src_stride src_stride[SysAddrWidth/32];
@@ -166,6 +191,7 @@ addrmap idma_reg #(
              src_addr src_addr[SysAddrWidth/32];
              length   length[SysAddrWidth/32];
              dim      dim[NumDims-1 | NumDims == 1];
+             compute_cfg compute_cfg;
 };
 
 `endif // IDMA_REG_RDL

--- a/src/frontend/reg/tpl/idma_reg.sv.tpl
+++ b/src/frontend/reg/tpl/idma_reg.sv.tpl
@@ -242,6 +242,19 @@ module idma_${identifier} #(
       nxt_dma_req${sep}opt.beo.src_reduce_len = dma_reg2hw[i].conf.src_reduce_len.value;
       nxt_dma_req${sep}opt.beo.dst_reduce_len = dma_reg2hw[i].conf.dst_reduce_len.value;
 
+      // Optional on-the-fly compute settings are part of the transfer descriptor and
+      // are captured together with the address/stride fields when next_id is read.
+      nxt_dma_req${sep}opt.compute.enable                    =
+          dma_reg2hw[i].compute_cfg.compute_enable.value;
+      nxt_dma_req${sep}opt.compute.op                        =
+          idma_pkg::compute_op_e'(dma_reg2hw[i].compute_cfg.compute_op.value);
+      nxt_dma_req${sep}opt.compute.params.transpose.mode     =
+          dma_reg2hw[i].compute_cfg.transpose_mode.value;
+      nxt_dma_req${sep}opt.compute.params.transpose.tensor_m =
+          dma_reg2hw[i].compute_cfg.transpose_tensor_m.value;
+      nxt_dma_req${sep}opt.compute.params.transpose.tensor_n =
+          dma_reg2hw[i].compute_cfg.transpose_tensor_n.value;
+
 % if num_dim != 1:
       // ND connections
 % for nd in range(0, num_dim-1):

--- a/src/midend/idma_transpose_midend.sv
+++ b/src/midend/idma_transpose_midend.sv
@@ -105,11 +105,10 @@ module idma_transpose_midend #(
                RepW, (TensorW > Log2Strb+1) ? TensorW : Log2Strb+1);
     initial assert (LenW > Log2Strb) else
         $fatal(1, "idma_transpose_midend: length field %0d b cannot hold StrbWidth", LenW);
-    // reserved mode 3 (EB=8) and zero-size tensors are out of contract
+    // Zero-size tensors are out of contract.  Modes 0..3 select 1, 2, 4,
+    // and 8 byte elements; mode 3 degenerates to NE=1 for a 64-bit datapath.
     always_comb begin : check_domain
         if (is_transpose) begin
-            assert (nd_req_i.burst_req.opt.compute.params.transpose.mode != 2'd3) else
-                $error("idma_transpose_midend: reserved element mode 3 (EB=8)");
             assert (nd_req_i.burst_req.opt.compute.params.transpose.tensor_m != '0 &&
                     nd_req_i.burst_req.opt.compute.params.transpose.tensor_n != '0) else
                 $error("idma_transpose_midend: zero-size tensor (M or N == 0)");


### PR DESCRIPTION
# Merge order:
This PR is based on the PR making the compute engine instantiation an elaboration-time parameter instead of a generation-time one, see https://github.com/pulp-platform/iDMA/pull/159 - that PR should be merged before this one.

# Changes:

- Add CI input for additional register frontends to generate in the `deploy` job (`IDMA_ADD_FE_IDS`)
- Add a register to hold compute (i.e., transpose) configuration to the register file definition
- BUGFIX: Transpose was buggy when the destination buffer was misaligned to the data bus
  - Previously, an output was popped from the transposition unit on every accepted output beat. As a misaligned write is split into 2 beats, that led to some data being dropped and AW transfers being issued without a corresponding W transfer to follow them up
  - This has been fixed by connecting the transpose unit's `ready_i` to `w_dp_req_ready` instead of `write_beat_done`; that signal is asserted on the last transaction of a write transfer, which is the correct behavior.