### PR TITLE
backend: Retire compute on w_dp_req_ready, drop dead w_beat_done

### DIFF
--- a/src/backend/idma_axi_write.sv
+++ b/src/backend/idma_axi_write.sv
@@ -75,9 +75,7 @@ module idma_axi_write #(
     /// Ready to buffer
     output strb_t buffer_out_ready_o,
     /// External write-strobe mask (ANDed into wstrb); tie to '1 when unused
-    input  strb_t mask_ext_i,
-    /// Pulses when a write beat is accepted on the bus (strobe-independent)
-    output logic  w_beat_done_o
+    input  strb_t mask_ext_i
 );
     // offsets needed for masks to empty buffer
     strb_t w_first_mask;
@@ -175,8 +173,6 @@ module idma_axi_write #(
 
     // write happening: both the bus (w_ready) and the buffer (ready_to_write) is high
     assign write_happening = ready_to_write & write_rsp_i.w_ready;
-
-    assign w_beat_done_o = write_happening;
 
     // the main buffer is conditionally to the write mask popped
     assign buffer_out_ready_o = write_happening ? mask_out : '0;

--- a/src/backend/tpl/idma_transport_layer.sv.tpl
+++ b/src/backend/tpl/idma_transport_layer.sv.tpl
@@ -239,9 +239,6 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     byte_t [StrbWidth-1:0] buffer_out_shifted;
     byte_t [StrbWidth-1:0] wr_data;
     strb_t                 wr_valid, wr_strb, mask_ext_shifted, dataflow_ready_in;
-% if 'axi' in used_write_protocols:
-    logic                  w_beat_done;
-% endif
 
 % if not one_read_port:
     // Read multiplexed signals
@@ -263,12 +260,9 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     logic ${mh_format['aw'][protocol]}${protocol}_w_dp_ready;
     w_dp_rsp_t ${mh_format['aw'][protocol]}${protocol}_w_dp_rsp;
     logic ${mh_format['aw'][protocol]}${protocol}_aw_ready;
-    % if protocol == 'axi':
-    logic ${mh_format['aw'][protocol]}${protocol}_w_beat_done;
-    % endif
 
     %endfor
-    logic w_dp_req_valid, w_dp_req_ready;
+    logic w_dp_req_valid;
     logic w_dp_rsp_mux_valid, w_dp_rsp_mux_ready;
     logic w_dp_rsp_valid, w_dp_rsp_ready;
     w_dp_rsp_t w_dp_rsp_mux;
@@ -280,6 +274,10 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     idma_pkg::multihead_t w_resp_fifo_out_head;
 % endif
     logic w_resp_fifo_out_valid, w_resp_fifo_out_ready;
+% endif
+    logic w_dp_req_ready;
+% if one_write_port:
+    assign w_dp_ready_o = w_dp_req_ready;
 % endif
 
     //--------------------------------------
@@ -404,7 +402,6 @@ ${rendered_read_ports[read_port]}
         byte_t [StrbWidth-1:0] cmp_data_o;
         strb_t                 cmp_strb_o;
 
-        // Beats retire on w_beat_done (strobe-independent).
         idma_otf_compute #(
             .StrbWidth           ( StrbWidth          ),
             .ComputeEnable       ( ComputeOps         ),
@@ -421,14 +418,12 @@ ${rendered_read_ports[read_port]}
             .data_o      ( cmp_data_o          ),
             .strb_o      ( cmp_strb_o          ),
             .valid_o     ( cmp_out_valid       ),
-            .ready_i     ( w_beat_done         )
+            .ready_i     ( w_dp_req_ready      )
         );
 
-        // Whole-beat valid; edge masking is carried on wr_strb.
         assign wr_data           = cmp_active ? cmp_data_o : buffer_out;
         assign wr_valid          = cmp_active ? {StrbWidth{cmp_out_valid}} : buffer_out_valid;
         assign wr_strb           = cmp_active ? cmp_strb_o : '1;
-        // Pop the buffer only on a compute input handshake.
         assign dataflow_ready_in = cmp_active ? {StrbWidth{(&buffer_out_valid) & cmp_in_ready}}
                                               : buffer_out_ready_shifted;
     end else begin : gen_no_compute
@@ -506,22 +501,6 @@ ${rendered_read_ports[read_port]}
         endcase
     end
 
-% if compute_eligible:
-    // route the active write port's beat-done to the compute engine retire
-    always_comb begin : gen_write_beat_done_mux
-        case(w_dp_req_i.dst_protocol)
-% for wp in used_write_protocols:
-    % if wp == 'axi' and mh_format['aw'][wp] == '':
-        idma_pkg::${database[wp]['protocol_enum']}: w_beat_done = ${wp}_w_beat_done;
-    % elif wp == 'axi':
-        idma_pkg::${database[wp]['protocol_enum']}: w_beat_done = ${wp}_w_beat_done [w_dp_req_i.dst_head];
-    % endif
-% endfor
-        default: w_beat_done = 1'b0;
-        endcase
-    end
-
-% endif
 % endif
     //--------------------------------------
     // Write Ports

--- a/src/db/idma_axi.yml
+++ b/src/db/idma_axi.yml
@@ -130,8 +130,7 @@ write_template: |
         .buffer_out_i       ( buffer_out_shifted ),
         .buffer_out_valid_i ( buffer_out_valid_shifted ),
         .buffer_out_ready_o ( ${buffer_out_ready} ),
-        .mask_ext_i         ( mask_ext_shifted ),
-        .w_beat_done_o      ( ${w_beat_done} )
+        .mask_ext_i         ( mask_ext_shifted )
     );
 synth_wrapper_ports_write: |
     output id_t                    axi_aw_id_o,

--- a/util/mario/transport_layer.py
+++ b/util/mario/transport_layer.py
@@ -189,7 +189,7 @@ def render_write_mgr_inst(prot_id: str, prot_ids: dict, db: dict) -> dict:
 
             if swp:
                 write_dp_valid_in = 'w_dp_valid_i'
-                write_dp_ready_out = 'w_dp_ready_o'
+                write_dp_ready_out = 'w_dp_req_ready'
                 write_dp_response = 'w_dp_rsp_o'
                 write_dp_valid_out = 'w_dp_valid_o'
                 write_dp_ready_in = 'w_dp_ready_i'
@@ -243,7 +243,6 @@ aw_valid_i\
                 'write_request': f'{wp}_write_req_o{mh_bus}',
                 'write_response': f'{wp}_write_rsp_i{mh_bus}',
                 'buffer_out_ready': buffer_out_ready,
-                'w_beat_done': 'w_beat_done' if swp else f'{wp}_w_beat_done{mh_bus}',
                 'mh': mh
             }
 

--- a/util/mario/util.py
+++ b/util/mario/util.py
@@ -44,12 +44,10 @@ def prot_key(used_prots: list, key: str, feature: str, db: dict) -> list:
 
 def compute_eligible(used_read_prots: list, used_write_prots: list, db: dict) -> bool:
     """Return true if this backend topology has data paths that can host compute."""
-    read_compute_protocols = {'AXI', 'OBI'}
-    write_compute_protocols = {'AXI'}
+    compute_protocols = {'AXI', 'OBI'}
     read_protocols = {db[prot]['protocol_enum'] for prot in used_read_prots}
     write_protocols = {db[prot]['protocol_enum'] for prot in used_write_prots}
-    return bool(read_protocols & read_compute_protocols) \
-        and bool(write_protocols & write_compute_protocols)
+    return bool(read_protocols & compute_protocols) and bool(write_protocols & compute_protocols)
 
 
 def prepare_ids(id_strs: list) -> dict:


### PR DESCRIPTION
Follow-up on devel after #162, adopting the compute-retire approach from #160 (`23b95c0c`).

Compute now retires on `w_dp_req_ready` (whole write transaction) instead of `w_beat_done` (per-beat). A misaligned destination needs 2 write beats per transpose row, so per-beat retire drops a beat; whole-transaction retire is correct and works on every write port.

- Supersedes #162's `w_beat_done` + AXI-only eligibility restriction (compute is eligible for AXI/OBI read+write again).
- Removes the now-dead `w_beat_done` path (transport decl/mux, `idma_axi.yml .w_beat_done_o`, `idma_axi_write` output).
- Keeps #162's `synth.py` fix (synth wrappers emit the compute params).

Verified (Verilator 5.046): 8/8 synth wrappers elaborate (EnableCompute=0); compute-enabled `rw_axi`, `r_axi_w_obi`, `rw_axi_rw_init_rw_obi` all reach `i_idma_otf_compute`, 0 errors.