### PR TITLE
backend: Fix compute synth-wrapper emission and AXI-write eligibility

### DIFF
--- a/src/backend/tpl/idma_transport_layer.sv.tpl
+++ b/src/backend/tpl/idma_transport_layer.sv.tpl
@@ -239,7 +239,9 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     byte_t [StrbWidth-1:0] buffer_out_shifted;
     byte_t [StrbWidth-1:0] wr_data;
     strb_t                 wr_valid, wr_strb, mask_ext_shifted, dataflow_ready_in;
+% if 'axi' in used_write_protocols:
     logic                  w_beat_done;
+% endif
 
 % if not one_read_port:
     // Read multiplexed signals
@@ -261,7 +263,9 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     logic ${mh_format['aw'][protocol]}${protocol}_w_dp_ready;
     w_dp_rsp_t ${mh_format['aw'][protocol]}${protocol}_w_dp_rsp;
     logic ${mh_format['aw'][protocol]}${protocol}_aw_ready;
+    % if protocol == 'axi':
     logic ${mh_format['aw'][protocol]}${protocol}_w_beat_done;
+    % endif
 
     %endfor
     logic w_dp_req_valid, w_dp_req_ready;
@@ -507,9 +511,9 @@ ${rendered_read_ports[read_port]}
     always_comb begin : gen_write_beat_done_mux
         case(w_dp_req_i.dst_protocol)
 % for wp in used_write_protocols:
-    % if wp in ('axi', 'obi') and mh_format['aw'][wp] == '':
+    % if wp == 'axi' and mh_format['aw'][wp] == '':
         idma_pkg::${database[wp]['protocol_enum']}: w_beat_done = ${wp}_w_beat_done;
-    % elif wp in ('axi', 'obi'):
+    % elif wp == 'axi':
         idma_pkg::${database[wp]['protocol_enum']}: w_beat_done = ${wp}_w_beat_done [w_dp_req_i.dst_head];
     % endif
 % endfor

--- a/util/mario/synth.py
+++ b/util/mario/synth.py
@@ -10,6 +10,8 @@
 """ MARIO synth wrapper interaction"""
 from mako.template import Template
 
+from mario.util import compute_eligible
+
 
 def render_synth_wrapper(prot_ids: dict, db: dict, tpl_file: str) -> str:
     """Generate synth wrapper"""
@@ -54,7 +56,8 @@ def render_synth_wrapper(prot_ids: dict, db: dict, tpl_file: str) -> str:
             'used_protocols': prot_ids[prot_id]['used'],
             'one_read_port': srp,
             'one_write_port': swp,
-            'any_mh': any_mh
+            'any_mh': any_mh,
+            'compute_eligible': compute_eligible(used_read_prots, used_write_prots, db)
         }
 
         # render

--- a/util/mario/util.py
+++ b/util/mario/util.py
@@ -44,10 +44,12 @@ def prot_key(used_prots: list, key: str, feature: str, db: dict) -> list:
 
 def compute_eligible(used_read_prots: list, used_write_prots: list, db: dict) -> bool:
     """Return true if this backend topology has data paths that can host compute."""
-    compute_protocols = {'AXI', 'OBI'}
+    read_compute_protocols = {'AXI', 'OBI'}
+    write_compute_protocols = {'AXI'}
     read_protocols = {db[prot]['protocol_enum'] for prot in used_read_prots}
     write_protocols = {db[prot]['protocol_enum'] for prot in used_write_prots}
-    return bool(read_protocols & compute_protocols) and bool(write_protocols & compute_protocols)
+    return bool(read_protocols & read_compute_protocols) \
+        and bool(write_protocols & write_compute_protocols)
 
 
 def prepare_ids(id_strs: list) -> dict:


### PR DESCRIPTION
Follow-up to #159 - review fixes deferred so #159 could land.

- `synth.py`: pass `compute_eligible` so synth wrappers emit the compute params (were silently dropped under Mako non-strict-undefined -> dead synth-wrapper path).
- `util.py`: restrict compute write-side to AXI (only `idma_axi_write` has `w_beat_done_o`; OBI-write eligible variants had an undriven `w_beat_done`).
- `idma_transport_layer.sv.tpl`: gate the `w_beat_done` decl, per-port copy, and mux arm to AXI write ports.

Verified (Verilator 5.046): all 8 synth wrappers elaborate; compute-enabled `rw_axi` and `rw_axi_rw_init_rw_obi` reach `i_idma_otf_compute`; non-AXI-write variants drop the dangling `w_beat_done`.