### PR TITLE
backend: Restore per-beat w_beat_done for compute retire

### DIFF
--- a/src/backend/idma_axi_write.sv
+++ b/src/backend/idma_axi_write.sv
@@ -75,7 +75,9 @@ module idma_axi_write #(
     /// Ready to buffer
     output strb_t buffer_out_ready_o,
     /// External write-strobe mask (ANDed into wstrb); tie to '1 when unused
-    input  strb_t mask_ext_i
+    input  strb_t mask_ext_i,
+    /// Pulses when a write beat is accepted on the bus (strobe-independent)
+    output logic  w_beat_done_o
 );
     // offsets needed for masks to empty buffer
     strb_t w_first_mask;
@@ -173,6 +175,8 @@ module idma_axi_write #(
 
     // write happening: both the bus (w_ready) and the buffer (ready_to_write) is high
     assign write_happening = ready_to_write & write_rsp_i.w_ready;
+
+    assign w_beat_done_o = write_happening;
 
     // the main buffer is conditionally to the write mask popped
     assign buffer_out_ready_o = write_happening ? mask_out : '0;

--- a/src/backend/tpl/idma_transport_layer.sv.tpl
+++ b/src/backend/tpl/idma_transport_layer.sv.tpl
@@ -239,6 +239,7 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     byte_t [StrbWidth-1:0] buffer_out_shifted;
     byte_t [StrbWidth-1:0] wr_data;
     strb_t                 wr_valid, wr_strb, mask_ext_shifted, dataflow_ready_in;
+    logic                  w_beat_done;
 
 % if not one_read_port:
     // Read multiplexed signals
@@ -260,6 +261,9 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     logic ${mh_format['aw'][protocol]}${protocol}_w_dp_ready;
     w_dp_rsp_t ${mh_format['aw'][protocol]}${protocol}_w_dp_rsp;
     logic ${mh_format['aw'][protocol]}${protocol}_aw_ready;
+    % if protocol == 'axi':
+    logic ${mh_format['aw'][protocol]}${protocol}_w_beat_done;
+    % endif
 
     %endfor
     logic w_dp_req_valid;
@@ -278,6 +282,10 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     logic w_dp_req_ready;
 % if one_write_port:
     assign w_dp_ready_o = w_dp_req_ready;
+% endif
+% if one_write_port and 'axi' not in used_write_protocols:
+    // single non-AXI write port: w_dp_ready is already per-beat
+    assign w_beat_done = w_dp_req_ready;
 % endif
 
     //--------------------------------------
@@ -418,7 +426,7 @@ ${rendered_read_ports[read_port]}
             .data_o      ( cmp_data_o          ),
             .strb_o      ( cmp_strb_o          ),
             .valid_o     ( cmp_out_valid       ),
-            .ready_i     ( w_dp_req_ready      )
+            .ready_i     ( w_beat_done         )
         );
 
         assign wr_data           = cmp_active ? cmp_data_o : buffer_out;
@@ -498,6 +506,20 @@ ${rendered_read_ports[read_port]}
     % endif
 % endfor
         default:       aw_ready_o = 1'b0;
+        endcase
+    end
+
+    // route the active write port's per-beat retire to the compute engine
+    always_comb begin : gen_write_beat_done_mux
+        case(w_dp_req_i.dst_protocol)
+% for wp in used_write_protocols:
+    % if wp == 'axi' and mh_format['aw'][wp] == '':
+        idma_pkg::${database[wp]['protocol_enum']}: w_beat_done = ${wp}_w_beat_done;
+    % elif wp == 'axi':
+        idma_pkg::${database[wp]['protocol_enum']}: w_beat_done = ${wp}_w_beat_done [w_dp_req_i.dst_head];
+    % endif
+% endfor
+        default: w_beat_done = w_dp_req_ready;
         endcase
     end
 

--- a/src/db/idma_axi.yml
+++ b/src/db/idma_axi.yml
@@ -130,7 +130,8 @@ write_template: |
         .buffer_out_i       ( buffer_out_shifted ),
         .buffer_out_valid_i ( buffer_out_valid_shifted ),
         .buffer_out_ready_o ( ${buffer_out_ready} ),
-        .mask_ext_i         ( mask_ext_shifted )
+        .mask_ext_i         ( mask_ext_shifted ),
+        .w_beat_done_o      ( ${w_beat_done} )
     );
 synth_wrapper_ports_write: |
     output id_t                    axi_aw_id_o,

--- a/util/mario/transport_layer.py
+++ b/util/mario/transport_layer.py
@@ -243,6 +243,7 @@ aw_valid_i\
                 'write_request': f'{wp}_write_req_o{mh_bus}',
                 'write_response': f'{wp}_write_rsp_i{mh_bus}',
                 'buffer_out_ready': buffer_out_ready,
+                'w_beat_done': 'w_beat_done' if swp else f'{wp}_w_beat_done{mh_bus}',
                 'mh': mh
             }
 


### PR DESCRIPTION
## Summary

The compute engine retires its output beats on the write manager's ready. Since #163 that is `w_dp_req_ready`, which for an AXI burst pulses only on the **last** beat: correct for byte-count-preserving compute (transpose issues single-beat bursts), but it replays beat 0 across every beat of a multi-beat write burst.

This partially reverts #163: `w_beat_done = write_happening` (strobe-independent, per-beat) is re-exposed from `idma_axi_write` and routed to the compute engine per active write protocol. AXI uses the per-beat pulse; other write ports keep `w_dp_ready`, which is already per-beat (e.g. OBI). The pulse becomes load-bearing for the multi-beat bursts that size-changing compute (follow-up PR) produces.

No behavior change for single-beat transpose bursts.

## Validation

- Builds standalone on `devel`; `tb_idma_transpose_b2b` green at DataWidth 32/64 (Questa 2026.1) at this commit alone.
- Generator rendered for all backend IDs plus `r_axil_w_axi`, `r_axis_w_axi`, `rw_tilelink`, and multihead variants: exactly one `w_beat_done` declaration and drive per topology.
