### PR TITLE
backend: Add MX quant/dequant on-the-fly compute (size-changing datapath)

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -34,6 +34,7 @@ sources:
     files:
       # Level 0
       - src/idma_pkg.sv
+      - src/idma_mxquant_pkg.sv
       # Level 1
       - src/backend/idma_axil_read.sv
       - src/backend/idma_axil_write.sv
@@ -44,6 +45,8 @@ sources:
       - src/backend/idma_channel_coupler.sv
       - src/backend/idma_dataflow_element.sv
       - src/backend/idma_otf_transpose.sv
+      - src/backend/idma_otf_mxquant.sv
+      - src/backend/idma_otf_mxdequant.sv
       - src/backend/idma_otf_compute.sv
       - src/backend/idma_error_handler.sv
       - src/backend/idma_init_read.sv
@@ -135,6 +138,11 @@ sources:
       - target/rtl/tb_idma_generated.sv
       - test/tb_idma_transpose_nd.sv
       - test/tb_idma_transpose_b2b.sv
+      - test/tb_idma_mxquant.sv
+      - test/tb_idma_mxroundtrip.sv
+      - test/tb_idma_mxrand.sv
+      - test/tb_idma_mxneg.sv
+      - test/tb_idma_mxperf.sv
 
   # Multi-head directed backend testbenches
   - target: multihead

--- a/idma.mk
+++ b/idma.mk
@@ -360,6 +360,7 @@ $(IDMA_VSIM_DIR)/compile_%.tcl: $(IDMA_BENDER_FILES) $(IDMA_FULL_TB) $(IDMA_FULL
 IDMA_VLOG_ARGS  := -suppress vlog-2583 \
 			  	   -suppress vlog-13314 \
 			  	   -suppress vlog-13233 \
+			  	   +define+INC_ASSERT \
 			  	   -timescale \"1 ns / 1 ps\"
 
 define idma_generate_vsim
@@ -423,6 +424,50 @@ idma_sim_tb_idma_transpose_b2b: $(IDMA_VSIM_DIR)/compile.tcl
 	# the TB sweeps the geometry list internally; one run per bus width
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_transpose_b2b -do "run -all; quit"
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_transpose_b2b -do "run -all; quit"
+
+.PHONY: idma_sim_tb_idma_mxquant
+idma_sim_tb_idma_mxquant: $(IDMA_VSIM_DIR)/compile.tcl
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
+	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_mxquant_dpi.c)
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_mxquant -do "run -all; quit"
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_mxquant -do "run -all; quit"
+
+.PHONY: idma_sim_tb_idma_mxroundtrip
+idma_sim_tb_idma_mxroundtrip: $(IDMA_VSIM_DIR)/compile.tcl
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
+	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_mxquant_dpi.c)
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_mxroundtrip -do "run -all; quit"
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_mxroundtrip -do "run -all; quit"
+
+.PHONY: idma_sim_tb_idma_mxrand
+idma_sim_tb_idma_mxrand: $(IDMA_VSIM_DIR)/compile.tcl
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
+	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_mxquant_dpi.c)
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_mxrand -do "run -all; quit"
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_mxrand -do "run -all; quit"
+
+.PHONY: idma_sim_tb_idma_mxperf
+idma_sim_tb_idma_mxperf: $(IDMA_VSIM_DIR)/compile.tcl
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_mxperf -do "run -all; quit"
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_mxperf -do "run -all; quit"
+
+# each case must print its guard assert; case 6 needs the op compiled out, case 4 a 1024-bit bus
+.PHONY: idma_sim_tb_idma_mxneg
+idma_sim_tb_idma_mxneg: $(IDMA_VSIM_DIR)/compile.tcl
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
+	cd $(IDMA_VSIM_DIR); set -e; \
+	for c in "1 ComputeSizeAligned 64 1" "2 ComputeSrcAligned 64 1" "3 ComputeDstAligned 64 1" \
+	         "4 ComputeMxquantFp16Width 1024 1" "5 ComputeMxdequantBeatAligned 64 1" \
+	         "6 ComputeOpUnsupported 64 0" "7 ComputeMxSrcProtocol 64 1" \
+	         "8 ComputeMxDstProtocol 64 1" "9 in-flight.state|config.changed.while 64 1" \
+	         "10 ComputeTransposeSingleBeat 64 1"; do \
+	  set -- $$c; \
+	  $(VSIM) -c -t 1ps -voptargs=+acc -gNegCase=$$1 -gDataWidth=$$3 -gEnDequant=$$4 \
+	    tb_idma_mxneg -do "run -all; quit" > mxneg_$$1.log 2>&1 || true; \
+	  if grep -qE "(ASSERT FAILED.*$$2|$$2)" mxneg_$$1.log; then echo "[MXNEG] case $$1 $$2 FIRED"; \
+	  else echo "[MXNEG] case $$1 $$2 DID NOT FIRE (see mxneg_$$1.log)"; exit 1; fi; \
+	done
 
 .PHONY: idma_sim_tb_idma_transpose_midend
 idma_sim_tb_idma_transpose_midend: $(IDMA_VSIM_DIR)/compile.tcl

--- a/idma.mk
+++ b/idma.mk
@@ -460,8 +460,8 @@ idma_sim_tb_idma_mxneg: $(IDMA_VSIM_DIR)/compile.tcl
 	for c in "1 ComputeSizeAligned 64 1" "2 ComputeSrcAligned 64 1" "3 ComputeDstAligned 64 1" \
 	         "4 ComputeMxquantFp16Width 1024 1" "5 ComputeMxdequantBeatAligned 64 1" \
 	         "6 ComputeOpUnsupported 64 0" "7 ComputeMxSrcProtocol 64 1" \
-	         "8 ComputeMxDstProtocol 64 1" "9 in-flight.state|config.changed.while 64 1" \
-	         "10 ComputeTransposeSingleBeat 64 1"; do \
+	         "8 ComputeMxDstProtocol 64 1" "10 ComputeTransposeSingleBeat 64 1" \
+	         "11 ComputeMxdequantLengthFits 64 1"; do \
 	  set -- $$c; \
 	  $(VSIM) -c -t 1ps -voptargs=+acc -gNegCase=$$1 -gDataWidth=$$3 -gEnDequant=$$4 \
 	    tb_idma_mxneg -do "run -all; quit" > mxneg_$$1.log 2>&1 || true; \

--- a/src/backend/idma_axi_write.sv
+++ b/src/backend/idma_axi_write.sv
@@ -174,6 +174,7 @@ module idma_axi_write #(
     // write happening: both the bus (w_ready) and the buffer (ready_to_write) is high
     assign write_happening = ready_to_write & write_rsp_i.w_ready;
 
+
     // the main buffer is conditionally to the write mask popped
     assign buffer_out_ready_o = write_happening ? mask_out : '0;
 

--- a/src/backend/idma_otf_compute.sv
+++ b/src/backend/idma_otf_compute.sv
@@ -6,7 +6,9 @@
 // - Daniel Keller <dankeller@iis.ee.ethz.ch>
 
 /// On-the-fly compute dispatcher: latches the per-transfer compute options
-/// and dispatches one op per transfer to its sub-unit.
+/// and dispatches one op per transfer to its sub-unit. Back-to-back transfers
+/// with an identical config may pipeline (lane-exact retire keeps the pack
+/// sound across tails); any config change requires the engine to be drained.
 module idma_otf_compute #(
   /// Byte lanes per beat (= DataWidth/8)
   parameter int unsigned StrbWidth       = 32'd8,
@@ -29,11 +31,13 @@ module idma_otf_compute #(
   input  logic                      valid_i,
   output logic                      in_ready_o,
 
-  /// Output beat stream (computed) with per-byte strobe for edge masking
+  /// Output beat stream: per-lane valid (occupancy) + per-byte strobe (edge mask)
   output logic [StrbWidth-1:0][7:0] data_o,
   output logic [StrbWidth-1:0]      strb_o,
-  output logic                      valid_o,
-  input  logic                      ready_i
+  output logic [StrbWidth-1:0]      lane_valid_o,
+  input  logic                      ready_i,
+  /// Byte lanes the write accepted this cycle (lane-exact retire for the MX units)
+  input  logic [StrbWidth-1:0]      lane_ready_i
 );
 
   // config latch with first-beat bypass
@@ -45,11 +49,17 @@ module idma_otf_compute #(
   assign eff_compute = cfg_valid_i ? compute_i : latched_q;
 
   // per-op select
-  logic sel_transpose;
+  logic sel_transpose, sel_mxquant, sel_mxdequant, mx_fp16;
   assign sel_transpose = eff_compute.enable &
                          (eff_compute.op == idma_pkg::COMPUTE_TRANSPOSE) & ComputeEnable.transpose;
+  assign sel_mxquant   = eff_compute.enable & ComputeEnable.mxquant &
+                         ((eff_compute.op == idma_pkg::COMPUTE_MXQUANT) |
+                          (eff_compute.op == idma_pkg::COMPUTE_MXQUANT_FP16));
+  assign mx_fp16       = (eff_compute.op == idma_pkg::COMPUTE_MXQUANT_FP16);
+  assign sel_mxdequant = eff_compute.enable &
+                         (eff_compute.op == idma_pkg::COMPUTE_MXDEQUANT) & ComputeEnable.mxdequant;
 
-  assign active_o = sel_transpose;
+  assign active_o = sel_transpose | sel_mxquant | sel_mxdequant;
 
   // transpose sub-unit
   logic [StrbWidth-1:0][7:0] tp_data;
@@ -80,21 +90,91 @@ module idma_otf_compute #(
     assign tp_data = '0; assign tp_strb = '0; assign tp_valid = 1'b0; assign tp_in_ready = 1'b0;
   end
 
+  // MX-quant sub-unit
+  logic [StrbWidth-1:0][7:0] mx_data;
+  logic [StrbWidth-1:0]      mx_lane_valid;
+  logic                      mx_in_ready, mx_busy;
+
+  if (ComputeEnable.mxquant) begin : gen_mxquant
+    idma_otf_mxquant #(
+      .StrbWidth ( StrbWidth )
+    ) i_idma_otf_mxquant (
+      .clk_i,
+      .rst_ni,
+      .clear_i      ( ~sel_mxquant          ),
+      .src_fp16_i   ( mx_fp16               ),
+      .data_i       ( data_i                ),
+      .valid_i      ( valid_i & sel_mxquant ),
+      .ready_o      ( mx_in_ready           ),
+      .data_o       ( mx_data               ),
+      .lane_valid_o ( mx_lane_valid         ),
+      .lane_ready_i ( lane_ready_i & {StrbWidth{sel_mxquant}} ),
+      .busy_o       ( mx_busy               )
+    );
+  end else begin : gen_no_mxquant
+    assign mx_data = '0; assign mx_lane_valid = '0; assign mx_in_ready = 1'b0;
+    assign mx_busy = 1'b0;
+  end
+
+  // MX-dequant sub-unit
+  logic [StrbWidth-1:0][7:0] dq_data;
+  logic [StrbWidth-1:0]      dq_lane_valid;
+  logic                      dq_in_ready, dq_busy;
+
+  if (ComputeEnable.mxdequant) begin : gen_mxdequant
+    idma_otf_mxdequant #(
+      .StrbWidth ( StrbWidth )
+    ) i_idma_otf_mxdequant (
+      .clk_i,
+      .rst_ni,
+      .clear_i      ( ~sel_mxdequant          ),
+      .data_i       ( data_i                  ),
+      .valid_i      ( valid_i & sel_mxdequant ),
+      .ready_o      ( dq_in_ready             ),
+      .data_o       ( dq_data                 ),
+      .lane_valid_o ( dq_lane_valid           ),
+      .lane_ready_i ( lane_ready_i & {StrbWidth{sel_mxdequant}} ),
+      .busy_o       ( dq_busy                 )
+    );
+  end else begin : gen_no_mxdequant
+    assign dq_data = '0; assign dq_lane_valid = '0; assign dq_in_ready = 1'b0;
+    assign dq_busy = 1'b0;
+  end
+
   // output dispatch
   always_comb begin
-    data_o     = '0;
-    strb_o     = '0;
-    valid_o    = 1'b0;
-    in_ready_o = 1'b0;
+    data_o       = '0;
+    strb_o       = '0;
+    lane_valid_o = '0;
+    in_ready_o   = 1'b0;
     unique case (1'b1)
       sel_transpose: begin
-        data_o     = tp_data;
-        strb_o     = tp_strb;
-        valid_o    = tp_valid;
-        in_ready_o = tp_in_ready;
+        data_o       = tp_data;
+        strb_o       = tp_strb;
+        lane_valid_o = {StrbWidth{tp_valid}};
+        in_ready_o   = tp_in_ready;
+      end
+      sel_mxquant: begin
+        data_o       = mx_data;
+        strb_o       = '1;
+        lane_valid_o = mx_lane_valid;
+        in_ready_o   = mx_in_ready;
+      end
+      sel_mxdequant: begin
+        data_o       = dq_data;
+        strb_o       = '1;
+        lane_valid_o = dq_lane_valid;
+        in_ready_o   = dq_in_ready;
       end
       default: ;
     endcase
   end
+
+  // pragma translate_off
+  // NOT IMPLEMENTED: config change while an MX unit holds state (pipelining needs identical cfg)
+  always @(posedge clk_i) if (rst_ni && cfg_valid_i && (compute_i != latched_q))
+    assert (!(mx_busy || dq_busy))
+      else $fatal(1, "idma_otf_compute: compute config changed while an MX unit is busy");
+  // pragma translate_on
 
 endmodule : idma_otf_compute

--- a/src/backend/idma_otf_compute.sv
+++ b/src/backend/idma_otf_compute.sv
@@ -171,7 +171,7 @@ module idma_otf_compute #(
   end
 
   // pragma translate_off
-  // NOT IMPLEMENTED: config change while an MX unit holds state (pipelining needs identical cfg)
+  // backstop: the backend request interlock must never let a differing config in while busy
   always @(posedge clk_i) if (rst_ni && cfg_valid_i && (compute_i != latched_q))
     assert (!(mx_busy || dq_busy))
       else $fatal(1, "idma_otf_compute: compute config changed while an MX unit is busy");

--- a/src/backend/idma_otf_mxdequant.sv
+++ b/src/backend/idma_otf_mxdequant.sv
@@ -6,10 +6,11 @@
 // - Daniel Keller <dankeller@iis.ee.ethz.ch>
 
 // On-the-fly MX dequantization sub-unit: collects 33B MX blocks
-// ([1B E8M0 scale][32B E5M2]) from the input beats and expands each to 32 FP32
-// (128B) in the pack buffer. Input length must be beat-aligned (33k % StrbWidth
-// == 0, i.e. k blocks with k % StrbWidth == 0); output (128k) is then always
-// whole beats, so only full beats are ever presented.
+// ([1B E8M0 scale][32B E5M2]) from the input beats and expands one block per
+// cycle (drain-bound: 33B in -> 128B out, so throughput-neutral) into a 256B
+// circular pack buffer. Input length must be beat-aligned (33k % StrbWidth
+// == 0); output (128k) is then always whole beats, so only full beats are
+// ever presented.
 module idma_otf_mxdequant
   import idma_mxquant_pkg::*;
 #(
@@ -30,122 +31,198 @@ module idma_otf_mxdequant
   output logic                      busy_o
 );
 
-  initial assert (StrbWidth >= 4 && (StrbWidth & (StrbWidth-1)) == 0) else
-      $fatal(1, "idma_otf_mxdequant: StrbWidth (%0d) must be a power of two >= 4", StrbWidth);
+  initial assert (StrbWidth >= 4 && StrbWidth <= 128 && (StrbWidth & (StrbWidth-1)) == 0) else
+      $fatal(1, "idma_otf_mxdequant: StrbWidth (%0d) must be a power of two in [4,128]", StrbWidth);
 
-  // one expanded-block window of headroom lets the collector refill while the pack drains
-  localparam int unsigned MaxBlkPerBeat = (StrbWidth + 32) / 33;
-  localparam int unsigned BufSize       = 128 * MaxBlkPerBeat + 128;
-  localparam int unsigned OffsetWidth   = $clog2(BufSize) + 1;
-  localparam int unsigned BlkW          = $clog2(MxCompressedBlockBytes) + 1;
+  localparam int unsigned NB      = MxCompressedBlockBytes;  // 33
+  localparam int unsigned XB      = 4 * MxBlockSize;         // 128 expanded bytes per block
+  localparam int unsigned XBW     = $clog2(XB);
+  localparam int unsigned BufSize = 2 * XB;                  // pow2 -> free circular wrap
+  localparam int unsigned PtrW    = $clog2(BufSize);
+  localparam int unsigned OccW    = PtrW + 1;
+  localparam int unsigned IcW     = $clog2(StrbWidth) + 1;
+  localparam int unsigned IW      = StrbWidth * 8;
+  localparam int unsigned TFW     = NB * 8;
+  localparam int unsigned PW      = (IW > TFW) ? IW : TFW;
 
-  logic [7:0]      blk_q [MxCompressedBlockBytes];
-  logic [BlkW-1:0] blk_fill_q;
-  logic [7:0]      blk_d [MxCompressedBlockBytes];
-  logic [BlkW-1:0] blk_fill_d;
+  // input staging beat + 33B block collector
+  logic [StrbWidth-1:0][7:0] in_q;
+  logic [IcW-1:0]            in_cnt_q, in_cnt_d;
+  logic [NB-1:0][7:0]        blk_q, blk_d;
+  logic [5:0]                fill_q, fill_d;
 
-  logic [            7:0] pack_q [BufSize];
-  logic [OffsetWidth-1:0] pack_off_q;
-  logic [            7:0] pack_d [BufSize];
-  logic [OffsetWidth-1:0] pack_off_d;
-  logic [StrbWidth-1:0][7:0] data_o_d;
-  logic [StrbWidth-1:0]      lane_valid_d;
+  // circular pack buffer: rd pointer + occupancy instead of a shift-down array
+  logic [BufSize-1:0][7:0] pack_q;
+  logic [PtrW-1:0]         rd_q;
+  logic [OccW-1:0]         occ_q, occ_d;
 
-  int unsigned pop_cnt;
+  logic [IcW-1:0] pop_cnt;
   always_comb begin
-    pop_cnt = 0;
+    pop_cnt = '0;
     for (int i = 0; i < StrbWidth; i++)
-      if (lane_ready_i[i] && lane_valid_o[i]) pop_cnt++;
+      if (lane_ready_i[i] && lane_valid_o[i]) pop_cnt += IcW'(1);
   end
 
-  assign busy_o = (blk_fill_q != '0) || (pack_off_q != '0);
+  logic [PtrW-1:0] rd_a;
+  logic [OccW-1:0] occ_a;
+  assign rd_a  = rd_q + PtrW'(pop_cnt);
+  assign occ_a = occ_q - OccW'(pop_cnt);
 
-  logic        can_accept;
-  logic        blk_completing;
-  logic [31:0] fp32;
-  int          dec_scale;
+  logic [7:0] total, rem;
+  logic [5:0] need;
+  logic       can_insert, do_expand, absorb, out_vld;
+  assign total      = 8'(fill_q) + 8'(in_cnt_q);
+  assign need       = 6'(NB) - fill_q;
+  assign rem        = total - 8'(NB);
+  assign can_insert = occ_a <= OccW'(XB);
+  assign do_expand  = (total >= 8'(NB)) && can_insert;
+  assign absorb     = (total < 8'(NB)) && (in_cnt_q != '0);
+  assign out_vld    = occ_q >= OccW'(StrbWidth);
 
-  assign blk_completing = (32'(blk_fill_q) + StrbWidth) >= MxCompressedBlockBytes;
+  assign ready_o      = (total < 8'(NB)) || (can_insert && (total < 8'(2 * NB)));
+  assign lane_valid_o = {StrbWidth{out_vld}};
+  assign busy_o       = (fill_q != '0) || (occ_q != '0) || (in_cnt_q != '0);
+
+  // staging tail at the consumed pointer, shifted up behind the collected bytes
+  logic [IcW-1:0] cons;
+  logic [PW-1:0]  in_pad;
+  logic [TFW-1:0] tail_flat, tail_shift, refill_flat;
+  assign cons        = IcW'(StrbWidth) - in_cnt_q;
+  assign in_pad      = PW'(in_q);
+  assign tail_flat   = TFW'(in_pad >> {cons, 3'b000});
+  assign tail_shift  = TFW'(tail_flat << {fill_q, 3'b000});
+  assign refill_flat = TFW'(in_pad >> {8'(cons) + 8'(need), 3'b000});
+
+  logic [NB-1:0][7:0] merged;
+  always_comb
+    for (int j = 0; j < NB; j++)
+      merged[j] = (j < 32'(fill_q)) ? blk_q[j] : tail_shift[8*j +: 8];
 
   always_comb begin
-    for (int i = 0; i < MxCompressedBlockBytes; i++) blk_d[i] = blk_q[i];
-    blk_fill_d = blk_fill_q;
-    for (int i = 0; i < BufSize; i++) pack_d[i] = pack_q[i];
-    pack_off_d = pack_off_q;
-    fp32       = '0;
-    dec_scale  = 0;
-
-    if (pop_cnt > 0) begin
-      for (int i = 0; i < BufSize; i++)
-        pack_d[i] = ((i + pop_cnt) < BufSize) ? pack_q[i+pop_cnt] : 8'd0;
-      pack_off_d = (pack_off_d > OffsetWidth'(pop_cnt)) ? OffsetWidth'(pack_off_d - pop_cnt) : '0;
-    end
-
-    // pack space is only needed on a block-completing beat
-    can_accept = (pack_off_d + OffsetWidth'(128 * MaxBlkPerBeat)) <= OffsetWidth'(BufSize)
-                 || !blk_completing;
-    if (valid_i && can_accept) begin
-      for (int b = 0; b < StrbWidth; b++) begin
-        blk_d[blk_fill_d[BlkW-2:0]] = data_i[b];
-        if (blk_fill_d == BlkW'(MxCompressedBlockBytes - 1)) begin
-          dec_scale = decode_signed_scale(blk_d[0]);
-          for (int e = 0; e < MxBlockSize; e++) begin
-            fp32 = mxfp8_byte_to_fp32_prescaled(blk_d[e+1], dec_scale);
-            pack_d[pack_off_d[OffsetWidth-2:0]]     = fp32[7:0];
-            pack_d[pack_off_d[OffsetWidth-2:0] + 1] = fp32[15:8];
-            pack_d[pack_off_d[OffsetWidth-2:0] + 2] = fp32[23:16];
-            pack_d[pack_off_d[OffsetWidth-2:0] + 3] = fp32[31:24];
-            pack_off_d = OffsetWidth'(pack_off_d + 4);
-          end
-          blk_fill_d = '0;
-        end else begin
-          blk_fill_d = blk_fill_d + BlkW'(1);
-        end
+    fill_d   = fill_q;
+    in_cnt_d = in_cnt_q;
+    blk_d    = blk_q;
+    if (do_expand) begin
+      blk_d = refill_flat;
+      if (rem < 8'(NB)) begin
+        fill_d   = rem[5:0];
+        in_cnt_d = '0;
+      end else begin
+        fill_d   = '0;
+        in_cnt_d = in_cnt_q - IcW'(need);
       end
+    end else if (absorb) begin
+      blk_d    = merged;
+      fill_d   = total[5:0];
+      in_cnt_d = '0;
     end
-
-    data_o_d     = '0;
-    lane_valid_d = '0;
-    if (pack_off_d >= OffsetWidth'(StrbWidth)) begin
-      for (int i = 0; i < StrbWidth; i++) data_o_d[i] = pack_d[i];
-      lane_valid_d = '1;
-    end
-
-    ready_o = can_accept;
+    if (valid_i && ready_o) in_cnt_d = IcW'(StrbWidth);
   end
+
+  // bit-exact local reimplementation of decode_signed_scale +
+  // mxfp8_byte_to_fp32_prescaled with proven 10-bit exponent range [-17,269]
+  function automatic logic [31:0] mx_dq(input logic [7:0] b, input logic signed [7:0] sc);
+    logic              sign;
+    logic [4:0]        e5;
+    logic [1:0]        m;
+    logic [7:0]        base;
+    logic signed [9:0] es;
+    logic [22:0]       om;
+    sign = b[7];
+    e5   = b[6:2];
+    m    = b[1:0];
+    base = (e5 == '0) ? (8'd111 + 8'(m[1])) : (8'd112 + 8'(e5));
+    es   = signed'({2'b00, base}) + signed'({{2{sc[7]}}, sc});
+    om   = (e5 == '0) ? {m[1] & m[0], 22'd0} : {m, 21'd0};
+    if (e5 == '0 && m == '0)  return {sign, 31'd0};
+    else if (e5 == 5'h1F)     return (m == '0) ? {sign, 8'hFF, 23'd0} : 32'h7FC00000;
+    else if (es <= 10'sd0)    return {sign, 31'd0};
+    else if (es >= 10'sd255)  return {sign, 8'hFE, 23'h7FFFFF};
+    else                      return {sign, es[7:0], om};
+  endfunction
+
+  logic signed [7:0]  dec_sc;
+  logic [XB-1:0][7:0] exp_bytes;
+  assign dec_sc = signed'(merged[0]);
+  for (genvar e = 0; e < MxBlockSize; e++) begin : gen_exp
+    logic [31:0] w;
+    assign w = mx_dq(merged[e+1], dec_sc);
+    assign exp_bytes[4*e+3 : 4*e] = w;
+  end
+
+  // write: rotate the 128B block by wr_off, page-decoded byte enables
+  logic [PtrW-1:0]    wr_ptr;
+  logic [XBW-1:0]     wr_off;
+  logic               wr_pg;
+  logic [XB-1:0][7:0] wrot [XBW+1];
+  logic [XB-1:0]      lt_off;
+  logic [BufSize-1:0] wren;
+  assign wr_ptr    = rd_q + occ_q[PtrW-1:0];
+  assign wr_off    = wr_ptr[XBW-1:0];
+  assign wr_pg     = wr_ptr[PtrW-1];
+  assign wrot[XBW] = exp_bytes;
+  for (genvar b = 0; b < XBW; b++) begin : gen_wrot
+    for (genvar i = 0; i < XB; i++) begin : gen_wrot_byte
+      assign wrot[b][i] = wr_off[b] ? wrot[b+1][(i + XB - (1 << b)) % XB] : wrot[b+1][i];
+    end
+  end
+  for (genvar i = 0; i < XB; i++) begin : gen_lt
+    assign lt_off[i] = (XBW'(i) < wr_off);
+  end
+  for (genvar s = 0; s < BufSize; s++) begin : gen_wren
+    assign wren[s] = do_expand & (((s >= XB) == wr_pg) ^ lt_off[s % XB]);
+  end
+
+  // read: log-stage rotator at rd_q; DC prunes it to the StrbWidth funnel
+  logic [BufSize-1:0][7:0] rrot [PtrW+1];
+  assign rrot[PtrW] = pack_q;
+  for (genvar b = 0; b < PtrW; b++) begin : gen_rrot
+    for (genvar i = 0; i < BufSize; i++) begin : gen_rrot_byte
+      assign rrot[b][i] = rd_q[b] ? rrot[b+1][(i + (1 << b)) % BufSize] : rrot[b+1][i];
+    end
+  end
+  assign data_o = out_vld ? rrot[0][StrbWidth-1:0] : '0;
+
+  assign occ_d = occ_a + (do_expand ? OccW'(XB) : '0);
 
   // pragma translate_off
   always @(posedge clk_i) if (rst_ni)
-    assert (pack_off_d <= OffsetWidth'(BufSize))
+    assert (occ_d <= OccW'(BufSize))
       else $fatal(1, "idma_otf_mxdequant: pack-buffer overflow (StrbWidth=%0d)", StrbWidth);
   // pragma translate_on
 
   // pragma translate_off
   always @(posedge clk_i) if (rst_ni)
-    assert (32'(pop_cnt) <= 32'(pack_off_q))
+    assert (32'(pop_cnt) <= 32'(occ_q))
       else $fatal(1, "idma_otf_mxdequant: pop exceeds pack occupancy");
   // NOT IMPLEMENTED: overlapping compute transfers (a clear must never drop in-flight state)
   always @(posedge clk_i) if (rst_ni && clear_i)
-    assert ((blk_fill_q == '0) && (pack_off_q == '0))
+    assert ((fill_q == '0) && (occ_q == '0) && (in_cnt_q == '0))
       else $fatal(1, "idma_otf_mxdequant: clear with in-flight state (overlapping transfers)");
   // pragma translate_on
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      blk_fill_q <= '0; pack_off_q <= '0;
-      for (int i = 0; i < MxCompressedBlockBytes; i++) blk_q[i] <= 8'd0;
-      for (int i = 0; i < BufSize; i++)                pack_q[i] <= 8'd0;
-      data_o <= '0; lane_valid_o <= '0;
+      rd_q <= '0; occ_q <= '0; fill_q <= '0; in_cnt_q <= '0;
+      blk_q <= '0; in_q <= '0;
     end else if (clear_i) begin
-      blk_fill_q <= '0; pack_off_q <= '0;
-      data_o <= '0; lane_valid_o <= '0;
+      rd_q <= '0; occ_q <= '0; fill_q <= '0; in_cnt_q <= '0;
     end else begin
-      for (int i = 0; i < MxCompressedBlockBytes; i++) blk_q[i] <= blk_d[i];
-      blk_fill_q <= blk_fill_d;
-      for (int i = 0; i < BufSize; i++)                pack_q[i] <= pack_d[i];
-      pack_off_q <= pack_off_d;
-      data_o       <= data_o_d;
-      lane_valid_o <= lane_valid_d;
+      rd_q     <= rd_a;
+      occ_q    <= occ_d;
+      fill_q   <= fill_d;
+      in_cnt_q <= in_cnt_d;
+      if (do_expand || absorb) blk_q <= blk_d;
+      if (valid_i && ready_o)  in_q  <= data_i;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      pack_q <= '0;
+    end else if (!clear_i) begin
+      for (int s = 0; s < BufSize; s++)
+        if (wren[s]) pack_q[s] <= wrot[0][s & (XB - 1)];
     end
   end
 

--- a/src/backend/idma_otf_mxdequant.sv
+++ b/src/backend/idma_otf_mxdequant.sv
@@ -1,0 +1,152 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// On-the-fly MX dequantization sub-unit: collects 33B MX blocks
+// ([1B E8M0 scale][32B E5M2]) from the input beats and expands each to 32 FP32
+// (128B) in the pack buffer. Input length must be beat-aligned (33k % StrbWidth
+// == 0, i.e. k blocks with k % StrbWidth == 0); output (128k) is then always
+// whole beats, so only full beats are ever presented.
+module idma_otf_mxdequant
+  import idma_mxquant_pkg::*;
+#(
+  parameter int unsigned StrbWidth = 32'd8
+) (
+  input  logic clk_i,
+  input  logic rst_ni,
+  input  logic clear_i,
+
+  input  logic [StrbWidth-1:0][7:0] data_i,
+  input  logic                      valid_i,
+  output logic                      ready_o,
+
+  output logic [StrbWidth-1:0][7:0] data_o,
+  output logic [StrbWidth-1:0]      lane_valid_o,
+  /// Byte lanes the write accepted this cycle; the pack pops exactly these
+  input  logic [StrbWidth-1:0]      lane_ready_i,
+  output logic                      busy_o
+);
+
+  initial assert (StrbWidth >= 4 && (StrbWidth & (StrbWidth-1)) == 0) else
+      $fatal(1, "idma_otf_mxdequant: StrbWidth (%0d) must be a power of two >= 4", StrbWidth);
+
+  // one expanded-block window of headroom lets the collector refill while the pack drains
+  localparam int unsigned MaxBlkPerBeat = (StrbWidth + 32) / 33;
+  localparam int unsigned BufSize       = 128 * MaxBlkPerBeat + 128;
+  localparam int unsigned OffsetWidth   = $clog2(BufSize) + 1;
+  localparam int unsigned BlkW          = $clog2(MxCompressedBlockBytes) + 1;
+
+  logic [7:0]      blk_q [MxCompressedBlockBytes];
+  logic [BlkW-1:0] blk_fill_q;
+  logic [7:0]      blk_d [MxCompressedBlockBytes];
+  logic [BlkW-1:0] blk_fill_d;
+
+  logic [            7:0] pack_q [BufSize];
+  logic [OffsetWidth-1:0] pack_off_q;
+  logic [            7:0] pack_d [BufSize];
+  logic [OffsetWidth-1:0] pack_off_d;
+  logic [StrbWidth-1:0][7:0] data_o_d;
+  logic [StrbWidth-1:0]      lane_valid_d;
+
+  int unsigned pop_cnt;
+  always_comb begin
+    pop_cnt = 0;
+    for (int i = 0; i < StrbWidth; i++)
+      if (lane_ready_i[i] && lane_valid_o[i]) pop_cnt++;
+  end
+
+  assign busy_o = (blk_fill_q != '0) || (pack_off_q != '0);
+
+  logic        can_accept;
+  logic        blk_completing;
+  logic [31:0] fp32;
+  int          dec_scale;
+
+  assign blk_completing = (32'(blk_fill_q) + StrbWidth) >= MxCompressedBlockBytes;
+
+  always_comb begin
+    for (int i = 0; i < MxCompressedBlockBytes; i++) blk_d[i] = blk_q[i];
+    blk_fill_d = blk_fill_q;
+    for (int i = 0; i < BufSize; i++) pack_d[i] = pack_q[i];
+    pack_off_d = pack_off_q;
+    fp32       = '0;
+    dec_scale  = 0;
+
+    if (pop_cnt > 0) begin
+      for (int i = 0; i < BufSize; i++)
+        pack_d[i] = ((i + pop_cnt) < BufSize) ? pack_q[i+pop_cnt] : 8'd0;
+      pack_off_d = (pack_off_d > OffsetWidth'(pop_cnt)) ? OffsetWidth'(pack_off_d - pop_cnt) : '0;
+    end
+
+    // pack space is only needed on a block-completing beat
+    can_accept = (pack_off_d + OffsetWidth'(128 * MaxBlkPerBeat)) <= OffsetWidth'(BufSize)
+                 || !blk_completing;
+    if (valid_i && can_accept) begin
+      for (int b = 0; b < StrbWidth; b++) begin
+        blk_d[blk_fill_d[BlkW-2:0]] = data_i[b];
+        if (blk_fill_d == BlkW'(MxCompressedBlockBytes - 1)) begin
+          dec_scale = decode_signed_scale(blk_d[0]);
+          for (int e = 0; e < MxBlockSize; e++) begin
+            fp32 = mxfp8_byte_to_fp32_prescaled(blk_d[e+1], dec_scale);
+            pack_d[pack_off_d[OffsetWidth-2:0]]     = fp32[7:0];
+            pack_d[pack_off_d[OffsetWidth-2:0] + 1] = fp32[15:8];
+            pack_d[pack_off_d[OffsetWidth-2:0] + 2] = fp32[23:16];
+            pack_d[pack_off_d[OffsetWidth-2:0] + 3] = fp32[31:24];
+            pack_off_d = OffsetWidth'(pack_off_d + 4);
+          end
+          blk_fill_d = '0;
+        end else begin
+          blk_fill_d = blk_fill_d + BlkW'(1);
+        end
+      end
+    end
+
+    data_o_d     = '0;
+    lane_valid_d = '0;
+    if (pack_off_d >= OffsetWidth'(StrbWidth)) begin
+      for (int i = 0; i < StrbWidth; i++) data_o_d[i] = pack_d[i];
+      lane_valid_d = '1;
+    end
+
+    ready_o = can_accept;
+  end
+
+  // pragma translate_off
+  always @(posedge clk_i) if (rst_ni)
+    assert (pack_off_d <= OffsetWidth'(BufSize))
+      else $fatal(1, "idma_otf_mxdequant: pack-buffer overflow (StrbWidth=%0d)", StrbWidth);
+  // pragma translate_on
+
+  // pragma translate_off
+  always @(posedge clk_i) if (rst_ni)
+    assert (32'(pop_cnt) <= 32'(pack_off_q))
+      else $fatal(1, "idma_otf_mxdequant: pop exceeds pack occupancy");
+  // NOT IMPLEMENTED: overlapping compute transfers (a clear must never drop in-flight state)
+  always @(posedge clk_i) if (rst_ni && clear_i)
+    assert ((blk_fill_q == '0) && (pack_off_q == '0))
+      else $fatal(1, "idma_otf_mxdequant: clear with in-flight state (overlapping transfers)");
+  // pragma translate_on
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      blk_fill_q <= '0; pack_off_q <= '0;
+      for (int i = 0; i < MxCompressedBlockBytes; i++) blk_q[i] <= 8'd0;
+      for (int i = 0; i < BufSize; i++)                pack_q[i] <= 8'd0;
+      data_o <= '0; lane_valid_o <= '0;
+    end else if (clear_i) begin
+      blk_fill_q <= '0; pack_off_q <= '0;
+      data_o <= '0; lane_valid_o <= '0;
+    end else begin
+      for (int i = 0; i < MxCompressedBlockBytes; i++) blk_q[i] <= blk_d[i];
+      blk_fill_q <= blk_fill_d;
+      for (int i = 0; i < BufSize; i++)                pack_q[i] <= pack_d[i];
+      pack_off_q <= pack_off_d;
+      data_o       <= data_o_d;
+      lane_valid_o <= lane_valid_d;
+    end
+  end
+
+endmodule : idma_otf_mxdequant

--- a/src/backend/idma_otf_mxquant.sv
+++ b/src/backend/idma_otf_mxquant.sv
@@ -1,0 +1,177 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// On-the-fly MX quantization sub-unit for the iDMA compute seam. Collects a
+// 32-element block over the input beats (FP32 4B/elem, FP16 2B/elem widened to
+// FP32), quantizes to one 33B MX block ([1B E8M0 scale][32B E5M2]) and packs it
+// into StrbWidth-wide output beats. lane_valid_o reports pack occupancy per
+// lane; the write manager's own beat mask decides acceptance, so a partial
+// presentation can only ever complete the transfer's genuine tail beat.
+// Adapted from pulp-platform/vidma hw/vidma/idma_otf_mxquant.sv. FP16 requires
+// StrbWidth <= 64 (<=1 block completes per beat).
+module idma_otf_mxquant
+  import idma_mxquant_pkg::*;
+#(
+  parameter int unsigned StrbWidth = 32'd8
+) (
+  input  logic clk_i,
+  input  logic rst_ni,
+  input  logic clear_i,
+  input  logic src_fp16_i,
+
+  input  logic [StrbWidth-1:0][7:0] data_i,
+  input  logic                      valid_i,
+  output logic                      ready_o,
+
+  output logic [StrbWidth-1:0][7:0] data_o,
+  output logic [StrbWidth-1:0]      lane_valid_o,
+  /// Byte lanes the write accepted this cycle; the pack pops exactly these
+  input  logic [StrbWidth-1:0]      lane_ready_i,
+  output logic                      busy_o
+);
+
+  // FP32 packs one block per beat up to StrbWidth 128; FP16 above 64 is rejected by the legalizer
+  initial assert (StrbWidth >= 4 && StrbWidth <= 128 && (StrbWidth & (StrbWidth-1)) == 0) else
+      $fatal(1, "idma_otf_mxquant: StrbWidth (%0d) must be a power of two in [4, 128]", StrbWidth);
+
+  localparam int unsigned BufSize     = MxCompressedBlockBytes + StrbWidth;
+  localparam int unsigned OffsetWidth = $clog2(BufSize) + 1;
+  localparam int unsigned ElemsFP32   = StrbWidth / 4;
+  localparam int unsigned ElemsFP16   = StrbWidth / 2;
+  localparam int unsigned FillW       = $clog2(MxBlockSize) + 1;
+
+  logic [31:0]      elem_q [MxBlockSize];
+  logic [FillW-1:0] fill_q;
+  logic [31:0]      elem_d [MxBlockSize];
+  logic [FillW-1:0] fill_d;
+
+  logic [            7:0] pack_q [BufSize];
+  logic [OffsetWidth-1:0] pack_off_q;
+  logic [            7:0] pack_d [BufSize];
+  logic [OffsetWidth-1:0] pack_off_d;
+  logic [StrbWidth-1:0][7:0] data_o_d;
+  logic [StrbWidth-1:0]      lane_valid_d;
+
+  // lane-exact pop: a tail beat pops only its own bytes, keeping any follow-on
+  // transfer's data intact (same-config back-to-back streaming)
+  int unsigned pop_cnt;
+  always_comb begin
+    pop_cnt = 0;
+    for (int i = 0; i < StrbWidth; i++)
+      if (lane_ready_i[i] && lane_valid_o[i]) pop_cnt++;
+  end
+
+  assign busy_o = (fill_q != '0) || (pack_off_q != '0);
+
+  // widen this beat's elements to FP32; mark valid iff all source bytes valid
+  logic [31:0]          in_elem [ElemsFP16];
+  logic [ElemsFP16-1:0] elem_valid;
+  always_comb begin
+    for (int e = 0; e < ElemsFP16; e++) begin
+      if (src_fp16_i) begin
+        in_elem[e]    = fp16_bits_to_fp32({data_i[e*2+1], data_i[e*2]});
+        elem_valid[e] = valid_i;
+      end else if (e < ElemsFP32) begin
+        in_elem[e]    = {data_i[e*4+3], data_i[e*4+2], data_i[e*4+1], data_i[e*4]};
+        elem_valid[e] = valid_i;
+      end else begin
+        in_elem[e]    = 32'd0;
+        elem_valid[e] = 1'b0;
+      end
+    end
+  end
+
+  logic       can_accept;
+  logic       blk_completing;
+  logic [7:0] blk_scale;
+
+  assign blk_completing =
+      (32'(fill_q) + (src_fp16_i ? ElemsFP16 : ElemsFP32)) >= MxBlockSize;
+
+  always_comb begin
+    for (int i = 0; i < MxBlockSize; i++) elem_d[i] = elem_q[i];
+    fill_d = fill_q;
+    for (int i = 0; i < BufSize; i++) pack_d[i] = pack_q[i];
+    pack_off_d = pack_off_q;
+    blk_scale  = '0;
+
+    if (pop_cnt > 0) begin
+      for (int i = 0; i < BufSize; i++)
+        pack_d[i] = ((i + pop_cnt) < BufSize) ? pack_q[i+pop_cnt] : 8'd0;
+      pack_off_d = (pack_off_d > OffsetWidth'(pop_cnt)) ? OffsetWidth'(pack_off_d - pop_cnt) : '0;
+    end
+
+    // pack space (one 33B block; <=1 completes per beat) is only needed on a completing beat
+    can_accept = (pack_off_d + OffsetWidth'(MxCompressedBlockBytes)) <= OffsetWidth'(BufSize)
+                 || !blk_completing;
+    if (valid_i && can_accept) begin
+      for (int e = 0; e < ElemsFP16; e++) begin
+        if (elem_valid[e]) begin
+          elem_d[fill_d[$clog2(MxBlockSize)-1:0]] = in_elem[e];
+          if (fill_d == FillW'(MxBlockSize-1)) begin
+            blk_scale = compute_block_scale_with_bias(elem_d, E5m2Bias);
+            pack_d[pack_off_d[OffsetWidth-2:0]] = blk_scale;
+            pack_off_d = OffsetWidth'(pack_off_d + 1);
+            for (int i = 0; i < MxBlockSize; i++) begin
+              pack_d[pack_off_d[OffsetWidth-2:0]] =
+                  fp32_to_mxfp8_byte_prescaled(elem_d[i], decode_signed_scale(blk_scale));
+              pack_off_d = OffsetWidth'(pack_off_d + 1);
+            end
+            fill_d = '0;
+          end else begin
+            fill_d = fill_d + FillW'(1);
+          end
+        end
+      end
+    end
+
+    // present pack occupancy per lane; the write mask gates full vs. tail beats
+    data_o_d     = '0;
+    lane_valid_d = '0;
+    for (int i = 0; i < StrbWidth; i++) begin
+      if (i < pack_off_d) begin
+        data_o_d[i]     = pack_d[i];
+        lane_valid_d[i] = 1'b1;
+      end
+    end
+
+    ready_o = can_accept;
+  end
+
+  // pragma translate_off
+  always @(posedge clk_i) if (rst_ni)
+    assert (pack_off_d <= OffsetWidth'(BufSize))
+      else $fatal(1, "idma_otf_mxquant: pack-buffer overflow (StrbWidth=%0d)", StrbWidth);
+  always @(posedge clk_i) if (rst_ni)
+    assert (32'(pop_cnt) <= 32'(pack_off_q))
+      else $fatal(1, "idma_otf_mxquant: pop exceeds pack occupancy");
+  // NOT IMPLEMENTED: overlapping compute transfers (a clear must never drop in-flight state)
+  always @(posedge clk_i) if (rst_ni && clear_i)
+    assert ((fill_q == '0) && (pack_off_q == '0))
+      else $fatal(1, "idma_otf_mxquant: clear with in-flight state (overlapping transfers)");
+  // pragma translate_on
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      fill_q <= '0; pack_off_q <= '0;
+      for (int i = 0; i < MxBlockSize; i++) elem_q[i] <= 32'd0;
+      for (int i = 0; i < BufSize; i++)     pack_q[i] <= 8'd0;
+      data_o <= '0; lane_valid_o <= '0;
+    end else if (clear_i) begin
+      fill_q <= '0; pack_off_q <= '0;
+      data_o <= '0; lane_valid_o <= '0;
+    end else begin
+      for (int i = 0; i < MxBlockSize; i++) elem_q[i] <= elem_d[i];
+      fill_q <= fill_d;
+      for (int i = 0; i < BufSize; i++)     pack_q[i] <= pack_d[i];
+      pack_off_q <= pack_off_d;
+      data_o       <= data_o_d;
+      lane_valid_o <= lane_valid_d;
+    end
+  end
+
+endmodule : idma_otf_mxquant

--- a/src/backend/idma_otf_mxquant.sv
+++ b/src/backend/idma_otf_mxquant.sv
@@ -63,8 +63,7 @@ module idma_otf_mxquant
   logic fp16_act;
   assign fp16_act = (Fp16En != 1'b0) && src_fp16_i;
 
-  // lane-exact pop: a tail beat pops only its own bytes, keeping any follow-on
-  // transfer's data intact (same-config back-to-back streaming)
+  // lane-exact pop: a tail beat pops only its own bytes
   logic [PopW-1:0] pop_cnt;
   always_comb begin
     pop_cnt = '0;

--- a/src/backend/idma_otf_mxquant.sv
+++ b/src/backend/idma_otf_mxquant.sv
@@ -43,6 +43,12 @@ module idma_otf_mxquant
   localparam int unsigned ElemsFP32   = StrbWidth / 4;
   localparam int unsigned ElemsFP16   = StrbWidth / 2;
   localparam int unsigned FillW       = $clog2(MxBlockSize) + 1;
+  // FP16 is illegal above StrbWidth 64 (legalizer ComputeMxquantFp16Width), so gate it off
+  localparam bit          Fp16En      = (StrbWidth <= 64);
+  localparam int unsigned ElemsMax    = Fp16En ? ElemsFP16 : ElemsFP32;
+  localparam bit          FullBeat    = (!Fp16En) && (ElemsFP32 == MxBlockSize);
+  localparam int unsigned PopW        = $clog2(StrbWidth + 1);
+  localparam int unsigned IdxW        = (ElemsMax > 1) ? $clog2(ElemsMax) : 1;
 
   logic [31:0]      elem_q [MxBlockSize];
   logic [FillW-1:0] fill_q;
@@ -53,93 +59,178 @@ module idma_otf_mxquant
   logic [OffsetWidth-1:0] pack_off_q;
   logic [            7:0] pack_d [BufSize];
   logic [OffsetWidth-1:0] pack_off_d;
-  logic [StrbWidth-1:0][7:0] data_o_d;
-  logic [StrbWidth-1:0]      lane_valid_d;
+
+  logic fp16_act;
+  assign fp16_act = (Fp16En != 1'b0) && src_fp16_i;
 
   // lane-exact pop: a tail beat pops only its own bytes, keeping any follow-on
   // transfer's data intact (same-config back-to-back streaming)
-  int unsigned pop_cnt;
+  logic [PopW-1:0] pop_cnt;
   always_comb begin
-    pop_cnt = 0;
+    pop_cnt = '0;
     for (int i = 0; i < StrbWidth; i++)
-      if (lane_ready_i[i] && lane_valid_o[i]) pop_cnt++;
+      if (lane_ready_i[i] && lane_valid_o[i]) pop_cnt += PopW'(1);
   end
 
   assign busy_o = (fill_q != '0) || (pack_off_q != '0);
 
-  // widen this beat's elements to FP32; mark valid iff all source bytes valid
-  logic [31:0]          in_elem [ElemsFP16];
-  logic [ElemsFP16-1:0] elem_valid;
+  // widen this beat's elements to FP32
+  logic [31:0] in_elem [ElemsMax];
   always_comb begin
-    for (int e = 0; e < ElemsFP16; e++) begin
-      if (src_fp16_i) begin
-        in_elem[e]    = fp16_bits_to_fp32({data_i[e*2+1], data_i[e*2]});
-        elem_valid[e] = valid_i;
-      end else if (e < ElemsFP32) begin
-        in_elem[e]    = {data_i[e*4+3], data_i[e*4+2], data_i[e*4+1], data_i[e*4]};
-        elem_valid[e] = valid_i;
-      end else begin
-        in_elem[e]    = 32'd0;
-        elem_valid[e] = 1'b0;
-      end
+    for (int e = 0; e < ElemsMax; e++) begin
+      if (fp16_act)
+        in_elem[e] = fp16_bits_to_fp32({data_i[e*2+1], data_i[e*2]});
+      else if (e < ElemsFP32)
+        in_elem[e] = {data_i[e*4+3], data_i[e*4+2], data_i[e*4+1], data_i[e*4]};
+      else
+        in_elem[e] = 32'd0;
     end
   end
 
-  logic       can_accept;
-  logic       blk_completing;
-  logic [7:0] blk_scale;
+  logic             blk_completing;
+  logic [FillW-1:0] nelems, fill_next;
+  assign nelems         = fp16_act ? FillW'(ElemsFP16) : FillW'(ElemsFP32);
+  assign fill_next      = fill_q + nelems;
+  assign blk_completing = fill_next[FillW-1];
 
-  assign blk_completing =
-      (32'(fill_q) + (src_fp16_i ? ElemsFP16 : ElemsFP32)) >= MxBlockSize;
+  // single rotate crossbar: lane i sees incoming element (i - fill_q) mod 32
+  logic [31:0] rot_elem [MxBlockSize];
+  logic [31:0] blk_elem [MxBlockSize];
+  always_comb begin
+    for (int i = 0; i < MxBlockSize; i++) begin : lane
+      logic [4:0] rot;
+      rot = 5'(i) - fill_q[4:0];
+      rot_elem[i] = in_elem[rot[IdxW-1:0]];
+      blk_elem[i] = (i < 32'(fill_q)) ? elem_q[i] : rot_elem[i];
+    end
+  end
+
+  // in-module reimplementation of fp32_to_mxfp8_byte_prescaled: bit-exact, with
+  // proven-bound narrowing (scaled_exp in [-255,256] -> 10b signed) and the
+  // subnormal shifter reduced to its 3 reachable amounts (sh in {22,23,24})
+  function automatic logic [7:0] q_e5m2(input logic [31:0] f, input logic signed [7:0] dec_scale);
+    logic               sign;
+    logic [7:0]         expf;
+    logic [22:0]        manf;
+    logic signed [9:0]  exp_s, sc_s, scaled_exp;
+    logic [23:0]        full_mant;
+    logic [3:0]         rounded;
+    logic               guard, sticky, roundup, carry;
+    logic [5:0]         oexp;
+    logic [4:0]         mexp;
+    logic [1:0]         mmant;
+    logic [3:0]         sub_kept;
+    logic               sub_guard, sub_stky;
+
+    sign = f[31]; expf = f[30:23]; manf = f[22:0];
+    if (expf == 8'd0 && manf == 23'd0) return {sign, 5'd0, 2'd0};
+    if (expf == 8'hFF && manf != 23'd0) return {sign, 5'h1F, 2'd1};
+    if (expf == 8'hFF)                  return {sign, 5'h1E, 2'd3};
+
+    exp_s      = signed'({2'b00, expf});
+    sc_s       = signed'({{2{dec_scale[7]}}, dec_scale});
+    scaled_exp = exp_s - 10'sd127 - sc_s;
+    full_mant  = {1'b1, manf};
+
+    if (scaled_exp > 10'sd15) return {sign, 5'h1E, 2'd3};
+
+    if (scaled_exp >= -10'sd14) begin
+      rounded = {1'b0, full_mant[23:21]};
+      guard   = full_mant[20];
+      sticky  = (full_mant[19:0] != 20'd0);
+      roundup = guard && (rounded[0] || sticky);
+      if (roundup) rounded = rounded + 4'd1;
+      carry = rounded[3];
+      oexp  = 6'(scaled_exp + 10'sd15) + 6'(carry);
+      mmant = rounded[1:0];
+      if (oexp > 6'd30) begin
+        mexp  = 5'd30;
+        mmant = 2'd3;
+      end else begin
+        mexp = oexp[4:0];
+      end
+      return {sign, mexp, mmant};
+    end
+
+    if (scaled_exp < -10'sd17) return {sign, 5'd0, 2'd0};
+    // scaled_exp in {-15,-16,-17} <=> low bits {01,00,11}; sh_amt {22,23,24}
+    case (scaled_exp[1:0])
+      2'b01:   begin sub_kept = {2'b00, full_mant[23:22]}; sub_guard = full_mant[21]; sub_stky = (full_mant[20:0] != 21'd0); end
+      2'b00:   begin sub_kept = {3'b000, full_mant[23]};   sub_guard = full_mant[22]; sub_stky = (full_mant[21:0] != 22'd0); end
+      default: begin sub_kept = 4'd0;                      sub_guard = full_mant[23]; sub_stky = (full_mant[22:0] != 23'd0); end
+    endcase
+    if (sub_guard && (sub_kept[0] || sub_stky)) sub_kept = sub_kept + 4'd1;
+    if (sub_kept == 4'd0)     return {sign, 5'd0, 2'd0};
+    else if (sub_kept < 4'd4) return {sign, 5'd0, sub_kept[1:0]};
+    else                      return {sign, 5'd1, 2'd0};
+  endfunction
+
+  // one shared scale tree + one bank of 32 quantizers (<=1 block completes per beat)
+  logic [7:0]        blk_scale;
+  logic signed [7:0] dec_scale;
+  logic [7:0]        qbyte [MxBlockSize];
+  always_comb begin
+    blk_scale = compute_block_scale_with_bias(blk_elem, E5m2Bias);
+    dec_scale = signed'(blk_scale);
+    for (int i = 0; i < MxBlockSize; i++)
+      qbyte[i] = q_e5m2(blk_elem[i], dec_scale);
+  end
+
+  logic                              can_accept, accept;
+  logic [OffsetWidth-1:0]            ins_base;
+  logic [MxCompressedBlockBytes-1:0][7:0] blk33;
+  logic [BufSize*8-1:0]              blk_vec;
+  logic [BufSize-1:0]                ins_mask;
 
   always_comb begin
-    for (int i = 0; i < MxBlockSize; i++) elem_d[i] = elem_q[i];
-    fill_d = fill_q;
     for (int i = 0; i < BufSize; i++) pack_d[i] = pack_q[i];
     pack_off_d = pack_off_q;
-    blk_scale  = '0;
 
-    if (pop_cnt > 0) begin
+    if (pop_cnt != '0) begin
       for (int i = 0; i < BufSize; i++)
-        pack_d[i] = ((i + pop_cnt) < BufSize) ? pack_q[i+pop_cnt] : 8'd0;
+        pack_d[i] = ((i + 32'(pop_cnt)) < BufSize) ? pack_q[i + 32'(pop_cnt)] : 8'd0;
       pack_off_d = (pack_off_d > OffsetWidth'(pop_cnt)) ? OffsetWidth'(pack_off_d - pop_cnt) : '0;
     end
 
     // pack space (one 33B block; <=1 completes per beat) is only needed on a completing beat
     can_accept = (pack_off_d + OffsetWidth'(MxCompressedBlockBytes)) <= OffsetWidth'(BufSize)
                  || !blk_completing;
-    if (valid_i && can_accept) begin
-      for (int e = 0; e < ElemsFP16; e++) begin
-        if (elem_valid[e]) begin
-          elem_d[fill_d[$clog2(MxBlockSize)-1:0]] = in_elem[e];
-          if (fill_d == FillW'(MxBlockSize-1)) begin
-            blk_scale = compute_block_scale_with_bias(elem_d, E5m2Bias);
-            pack_d[pack_off_d[OffsetWidth-2:0]] = blk_scale;
-            pack_off_d = OffsetWidth'(pack_off_d + 1);
-            for (int i = 0; i < MxBlockSize; i++) begin
-              pack_d[pack_off_d[OffsetWidth-2:0]] =
-                  fp32_to_mxfp8_byte_prescaled(elem_d[i], decode_signed_scale(blk_scale));
-              pack_off_d = OffsetWidth'(pack_off_d + 1);
-            end
-            fill_d = '0;
-          end else begin
-            fill_d = fill_d + FillW'(1);
-          end
-        end
+    accept = valid_i && can_accept;
+
+    fill_d = fill_q;
+    for (int i = 0; i < MxBlockSize; i++) elem_d[i] = elem_q[i];
+    if (accept) begin
+      if (blk_completing) begin
+        // spill = fill_next - 32 elements start the next block at index 0
+        for (int i = 0; i < MxBlockSize; i++)
+          elem_d[i] = (i < 32'(fill_next[FillW-2:0])) ? rot_elem[i] : blk_elem[i];
+        fill_d = {1'b0, fill_next[FillW-2:0]};
+      end else begin
+        for (int i = 0; i < MxBlockSize; i++)
+          elem_d[i] = (i < 32'(fill_next)) ? blk_elem[i] : elem_q[i];
+        fill_d = fill_next;
       end
     end
 
-    // present pack occupancy per lane; the write mask gates full vs. tail beats
-    data_o_d     = '0;
-    lane_valid_d = '0;
-    for (int i = 0; i < StrbWidth; i++) begin
-      if (i < pack_off_d) begin
-        data_o_d[i]     = pack_d[i];
-        lane_valid_d[i] = 1'b1;
-      end
+    // hoisted single 33B block insert at the post-pop write offset
+    ins_base = pack_off_d;
+    blk33[0] = blk_scale;
+    for (int i = 0; i < MxBlockSize; i++) blk33[i+1] = qbyte[i];
+    blk_vec  = (BufSize*8)'(blk33) << {ins_base, 3'b000};
+    ins_mask = BufSize'({MxCompressedBlockBytes{1'b1}}) << ins_base;
+    if (accept && blk_completing) begin
+      for (int i = 0; i < BufSize; i++)
+        if (ins_mask[i]) pack_d[i] = blk_vec[i*8 +: 8];
+      pack_off_d = pack_off_d + OffsetWidth'(MxCompressedBlockBytes);
     end
 
     ready_o = can_accept;
+  end
+
+  // outputs are pure functions of pack state (identical to the former output regs)
+  for (genvar i = 0; i < StrbWidth; i++) begin : gen_out
+    assign lane_valid_o[i] = (OffsetWidth'(i) < pack_off_q);
+    assign data_o[i]       = lane_valid_o[i] ? pack_q[i] : 8'd0;
   end
 
   // pragma translate_off
@@ -155,22 +246,28 @@ module idma_otf_mxquant
       else $fatal(1, "idma_otf_mxquant: clear with in-flight state (overlapping transfers)");
   // pragma translate_on
 
+  if (FullBeat) begin : gen_fill_const
+    // every accepted beat is a whole block, so the fill counter is a constant 0
+    assign fill_q = '0;
+  end else begin : gen_fill_ff
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni)      fill_q <= '0;
+      else if (clear_i) fill_q <= '0;
+      else              fill_q <= fill_d;
+    end
+  end
+
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      fill_q <= '0; pack_off_q <= '0;
+      pack_off_q <= '0;
       for (int i = 0; i < MxBlockSize; i++) elem_q[i] <= 32'd0;
       for (int i = 0; i < BufSize; i++)     pack_q[i] <= 8'd0;
-      data_o <= '0; lane_valid_o <= '0;
     end else if (clear_i) begin
-      fill_q <= '0; pack_off_q <= '0;
-      data_o <= '0; lane_valid_o <= '0;
+      pack_off_q <= '0;
     end else begin
       for (int i = 0; i < MxBlockSize; i++) elem_q[i] <= elem_d[i];
-      fill_q <= fill_d;
-      for (int i = 0; i < BufSize; i++)     pack_q[i] <= pack_d[i];
       pack_off_q <= pack_off_d;
-      data_o       <= data_o_d;
-      lane_valid_o <= lane_valid_d;
+      for (int i = 0; i < BufSize; i++)     pack_q[i] <= pack_d[i];
     end
   end
 

--- a/src/backend/tpl/idma_backend.sv.tpl
+++ b/src/backend/tpl/idma_backend.sv.tpl
@@ -441,6 +441,34 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
 
 
     //--------------------------------------
+    // Compute config serialization interlock
+    //--------------------------------------
+    logic req_valid_leg, leg_ready;
+% if compute_eligible:
+    if (EnableCompute) begin : gen_compute_cfg_gate
+        // a request whose compute config differs from the last accepted one waits
+        // until the datapath drained: its reads must not race a draining engine
+        idma_pkg::compute_options_t cmp_cfg_q;
+        logic backend_active, cmp_cfg_stall;
+        assign backend_active = busy_o.buffer_busy | busy_o.r_dp_busy | busy_o.w_dp_busy |
+                                busy_o.r_leg_busy | busy_o.w_leg_busy | busy_o.raw_coupler_busy;
+        assign cmp_cfg_stall  = req_valid & (idma_req_i.opt.compute != cmp_cfg_q) & backend_active;
+        assign req_valid_leg  = req_valid & ~cmp_cfg_stall;
+        assign req_ready_o    = leg_ready & ~cmp_cfg_stall;
+        always_ff @(posedge clk_i or negedge rst_ni) begin
+            if (!rst_ni)                        cmp_cfg_q <= '0;
+            else if (req_valid_leg & leg_ready) cmp_cfg_q <= idma_req_i.opt.compute;
+        end
+    end else begin : gen_no_compute_cfg_gate
+        assign req_valid_leg = req_valid;
+        assign req_ready_o   = leg_ready;
+    end
+% else:
+    assign req_valid_leg = req_valid;
+    assign req_ready_o   = leg_ready;
+% endif
+
+    //--------------------------------------
     // Legalization
     //--------------------------------------
     if (HardwareLegalizer) begin : gen_hw_legalizer
@@ -463,8 +491,8 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
             .clk_i     ( clk_i             ),
             .rst_ni    ( rst_ni            ),
             .req_i     ( idma_req_i        ),
-            .valid_i   ( req_valid         ),
-            .ready_o   ( req_ready_o       ),
+            .valid_i   ( req_valid_leg     ),
+            .ready_o   ( leg_ready         ),
             .r_req_o   ( r_req             ),
             .w_req_o   ( w_req             ),
             .r_valid_o ( r_valid           ),
@@ -485,8 +513,8 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
         ) i_stream_fork (
             .clk_i   ( clk_i                ),
             .rst_ni  ( rst_ni               ),
-            .valid_i ( req_valid            ),
-            .ready_o ( req_ready_o          ),
+            .valid_i ( req_valid_leg        ),
+            .ready_o ( leg_ready            ),
             .valid_o ( { r_valid, w_valid } ),
             .ready_i ( { r_ready, w_ready } )
         );

--- a/src/backend/tpl/idma_backend.sv.tpl
+++ b/src/backend/tpl/idma_backend.sv.tpl
@@ -447,6 +447,10 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
         // hardware legalizer is present
         idma_legalizer_${name_uniqueifier} #(
             .CombinedShifter   ( CombinedShifter   ),
+% if compute_eligible:
+            .EnableCompute     ( EnableCompute     ),
+            .ComputeOps        ( ComputeOps        ),
+% endif
             .DataWidth         ( DataWidth         ),
             .AddrWidth         ( AddrWidth         ),
             .BurstLen          ( BurstLen          ),
@@ -973,6 +977,8 @@ w_req.decouple_aw || (w_req.w_dp_req.dst_protocol inside {\
 % if compute_eligible:
         compute_error_handling : assert(!EnableCompute || ErrorCap == idma_pkg::NO_ERROR_HANDLING) else
             $fatal(1, "EnableCompute requires ErrorCap == NO_ERROR_HANDLING!");
+        compute_combined_shifter : assert(!EnableCompute || !CombinedShifter) else
+            $fatal(1, "EnableCompute requires CombinedShifter == 0!");
 % endif
     end
     )

--- a/src/backend/tpl/idma_legalizer.sv.tpl
+++ b/src/backend/tpl/idma_legalizer.sv.tpl
@@ -721,6 +721,12 @@ ${database[protocol]['legalizer_write_data_path']}
     `ASSERT_NEVER(ComputeMxdequantBeatAligned, (ready_o & valid_i & req_i.opt.compute.enable &
                   (req_i.opt.compute.op == idma_pkg::COMPUTE_MXDEQUANT) &
                   (req_i.length % (33*StrbWidth) != 0)), clk_i, !rst_ni)
+    // NOT IMPLEMENTED: dequant output length that overflows the length field
+    `ASSERT_NEVER(ComputeMxdequantLengthFits, (ready_o & valid_i & req_i.opt.compute.enable &
+                  (req_i.opt.compute.op == idma_pkg::COMPUTE_MXDEQUANT) &
+                  ($bits(req_i.length) < 64) &
+                  (((64'(req_i.length) / 64'd33) * 64'd128) >=
+                   (64'd1 << $bits(req_i.length)))), clk_i, !rst_ni)
     // compute retires on the per-beat write pulse; TileLink writes retire per burst
     `ASSERT_NEVER(ComputeDstTilelink, (ready_o & valid_i & req_i.opt.compute.enable &
                   (req_i.opt.dst_protocol == idma_pkg::TILELINK)), clk_i, !rst_ni)

--- a/src/backend/tpl/idma_legalizer.sv.tpl
+++ b/src/backend/tpl/idma_legalizer.sv.tpl
@@ -724,8 +724,7 @@ ${database[protocol]['legalizer_write_data_path']}
     // compute retires on the per-beat write pulse; TileLink writes retire per burst
     `ASSERT_NEVER(ComputeDstTilelink, (ready_o & valid_i & req_i.opt.compute.enable &
                   (req_i.opt.dst_protocol == idma_pkg::TILELINK)), clk_i, !rst_ni)
-    // NOT IMPLEMENTED: multi-beat transpose write bursts (the seam retires per write
-    // transaction; the transpose midend decomposition keeps every burst single-beat)
+    // NOT IMPLEMENTED: multi-beat transpose write bursts (midend strips are single-beat)
     `ASSERT_NEVER(ComputeTransposeSingleBeat, (ready_o & valid_i & req_i.opt.compute.enable &
                   (req_i.opt.compute.op == idma_pkg::COMPUTE_TRANSPOSE) &
                   (req_i.length > StrbWidth)), clk_i, !rst_ni)

--- a/src/backend/tpl/idma_legalizer.sv.tpl
+++ b/src/backend/tpl/idma_legalizer.sv.tpl
@@ -17,6 +17,12 @@ module idma_legalizer_${name_uniqueifier} #(
     /// If this is enabled, then the data inserted into the dataflow element
     /// will no longer be word aligned, but only a single shifter is needed
     parameter bit          CombinedShifter = 1'b0,
+% if compute_eligible:
+    /// On-the-fly compute engine is elaborated in the transport layer
+    parameter bit          EnableCompute   = 1'b0,
+    /// Per-operation compute support mask
+    parameter idma_pkg::compute_enable_t ComputeOps = '1,
+% endif
     /// Data width
     parameter int unsigned DataWidth       = 32'd16,
     /// Address width
@@ -476,6 +482,17 @@ w_num_bytes_to_pb = w_page_num_bytes_to_pb;
                 user: req_i.user,
                 default: '0
             };
+% if compute_eligible:
+            // size-changing compute: write length follows the per-op byte ratio
+            if (EnableCompute && req_i.opt.compute.enable) begin
+                unique case (req_i.opt.compute.op)
+                    idma_pkg::COMPUTE_MXQUANT:      w_tf_d.length = (req_i.length >> 7) * 33;
+                    idma_pkg::COMPUTE_MXQUANT_FP16: w_tf_d.length = (req_i.length >> 6) * 33;
+                    idma_pkg::COMPUTE_MXDEQUANT:    w_tf_d.length = (req_i.length / 33) * 128;
+                    default: ;
+                endcase
+            end
+% endif
             // options
             opt_tf_d = '{
                 src_protocol:   req_i.opt.src_protocol,
@@ -682,5 +699,55 @@ ${database[protocol]['legalizer_write_data_path']}
                   req_i.opt.src.burst != axi_pkg::BURST_INCR), clk_i, !rst_ni)
     `ASSERT_NEVER(OnlyIncrementalBurstsDST, (ready_o & valid_i &
                   req_i.opt.dst.burst != axi_pkg::BURST_INCR), clk_i, !rst_ni)
+
+    // size-changing compute: length must be a whole multiple of the op's input granule
+    `ASSERT_NEVER(ComputeSizeAligned, (ready_o & valid_i & req_i.opt.compute.enable &
+                  (req_i.length %
+                   idma_pkg::compute_in_bytes(req_i.opt.compute.op) != 0)), clk_i, !rst_ni)
+    // size-changing compute requires beat-aligned addresses
+    `ASSERT_NEVER(ComputeSrcAligned, (ready_o & valid_i & req_i.opt.compute.enable &
+                  (idma_pkg::compute_in_bytes(req_i.opt.compute.op) !=
+                   idma_pkg::compute_out_bytes(req_i.opt.compute.op)) &
+                  (req_i.src_addr[OffsetWidth-1:0] != '0)), clk_i, !rst_ni)
+    `ASSERT_NEVER(ComputeDstAligned, (ready_o & valid_i & req_i.opt.compute.enable &
+                  (idma_pkg::compute_in_bytes(req_i.opt.compute.op) !=
+                   idma_pkg::compute_out_bytes(req_i.opt.compute.op)) &
+                  (req_i.dst_addr[OffsetWidth-1:0] != '0)), clk_i, !rst_ni)
+    // FP16 MX quant packs at most one block per beat
+    `ASSERT_NEVER(ComputeMxquantFp16Width, (ready_o & valid_i & req_i.opt.compute.enable &
+                  (req_i.opt.compute.op == idma_pkg::COMPUTE_MXQUANT_FP16) &
+                  (StrbWidth > 64)), clk_i, !rst_ni)
+    // mxdequant input must additionally be beat-aligned (33k % StrbWidth == 0)
+    `ASSERT_NEVER(ComputeMxdequantBeatAligned, (ready_o & valid_i & req_i.opt.compute.enable &
+                  (req_i.opt.compute.op == idma_pkg::COMPUTE_MXDEQUANT) &
+                  (req_i.length % (33*StrbWidth) != 0)), clk_i, !rst_ni)
+    // compute retires on the per-beat write pulse; TileLink writes retire per burst
+    `ASSERT_NEVER(ComputeDstTilelink, (ready_o & valid_i & req_i.opt.compute.enable &
+                  (req_i.opt.dst_protocol == idma_pkg::TILELINK)), clk_i, !rst_ni)
+    // NOT IMPLEMENTED: multi-beat transpose write bursts (the seam retires per write
+    // transaction; the transpose midend decomposition keeps every burst single-beat)
+    `ASSERT_NEVER(ComputeTransposeSingleBeat, (ready_o & valid_i & req_i.opt.compute.enable &
+                  (req_i.opt.compute.op == idma_pkg::COMPUTE_TRANSPOSE) &
+                  (req_i.length > StrbWidth)), clk_i, !rst_ni)
+    // NOT IMPLEMENTED: size-changing compute is validated on AXI src/dst only (TODO: OBI)
+    `ASSERT_NEVER(ComputeMxSrcProtocol, (ready_o & valid_i & req_i.opt.compute.enable &
+                  (idma_pkg::compute_in_bytes(req_i.opt.compute.op) !=
+                   idma_pkg::compute_out_bytes(req_i.opt.compute.op)) &
+                  (req_i.opt.src_protocol != idma_pkg::AXI)), clk_i, !rst_ni)
+    `ASSERT_NEVER(ComputeMxDstProtocol, (ready_o & valid_i & req_i.opt.compute.enable &
+                  (idma_pkg::compute_in_bytes(req_i.opt.compute.op) !=
+                   idma_pkg::compute_out_bytes(req_i.opt.compute.op)) &
+                  (req_i.opt.dst_protocol != idma_pkg::AXI)), clk_i, !rst_ni)
+% if compute_eligible:
+    // the requested op must be elaborated in this configuration
+    `ASSERT_NEVER(ComputeOpUnsupported, (ready_o & valid_i & req_i.opt.compute.enable & ~(
+                  EnableCompute & (
+                  ((req_i.opt.compute.op == idma_pkg::COMPUTE_TRANSPOSE) & ComputeOps.transpose) |
+                  (((req_i.opt.compute.op == idma_pkg::COMPUTE_MXQUANT) |
+                    (req_i.opt.compute.op == idma_pkg::COMPUTE_MXQUANT_FP16))
+                   & ComputeOps.mxquant) |
+                  ((req_i.opt.compute.op == idma_pkg::COMPUTE_MXDEQUANT) & ComputeOps.mxdequant)))),
+                  clk_i, !rst_ni)
+% endif
 
 endmodule

--- a/src/backend/tpl/idma_transport_layer.sv.tpl
+++ b/src/backend/tpl/idma_transport_layer.sv.tpl
@@ -398,9 +398,9 @@ ${rendered_read_ports[read_port]}
 % if compute_eligible:
     if (EnableCompute) begin : gen_compute
         logic                  cmp_active;
-        logic                  cmp_in_ready, cmp_out_valid;
+        logic                  cmp_in_ready;
         byte_t [StrbWidth-1:0] cmp_data_o;
-        strb_t                 cmp_strb_o;
+        strb_t                 cmp_strb_o, cmp_lane_valid;
 
         idma_otf_compute #(
             .StrbWidth           ( StrbWidth          ),
@@ -415,14 +415,16 @@ ${rendered_read_ports[read_port]}
             .data_i      ( buffer_out          ),
             .valid_i     ( &buffer_out_valid   ),
             .in_ready_o  ( cmp_in_ready        ),
-            .data_o      ( cmp_data_o          ),
-            .strb_o      ( cmp_strb_o          ),
-            .valid_o     ( cmp_out_valid       ),
-            .ready_i     ( w_dp_req_ready      )
+            .data_o       ( cmp_data_o          ),
+            .strb_o       ( cmp_strb_o          ),
+            .lane_valid_o ( cmp_lane_valid      ),
+            // transpose retires per write transaction; the MX units retire lane-exactly
+            .ready_i      ( w_dp_req_ready      ),
+            .lane_ready_i ( buffer_out_ready_shifted )
         );
 
         assign wr_data           = cmp_active ? cmp_data_o : buffer_out;
-        assign wr_valid          = cmp_active ? {StrbWidth{cmp_out_valid}} : buffer_out_valid;
+        assign wr_valid          = cmp_active ? cmp_lane_valid : buffer_out_valid;
         assign wr_strb           = cmp_active ? cmp_strb_o : '1;
         assign dataflow_ready_in = cmp_active ? {StrbWidth{(&buffer_out_valid) & cmp_in_ready}}
                                               : buffer_out_ready_shifted;

--- a/src/backend/tpl/idma_transport_layer.sv.tpl
+++ b/src/backend/tpl/idma_transport_layer.sv.tpl
@@ -418,7 +418,6 @@ ${rendered_read_ports[read_port]}
             .data_o       ( cmp_data_o          ),
             .strb_o       ( cmp_strb_o          ),
             .lane_valid_o ( cmp_lane_valid      ),
-            // transpose retires per write transaction; the MX units retire lane-exactly
             .ready_i      ( w_dp_req_ready      ),
             .lane_ready_i ( buffer_out_ready_shifted )
         );

--- a/src/frontend/reg/idma_reg.rdl
+++ b/src/frontend/reg/idma_reg.rdl
@@ -160,7 +160,7 @@ addrmap idma_reg #(
             desc = "Enable on-the-fly compute for the launched transfer.";
         } compute_enable [0:0] = 0;
         field {
-            desc = "Compute operation selector. Currently, 1 selects transpose.";
+            desc = "Compute operation selector: 1 transpose, 2 MX quant (FP32 source), 3 MX quant (FP16 source), 4 MX dequant.";
         } compute_op [4:1] = 0;
         field {
             desc = "Transpose element-size mode. The element size is 1 << transpose_mode bytes, encoding 8b, 16b, 32b, and 64b elements.";

--- a/src/idma_mxquant_pkg.sv
+++ b/src/idma_mxquant_pkg.sv
@@ -26,16 +26,22 @@ package idma_mxquant_pkg;
     else return int'(scale) - 256;
   endfunction
 
+  // Inf/NaN lanes are excluded from the scan and the scale saturates instead of
+  // wrapping (two deliberate corrections vs the viDMA ALCU)
   function automatic logic [7:0] compute_block_scale_with_bias(
       input logic [31:0] fp32_bits[MxBlockSize], input int bias);
     logic [7:0] max_exp;
     logic [7:0] elem_exp;
+    int         scale;
     max_exp = 8'd0;
     for (int i = 0; i < MxBlockSize; i++) begin
       elem_exp = fp32_bits[i][30:23];
-      if (elem_exp > max_exp) max_exp = elem_exp;
+      if (elem_exp != 8'hFF && elem_exp > max_exp) max_exp = elem_exp;
     end
-    return 8'((int'(max_exp) - Fp32Bias - bias));
+    scale = int'(max_exp) - Fp32Bias - bias;
+    if (scale < -128) scale = -128;
+    else if (scale > 127) scale = 127;
+    return 8'(scale);
   endfunction
 
   // RNE FP32 -> E5M2 with full subnormal support. The split normal/subnormal

--- a/src/idma_mxquant_pkg.sv
+++ b/src/idma_mxquant_pkg.sv
@@ -1,0 +1,191 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+/// MX quantization numeric core: FP16/FP32 -> MXFP8 (E5M2) with E8M0 block
+/// scale. Bit-exact with the viDMA ALCU / Rust golden. Ported from
+/// pulp-platform/vidma hw/vidma/vidma_alcu_pkg.sv.
+package idma_mxquant_pkg;
+
+  localparam int unsigned MxBlockSize          = 32;
+  localparam int unsigned MxFp32BlockBytes     = MxBlockSize * 4; // 128
+  localparam int unsigned MxFp16BlockBytes     = MxBlockSize * 2; // 64
+  localparam int unsigned MxCompressedBlockBytes = MxBlockSize + 1; // 33
+
+  localparam int E5m2Bias   = 15;
+  localparam int E5m2ExpMax = 15;
+  localparam int E5m2ExpMin = -14;
+  localparam int Fp32Bias   = 127;
+  localparam int Fp16Bias   = 15;
+
+  function automatic int decode_signed_scale(input logic [7:0] scale);
+    if (scale < 128) return int'(scale);
+    else return int'(scale) - 256;
+  endfunction
+
+  function automatic logic [7:0] compute_block_scale_with_bias(
+      input logic [31:0] fp32_bits[MxBlockSize], input int bias);
+    logic [7:0] max_exp;
+    logic [7:0] elem_exp;
+    max_exp = 8'd0;
+    for (int i = 0; i < MxBlockSize; i++) begin
+      elem_exp = fp32_bits[i][30:23];
+      if (elem_exp > max_exp) max_exp = elem_exp;
+    end
+    return 8'((int'(max_exp) - Fp32Bias - bias));
+  endfunction
+
+  // RNE FP32 -> E5M2 with full subnormal support. The split normal/subnormal
+  // bands are load-bearing: merging them halves the smallest-normal band and
+  // flushes all subnormals to zero. Do not merge.
+  function automatic logic [7:0] fp32_to_mxfp8_byte_prescaled(input logic [31:0] fp32_bits,
+                                                              input int decoded_scale);
+    logic        sign;
+    logic [ 7:0] expf;
+    logic [22:0] manf;
+    int unbiased, scaled_exp;
+    logic [23:0] full_mant;
+    logic [ 4:0] mexp;
+    logic [ 1:0] mmant;
+    logic exp_is_zero, exp_is_max, mant_is_zero;
+    logic [ 3:0] rounded;
+    logic guard, sticky, roundup;
+    int   out_exp;
+    logic carry;
+    logic [ 5:0] sh_amt;
+    logic [ 3:0] sub_kept;
+    logic        sub_guard, sub_stky;
+
+    sign         = fp32_bits[31];
+    expf         = fp32_bits[30:23];
+    manf         = fp32_bits[22:0];
+
+    exp_is_zero  = (expf == 8'd0);
+    exp_is_max   = (expf == 8'hFF);
+    mant_is_zero = (manf == 23'd0);
+
+    if (exp_is_zero && mant_is_zero) begin
+      return {sign, 5'd0, 2'd0};   // zero
+    end else if (exp_is_max && !mant_is_zero) begin
+      return {sign, 5'h1F, 2'd1};  // NaN
+    end else if (exp_is_max) begin
+      return {sign, 5'h1E, 2'd3};  // Inf
+    end
+
+    unbiased   = int'(expf) - Fp32Bias;
+    scaled_exp = unbiased - decoded_scale;
+    full_mant  = {1'b1, manf};
+
+    if (scaled_exp > E5m2ExpMax) return {sign, 5'h1E, 2'd3}; // saturate
+
+    if (scaled_exp >= E5m2ExpMin) begin
+      rounded = {1'b0, full_mant[23:21]};
+      guard   = full_mant[20];
+      sticky  = (full_mant[19:0] != 20'd0);
+      roundup = guard && (rounded[0] || sticky);
+      if (roundup) rounded = rounded + 4'd1;
+      carry   = rounded[3];
+      out_exp = scaled_exp + E5m2Bias + int'(carry);
+      mmant   = rounded[1:0];
+      if (out_exp > 30) begin
+        mexp  = 5'd30;
+        mmant = 2'd3;
+      end else begin
+        mexp = out_exp[4:0];
+      end
+      return {sign, mexp, mmant};
+    end else begin
+      if (scaled_exp < (E5m2ExpMin - 3)) return {sign, 5'd0, 2'd0};
+      sh_amt    = 6'(21 + (E5m2ExpMin - scaled_exp));
+      sub_kept  = 4'(full_mant >> sh_amt);
+      sub_guard = full_mant[sh_amt - 1];
+      sub_stky  = |(full_mant & ((24'd1 << (sh_amt - 1)) - 24'd1));
+      if (sub_guard && (sub_kept[0] || sub_stky)) sub_kept = sub_kept + 4'd1;
+      if (sub_kept == 4'd0)      return {sign, 5'd0, 2'd0};
+      else if (sub_kept < 4'd4)  return {sign, 5'd0, sub_kept[1:0]};
+      else                       return {sign, 5'd1, 2'd0};
+    end
+  endfunction
+
+  // Exact FP16 (E5M10) -> FP32 widen (lossless).
+  function automatic logic [31:0] fp16_bits_to_fp32(input logic [15:0] fp16_bits);
+    logic       sign;
+    logic [4:0] exp16;
+    logic [9:0] man16;
+    logic [7:0] exp32;
+    logic [22:0] man32;
+    logic [3:0] lz;
+    logic [9:0] man_norm;
+
+    sign  = fp16_bits[15];
+    exp16 = fp16_bits[14:10];
+    man16 = fp16_bits[9:0];
+
+    if (exp16 == 5'h1F) begin
+      if (man16 == 10'd0) return {sign, 8'hFF, 23'd0};
+      else                return {sign, 8'hFF, 1'b1, man16, 12'd0};
+    end
+    if (exp16 == 5'd0 && man16 == 10'd0) return {sign, 31'd0};
+    if (exp16 == 5'd0) begin
+      casez (man16)
+        10'b1?????????: lz = 4'd0;
+        10'b01????????: lz = 4'd1;
+        10'b001???????: lz = 4'd2;
+        10'b0001??????: lz = 4'd3;
+        10'b00001?????: lz = 4'd4;
+        10'b000001????: lz = 4'd5;
+        10'b0000001???: lz = 4'd6;
+        10'b00000001??: lz = 4'd7;
+        10'b000000001?: lz = 4'd8;
+        default:        lz = 4'd9;
+      endcase
+      exp32    = 8'((Fp32Bias - Fp16Bias) - int'(lz));
+      man_norm = man16 << (lz + 4'd1);
+      man32    = {man_norm, 13'd0};
+      return {sign, exp32, man32};
+    end
+    exp32 = 8'(int'(exp16) + (Fp32Bias - Fp16Bias));
+    man32 = {man16, 13'd0};
+    return {sign, exp32, man32};
+  endfunction
+
+  // MXFP8 (E5M2) -> FP32 dequantization with the decoded block scale applied.
+  function automatic logic [31:0] mxfp8_byte_to_fp32_prescaled(input logic [7:0] byte_val,
+                                                               input int scaled);
+    logic        sign;
+    logic [ 4:0] exp_e5;
+    logic [ 1:0] mant;
+    logic [31:0] sign_bit;
+    int          fp32_exp;
+    logic [22:0] out_mant;
+    logic exp_is_zero, exp_is_max;
+
+    sign        = byte_val[7];
+    exp_e5      = byte_val[6:2];
+    mant        = byte_val[1:0];
+    sign_bit    = {sign, 31'd0};
+
+    exp_is_zero = (exp_e5 == 5'd0);
+    exp_is_max  = (exp_e5 == 5'h1F);
+
+    if (exp_is_zero && mant == 2'd0) return sign_bit;
+    if (exp_is_max && mant == 2'd0) return sign_bit | 32'h7F800000;
+    if (exp_is_max) return 32'h7FC00000;
+
+    if (exp_is_zero) begin
+      fp32_exp = (-16 + int'(mant > 2'd1) + scaled) + Fp32Bias;
+      out_mant = {mant[1] & mant[0], 22'd0};
+    end else begin
+      fp32_exp = int'(exp_e5) - E5m2Bias + scaled + Fp32Bias;
+      out_mant = {mant, 21'd0};
+    end
+
+    if (fp32_exp <= 0) return sign_bit;
+    else if (fp32_exp >= 255) return sign_bit | {1'b0, 8'hFE, 23'h7FFFFF};
+    else return sign_bit | (32'(fp32_exp[7:0]) << 23) | 32'(out_mant);
+  endfunction
+
+endpackage

--- a/src/idma_pkg.sv
+++ b/src/idma_pkg.sv
@@ -83,9 +83,31 @@ package idma_pkg;
 
     /// Compute operation selector
     typedef enum logic [3:0] {
-        COMPUTE_NONE      = 4'd0,
-        COMPUTE_TRANSPOSE = 4'd1
+        COMPUTE_NONE         = 4'd0,
+        COMPUTE_TRANSPOSE    = 4'd1,
+        COMPUTE_MXQUANT      = 4'd2, // FP32 -> MXFP8, 128B -> 33B per 32-elem block
+        COMPUTE_MXQUANT_FP16 = 4'd3, // FP16 -> MXFP8,  64B -> 33B per 32-elem block
+        COMPUTE_MXDEQUANT    = 4'd4  // MXFP8 -> FP32,  33B -> 128B per 32-elem block
     } compute_op_e;
+
+    /// Per-op source:dest byte ratio; the legalizer sizes the write length from it.
+    function automatic int unsigned compute_in_bytes(compute_op_e op);
+        unique case (op)
+            COMPUTE_MXQUANT:      return 32'd128;
+            COMPUTE_MXQUANT_FP16: return 32'd64;
+            COMPUTE_MXDEQUANT:    return 32'd33;
+            default:              return 32'd1;
+        endcase
+    endfunction
+
+    function automatic int unsigned compute_out_bytes(compute_op_e op);
+        unique case (op)
+            COMPUTE_MXQUANT:      return 32'd33;
+            COMPUTE_MXQUANT_FP16: return 32'd33;
+            COMPUTE_MXDEQUANT:    return 32'd128;
+            default:              return 32'd1;
+        endcase
+    endfunction
 
     /// Transpose tensor dimension width (elements)
     localparam int unsigned TransposeDimWidth = 32'd12;
@@ -112,6 +134,8 @@ package idma_pkg;
     /// Compile-time per-op compute feature enables
     typedef struct packed {
         logic transpose;
+        logic mxquant;
+        logic mxdequant;
     } compute_enable_t;
 
     /// Supported Protocols

--- a/test/idma_mxquant_dpi.c
+++ b/test/idma_mxquant_dpi.c
@@ -1,0 +1,156 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// DPI-C golden for idma_otf_mxquant: FP16 -> MXFP8 (E5M2), 32-element blocks
+// packed as [1B E8M0 scale][32B E5M2]. Bit-exact with idma_mxquant_pkg / the
+// viDMA ALCU. Ported from sw/cheshire/tests/l2_dma_mxquant.c.
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define GM_MAX_BYTES (1 << 24)
+
+static uint8_t gm_in[GM_MAX_BYTES];   // FP16 input bytes (little-endian)
+static uint8_t gm_out[GM_MAX_BYTES];  // 33B-block MXFP8 output
+
+void gm_load(int idx, int val) {
+  if (idx >= 0 && idx < GM_MAX_BYTES) gm_in[idx] = (uint8_t)val;
+}
+int gm_get(int idx) {
+  if (idx >= 0 && idx < GM_MAX_BYTES) return (int)gm_out[idx];
+  return -1;
+}
+
+static uint32_t fp16_to_fp32_bits(uint16_t h) {
+  uint32_t sign = (uint32_t)(h >> 15) & 0x1u;
+  uint32_t exp  = (uint32_t)(h >> 10) & 0x1Fu;
+  uint32_t mant = (uint32_t)h & 0x3FFu;
+  if (exp == 0) {
+    if (mant == 0) return sign << 31;
+    int e = -1;
+    uint32_t m = mant;
+    do { m <<= 1; e++; } while ((m & 0x400u) == 0);
+    m &= 0x3FFu;
+    uint32_t fexp = (uint32_t)(127 - 15 - e);
+    return (sign << 31) | (fexp << 23) | (m << 13);
+  }
+  if (exp == 0x1Fu) {
+    if (mant == 0) return (sign << 31) | (0xFFu << 23);
+    return (sign << 31) | (0xFFu << 23) | (1u << 22) | (mant << 12);  // qNaN, payload kept
+  }
+  return (sign << 31) | ((exp + (127 - 15)) << 23) | (mant << 13);
+}
+
+static uint8_t block_scale_e5m2(const uint32_t *block, size_t len) {
+  uint32_t max_exp = 0;
+  for (size_t i = 0; i < len; ++i) {
+    uint32_t exp = (block[i] >> 23) & 0xFFu;
+    if (exp > max_exp) max_exp = exp;
+  }
+  int32_t scaled = (int32_t)max_exp - 127 - 15;
+  return (uint8_t)(scaled & 0xFF);
+}
+
+static uint8_t quantize_fp32_e5m2(uint32_t bits, int8_t scale) {
+  uint32_t sign = bits >> 31, expf = (bits >> 23) & 0xFFu, manf = bits & 0x7FFFFFu;
+  if (expf == 0u && manf == 0u) return (uint8_t)(sign << 7);
+  if (expf == 0xFFu && manf != 0u) return (uint8_t)((sign << 7) | (0x1Fu << 2) | 0x1u);
+  if (expf == 0xFFu) return (uint8_t)((sign << 7) | (0x1Eu << 2) | 0x3u);
+  int unbiased   = (int)expf - 127;
+  int scaled_exp = unbiased - (int)scale;
+  uint32_t full_mant = (1u << 23) | manf;
+  const int EMAX = 15, EMIN = -14, EBIAS = 15;
+  if (scaled_exp > EMAX) return (uint8_t)((sign << 7) | (0x1Eu << 2) | 0x3u);
+  if (scaled_exp >= EMIN) {
+    uint32_t rounded = (full_mant >> 21) & 0x7u;
+    uint32_t guard   = (full_mant >> 20) & 0x1u;
+    uint32_t sticky  = (full_mant & 0xFFFFFu) != 0u;
+    if (guard && ((rounded & 0x1u) || sticky)) rounded += 1u;
+    uint32_t carry = (rounded >> 3) & 0x1u;
+    int out_exp = scaled_exp + EBIAS + (int)carry;
+    uint32_t mmant = rounded & 0x3u, mexp;
+    if (out_exp > 30) { mexp = 30u; mmant = 0x3u; }
+    else mexp = (uint32_t)out_exp & 0x1Fu;
+    return (uint8_t)((sign << 7) | ((mexp & 0x1Fu) << 2) | (mmant & 0x3u));
+  } else {
+    if (scaled_exp < (EMIN - 3)) return (uint8_t)(sign << 7);
+    uint32_t sh   = (uint32_t)(21 + (EMIN - scaled_exp));
+    uint32_t kept = (full_mant >> sh) & 0xFu;
+    uint32_t sg   = (full_mant >> (sh - 1u)) & 0x1u;
+    uint32_t ss   = (full_mant & ((1u << (sh - 1u)) - 1u)) != 0u;
+    if (sg && ((kept & 0x1u) || ss)) kept += 1u;
+    if (kept == 0u)     return (uint8_t)(sign << 7);
+    else if (kept < 4u) return (uint8_t)((sign << 7) | (kept & 0x3u));
+    else                return (uint8_t)((sign << 7) | (0x1u << 2));
+  }
+}
+
+// Bit-exact C port of idma_mxquant_pkg::mxfp8_byte_to_fp32_prescaled.
+static uint32_t dequant_e5m2_fp32(uint8_t b, int scaled) {
+  uint32_t sign = (b >> 7) & 1u, exp5 = (b >> 2) & 0x1Fu, mant = b & 3u;
+  uint32_t sign_bit = sign << 31;
+  int fp32_exp;
+  uint32_t out_mant;
+  if (exp5 == 0u && mant == 0u) return sign_bit;
+  if (exp5 == 0x1Fu && mant == 0u) return sign_bit | 0x7F800000u;
+  if (exp5 == 0x1Fu) return 0x7FC00000u;
+  if (exp5 == 0u) {
+    fp32_exp = (-16 + (mant > 1u ? 1 : 0) + scaled) + 127;
+    out_mant = ((mant == 3u) ? 1u : 0u) << 22;
+  } else {
+    fp32_exp = (int)exp5 - 15 + scaled + 127;
+    out_mant = mant << 21;
+  }
+  if (fp32_exp <= 0) return sign_bit;
+  if (fp32_exp >= 255) return sign_bit | (0xFEu << 23) | 0x7FFFFFu;
+  return sign_bit | ((uint32_t)fp32_exp << 23) | out_mant;
+}
+
+// Dequantize num_blocks 33B MX blocks from gm_in into 128B FP32 blocks in gm_out.
+void gm_mxdequant(int num_blocks) {
+  for (int b = 0; b < num_blocks; ++b) {
+    int dec = (int)(int8_t)gm_in[b*33];
+    for (int e = 0; e < 32; ++e) {
+      uint32_t f = dequant_e5m2_fp32(gm_in[b*33 + 1 + e], dec);
+      gm_out[b*128 + e*4 + 0] = (uint8_t)(f & 0xFFu);
+      gm_out[b*128 + e*4 + 1] = (uint8_t)((f >> 8) & 0xFFu);
+      gm_out[b*128 + e*4 + 2] = (uint8_t)((f >> 16) & 0xFFu);
+      gm_out[b*128 + e*4 + 3] = (uint8_t)((f >> 24) & 0xFFu);
+    }
+  }
+}
+
+// Quantize num_blocks 32-element FP16 blocks from gm_in into 33B MX blocks in gm_out.
+void gm_mxquant(int num_blocks) {
+  for (int b = 0; b < num_blocks; ++b) {
+    uint32_t blk[32];
+    for (int lane = 0; lane < 32; ++lane) {
+      uint16_t h = (uint16_t)(gm_in[b*64 + lane*2] | (gm_in[b*64 + lane*2 + 1] << 8));
+      blk[lane] = fp16_to_fp32_bits(h);
+    }
+    uint8_t scale = block_scale_e5m2(blk, 32);
+    gm_out[b*33] = scale;
+    for (int lane = 0; lane < 32; ++lane)
+      gm_out[b*33 + 1 + lane] = quantize_fp32_e5m2(blk[lane], (int8_t)scale);
+  }
+}
+
+// Quantize num_blocks 32-element FP32 blocks from gm_in into 33B MX blocks in gm_out.
+void gm_mxquant_fp32(int num_blocks) {
+  for (int b = 0; b < num_blocks; ++b) {
+    uint32_t blk[32];
+    for (int lane = 0; lane < 32; ++lane)
+      blk[lane] = (uint32_t)gm_in[b*128 + lane*4]
+                | ((uint32_t)gm_in[b*128 + lane*4 + 1] << 8)
+                | ((uint32_t)gm_in[b*128 + lane*4 + 2] << 16)
+                | ((uint32_t)gm_in[b*128 + lane*4 + 3] << 24);
+    uint8_t scale = block_scale_e5m2(blk, 32);
+    gm_out[b*33] = scale;
+    for (int lane = 0; lane < 32; ++lane)
+      gm_out[b*33 + 1 + lane] = quantize_fp32_e5m2(blk[lane], (int8_t)scale);
+  }
+}

--- a/test/idma_mxquant_dpi.c
+++ b/test/idma_mxquant_dpi.c
@@ -49,9 +49,11 @@ static uint8_t block_scale_e5m2(const uint32_t *block, size_t len) {
   uint32_t max_exp = 0;
   for (size_t i = 0; i < len; ++i) {
     uint32_t exp = (block[i] >> 23) & 0xFFu;
-    if (exp > max_exp) max_exp = exp;
+    if (exp != 0xFFu && exp > max_exp) max_exp = exp;
   }
   int32_t scaled = (int32_t)max_exp - 127 - 15;
+  if (scaled < -128) scaled = -128;
+  else if (scaled > 127) scaled = 127;
   return (uint8_t)(scaled & 0xFF);
 }
 

--- a/test/tb_idma_mxneg.sv
+++ b/test/tb_idma_mxneg.sv
@@ -152,6 +152,8 @@ module tb_idma_mxneg
       end
       10: issue(Src, Dst, 4 * StrbWidth, idma_pkg::COMPUTE_TRANSPOSE,
                 idma_pkg::AXI, idma_pkg::AXI, 1'b0);
+      11: issue(Src, Dst, 32'd264 << 22, idma_pkg::COMPUTE_MXDEQUANT,
+                idma_pkg::AXI, idma_pkg::AXI, 1'b0);
       default: $fatal(1, "[MXNEG] unknown NegCase %0d", NegCase);
     endcase
 

--- a/test/tb_idma_mxneg.sv
+++ b/test/tb_idma_mxneg.sv
@@ -1,0 +1,165 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// Negative tests: each NegCase issues one illegal compute request and expects
+// the matching legalizer guard assert to report (compile with +define+INC_ASSERT).
+// The runner greps the transcript for the assert name; case 9 provokes transfer
+// overlap and expects the mxquant sub-unit's clear-with-in-flight-state fatal.
+
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+
+module tb_idma_mxneg
+  import idma_pkg::*;
+#(
+  parameter int unsigned DataWidth  = 64,
+  parameter int unsigned AddrWidth  = 32,
+  parameter int unsigned UserWidth  = 1,
+  parameter int unsigned AxiIdWidth = 12,
+  parameter int unsigned TFLenWidth = 32,
+  parameter int unsigned NegCase    = 1,
+  parameter bit          EnDequant  = 1'b1
+);
+
+  localparam time TA = 1ns, TT = 9ns, TCK = 10ns;
+  localparam int unsigned StrbWidth = DataWidth / 8;
+
+  typedef logic [AddrWidth-1:0]  addr_t;
+  typedef logic [DataWidth-1:0]  data_t;
+  typedef logic [StrbWidth-1:0]  strb_t;
+  typedef logic [AxiIdWidth-1:0] id_t;
+  typedef logic [UserWidth-1:0]  user_t;
+  typedef logic [TFLenWidth-1:0] tf_len_t;
+
+  `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_chan_t, axi_w_chan_t, axi_ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(axi_rsp_t, axi_b_chan_t, axi_r_chan_t)
+
+  `IDMA_TYPEDEF_FULL_REQ_T(idma_req_t, id_t, addr_t, tf_len_t)
+  `IDMA_TYPEDEF_FULL_RSP_T(idma_rsp_t, addr_t)
+
+  typedef struct packed { axi_ar_chan_t ar_chan; } axi_read_meta_channel_t;
+  typedef struct packed { axi_read_meta_channel_t axi; } read_meta_channel_t;
+  typedef struct packed { axi_aw_chan_t aw_chan; } axi_write_meta_channel_t;
+  typedef struct packed { axi_write_meta_channel_t axi; } write_meta_channel_t;
+
+  logic clk, rst_n;
+  idma_req_t    idma_req;    logic req_valid, req_ready;
+  idma_rsp_t    idma_rsp;    logic rsp_valid, rsp_ready;
+  idma_eh_req_t idma_eh_req; logic eh_req_valid, eh_req_ready;
+  axi_req_t axi_read_req, axi_write_req, axi_req;
+  axi_rsp_t axi_read_rsp, axi_write_rsp, axi_rsp;
+  idma_busy_t busy;
+
+  assign idma_eh_req = '0;
+  assign eh_req_valid = 1'b0;
+
+  clk_rst_gen #(.ClkPeriod(TCK), .RstClkCycles(1)) i_clk_rst_gen (.clk_o(clk), .rst_no(rst_n));
+
+  axi_rw_join #(.axi_req_t(axi_req_t), .axi_resp_t(axi_rsp_t)) i_axi_rw_join (
+    .clk_i(clk), .rst_ni(rst_n),
+    .slv_read_req_i(axi_read_req),  .slv_read_resp_o(axi_read_rsp),
+    .slv_write_req_i(axi_write_req), .slv_write_resp_o(axi_write_rsp),
+    .mst_req_o(axi_req), .mst_resp_i(axi_rsp)
+  );
+
+  axi_sim_mem #(
+    .AddrWidth(AddrWidth), .DataWidth(DataWidth), .IdWidth(AxiIdWidth), .UserWidth(UserWidth),
+    .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .WarnUninitialized(1'b0), .ClearErrOnAccess(1'b1), .ApplDelay(TA), .AcqDelay(TT)
+  ) i_axi_sim_mem (
+    .clk_i(clk), .rst_ni(rst_n), .axi_req_i(axi_req), .axi_rsp_o(axi_rsp),
+    .mon_r_last_o(), .mon_r_beat_count_o(), .mon_r_user_o(), .mon_r_id_o(),
+    .mon_r_data_o(), .mon_r_addr_o(), .mon_r_valid_o(),
+    .mon_w_last_o(), .mon_w_beat_count_o(), .mon_w_user_o(), .mon_w_id_o(),
+    .mon_w_data_o(), .mon_w_addr_o(), .mon_w_valid_o()
+  );
+
+  idma_backend_rw_axi #(
+    .CombinedShifter(1'b0), .DataWidth(DataWidth), .AddrWidth(AddrWidth), .AxiIdWidth(AxiIdWidth),
+    .UserWidth(UserWidth), .TFLenWidth(TFLenWidth), .MaskInvalidData(1'b1), .BufferDepth(3),
+    .EnableCompute(1'b1),
+    .ComputeOps(idma_pkg::compute_enable_t'{transpose: 1'b1, mxquant: 1'b1,
+                                            mxdequant: EnDequant, default: '0}),
+    .ComputeFullDuplex(1'b1),
+    .RAWCouplingAvail(1'b1), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
+    .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(StrbWidth), .MemSysDepth(0),
+    .idma_req_t(idma_req_t), .idma_rsp_t(idma_rsp_t), .idma_eh_req_t(idma_eh_req_t),
+    .idma_busy_t(idma_busy_t), .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .write_meta_channel_t(write_meta_channel_t), .read_meta_channel_t(read_meta_channel_t)
+  ) i_idma_backend (
+    .clk_i(clk), .rst_ni(rst_n), .testmode_i(1'b0),
+    .idma_req_i(idma_req), .req_valid_i(req_valid), .req_ready_o(req_ready),
+    .idma_rsp_o(idma_rsp), .rsp_valid_o(rsp_valid), .rsp_ready_i(rsp_ready),
+    .idma_eh_req_i(idma_eh_req), .eh_req_valid_i(eh_req_valid), .eh_req_ready_o(eh_req_ready),
+    .axi_read_req_o(axi_read_req), .axi_read_rsp_i(axi_read_rsp),
+    .axi_write_req_o(axi_write_req), .axi_write_rsp_i(axi_write_rsp), .busy_o(busy)
+  );
+
+  task automatic issue(input addr_t src, input addr_t dst, input int unsigned L,
+                       input idma_pkg::compute_op_e op,
+                       input idma_pkg::protocol_e src_prot, input idma_pkg::protocol_e dst_prot,
+                       input bit wait_done);
+    idma_req = '0;
+    idma_req.length   = tf_len_t'(L);
+    idma_req.src_addr = src;
+    idma_req.dst_addr = dst;
+    idma_req.opt.src_protocol = src_prot;
+    idma_req.opt.dst_protocol = dst_prot;
+    idma_req.opt.src.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.dst.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.beo.decouple_rw = 1'b1;
+    idma_req.opt.beo.decouple_aw = 1'b1;
+    idma_req.opt.compute.enable  = (op != idma_pkg::COMPUTE_NONE);
+    idma_req.opt.compute.op      = op;
+    idma_req.opt.last            = 1'b1;
+    req_valid = 1'b1;
+    do @(posedge clk); while (!req_ready);
+    req_valid = 1'b0;
+    idma_req = '0;
+    if (wait_done) while (!(rsp_valid && rsp_ready)) @(posedge clk);
+  endtask
+
+  localparam addr_t Src = 'h0001_0000, Dst = 'h0005_0000;
+
+  initial begin
+    req_valid = 1'b0; rsp_ready = 1'b1; idma_req = '0;
+    for (int unsigned i = 0; i < 8192; i++) i_axi_sim_mem.mem[Src + i] = 8'(i);
+    @(posedge rst_n);
+    repeat (5) @(posedge clk);
+
+    case (NegCase)
+      1: issue(Src, Dst, 100, idma_pkg::COMPUTE_MXQUANT, idma_pkg::AXI, idma_pkg::AXI, 1'b0);
+      2: issue(Src + 1, Dst, 128, idma_pkg::COMPUTE_MXQUANT, idma_pkg::AXI, idma_pkg::AXI, 1'b0);
+      3: issue(Src, Dst + 1, 128, idma_pkg::COMPUTE_MXQUANT, idma_pkg::AXI, idma_pkg::AXI, 1'b0);
+      4: issue(Src, Dst, 64, idma_pkg::COMPUTE_MXQUANT_FP16, idma_pkg::AXI, idma_pkg::AXI, 1'b0);
+      5: issue(Src, Dst, 33, idma_pkg::COMPUTE_MXDEQUANT, idma_pkg::AXI, idma_pkg::AXI, 1'b0);
+      6: issue(Src, Dst, 33 * StrbWidth, idma_pkg::COMPUTE_MXDEQUANT,
+               idma_pkg::AXI, idma_pkg::AXI, 1'b0);
+      7: issue(Src, Dst, 128, idma_pkg::COMPUTE_MXQUANT, idma_pkg::OBI, idma_pkg::AXI, 1'b0);
+      8: issue(Src, Dst, 128, idma_pkg::COMPUTE_MXQUANT, idma_pkg::AXI, idma_pkg::OBI, 1'b0);
+      9: begin  // overlap: second transfer issued while the quant drain is still in flight
+        issue(Src, Dst, 24 * 128, idma_pkg::COMPUTE_MXQUANT, idma_pkg::AXI, idma_pkg::AXI, 1'b0);
+        issue(Src, Dst + 'h2000, 512, idma_pkg::COMPUTE_NONE, idma_pkg::AXI, idma_pkg::AXI, 1'b0);
+      end
+      10: issue(Src, Dst, 4 * StrbWidth, idma_pkg::COMPUTE_TRANSPOSE,
+                idma_pkg::AXI, idma_pkg::AXI, 1'b0);
+      default: $fatal(1, "[MXNEG] unknown NegCase %0d", NegCase);
+    endcase
+
+    repeat (3000) @(posedge clk);
+    $display("[MXNEG] case %0d done", NegCase);
+    $finish();
+  end
+
+  initial begin #10_000_000; $display("[MXNEG] case %0d done (timeout)", NegCase); $finish(); end
+
+endmodule

--- a/test/tb_idma_mxperf.sv
+++ b/test/tb_idma_mxperf.sv
@@ -1,0 +1,253 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// Steady-state throughput: measures bottleneck-channel utilization (beats per
+// cycle between first and last handshake) for large MX transfers against an
+// ideal memory. Quant is read-bound, dequant write-bound; each must stay within
+// UtilSlackPct of the plain-copy baseline on the same channel.
+
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+
+module tb_idma_mxperf
+  import idma_pkg::*;
+#(
+  parameter int unsigned DataWidth    = 64,
+  parameter int unsigned AddrWidth    = 32,
+  parameter int unsigned UserWidth    = 1,
+  parameter int unsigned AxiIdWidth   = 12,
+  parameter int unsigned TFLenWidth   = 32,
+  parameter int unsigned UtilSlackPct = 5
+);
+
+  localparam time TA = 1ns, TT = 9ns, TCK = 10ns;
+  localparam int unsigned StrbWidth = DataWidth / 8;
+
+  typedef logic [AddrWidth-1:0]  addr_t;
+  typedef logic [DataWidth-1:0]  data_t;
+  typedef logic [StrbWidth-1:0]  strb_t;
+  typedef logic [AxiIdWidth-1:0] id_t;
+  typedef logic [UserWidth-1:0]  user_t;
+  typedef logic [TFLenWidth-1:0] tf_len_t;
+
+  `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_chan_t, axi_w_chan_t, axi_ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(axi_rsp_t, axi_b_chan_t, axi_r_chan_t)
+
+  `IDMA_TYPEDEF_FULL_REQ_T(idma_req_t, id_t, addr_t, tf_len_t)
+  `IDMA_TYPEDEF_FULL_RSP_T(idma_rsp_t, addr_t)
+
+  typedef struct packed { axi_ar_chan_t ar_chan; } axi_read_meta_channel_t;
+  typedef struct packed { axi_read_meta_channel_t axi; } read_meta_channel_t;
+  typedef struct packed { axi_aw_chan_t aw_chan; } axi_write_meta_channel_t;
+  typedef struct packed { axi_write_meta_channel_t axi; } write_meta_channel_t;
+
+  logic clk, rst_n;
+  idma_req_t    idma_req;    logic req_valid, req_ready;
+  idma_rsp_t    idma_rsp;    logic rsp_valid, rsp_ready;
+  idma_eh_req_t idma_eh_req; logic eh_req_valid, eh_req_ready;
+  axi_req_t axi_read_req, axi_write_req, axi_req;
+  axi_rsp_t axi_read_rsp, axi_write_rsp, axi_rsp;
+  idma_busy_t busy;
+
+  assign idma_eh_req = '0;
+  assign eh_req_valid = 1'b0;
+
+  clk_rst_gen #(.ClkPeriod(TCK), .RstClkCycles(1)) i_clk_rst_gen (.clk_o(clk), .rst_no(rst_n));
+
+  axi_rw_join #(.axi_req_t(axi_req_t), .axi_resp_t(axi_rsp_t)) i_axi_rw_join (
+    .clk_i(clk), .rst_ni(rst_n),
+    .slv_read_req_i(axi_read_req),  .slv_read_resp_o(axi_read_rsp),
+    .slv_write_req_i(axi_write_req), .slv_write_resp_o(axi_write_rsp),
+    .mst_req_o(axi_req), .mst_resp_i(axi_rsp)
+  );
+
+  axi_sim_mem #(
+    .AddrWidth(AddrWidth), .DataWidth(DataWidth), .IdWidth(AxiIdWidth), .UserWidth(UserWidth),
+    .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .WarnUninitialized(1'b0), .ClearErrOnAccess(1'b1), .ApplDelay(TA), .AcqDelay(TT)
+  ) i_axi_sim_mem (
+    .clk_i(clk), .rst_ni(rst_n), .axi_req_i(axi_req), .axi_rsp_o(axi_rsp),
+    .mon_r_last_o(), .mon_r_beat_count_o(), .mon_r_user_o(), .mon_r_id_o(),
+    .mon_r_data_o(), .mon_r_addr_o(), .mon_r_valid_o(),
+    .mon_w_last_o(), .mon_w_beat_count_o(), .mon_w_user_o(), .mon_w_id_o(),
+    .mon_w_data_o(), .mon_w_addr_o(), .mon_w_valid_o()
+  );
+
+  idma_backend_rw_axi #(
+    .CombinedShifter(1'b0), .DataWidth(DataWidth), .AddrWidth(AddrWidth), .AxiIdWidth(AxiIdWidth),
+    .UserWidth(UserWidth), .TFLenWidth(TFLenWidth), .MaskInvalidData(1'b1), .BufferDepth(3),
+    .EnableCompute(1'b1),
+    .ComputeOps(idma_pkg::compute_enable_t'{mxquant: 1'b1, mxdequant: 1'b1, default: '0}),
+    .ComputeFullDuplex(1'b1),
+    .RAWCouplingAvail(1'b1), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
+    .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(StrbWidth), .MemSysDepth(0),
+    .idma_req_t(idma_req_t), .idma_rsp_t(idma_rsp_t), .idma_eh_req_t(idma_eh_req_t),
+    .idma_busy_t(idma_busy_t), .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .write_meta_channel_t(write_meta_channel_t), .read_meta_channel_t(read_meta_channel_t)
+  ) i_idma_backend (
+    .clk_i(clk), .rst_ni(rst_n), .testmode_i(1'b0),
+    .idma_req_i(idma_req), .req_valid_i(req_valid), .req_ready_o(req_ready),
+    .idma_rsp_o(idma_rsp), .rsp_valid_o(rsp_valid), .rsp_ready_i(rsp_ready),
+    .idma_eh_req_i(idma_eh_req), .eh_req_valid_i(eh_req_valid), .eh_req_ready_o(eh_req_ready),
+    .axi_read_req_o(axi_read_req), .axi_read_rsp_i(axi_read_rsp),
+    .axi_write_req_o(axi_write_req), .axi_write_rsp_i(axi_write_rsp), .busy_o(busy)
+  );
+
+  // per-channel handshake windows
+  longint cyc, r_beats, w_beats, r_first, r_last, w_first, w_last, rsp_cnt;
+  always @(posedge clk) begin
+    cyc <= cyc + 1;
+    if (axi_rsp.r_valid && axi_req.r_ready) begin
+      if (r_beats == 0) r_first <= cyc;
+      r_last  <= cyc;
+      r_beats <= r_beats + 1;
+    end
+    if (axi_req.w_valid && axi_rsp.w_ready) begin
+      if (w_beats == 0) w_first <= cyc;
+      w_last  <= cyc;
+      w_beats <= w_beats + 1;
+    end
+    if (rsp_valid && rsp_ready) rsp_cnt <= rsp_cnt + 1;
+  end
+
+  function automatic int unsigned util_pct(input longint beats, input longint first,
+                                           input longint last);
+    return (last > first) ? int'(100 * beats / (last - first + 1)) : 100;
+  endfunction
+
+  task automatic do_xfer(input addr_t src, input addr_t dst, input int unsigned L,
+                         input logic en, input idma_pkg::compute_op_e op);
+    idma_req = '0;
+    idma_req.length   = tf_len_t'(L);
+    idma_req.src_addr = src;
+    idma_req.dst_addr = dst;
+    idma_req.opt.src_protocol = idma_pkg::AXI;
+    idma_req.opt.dst_protocol = idma_pkg::AXI;
+    idma_req.opt.src.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.dst.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.beo.decouple_rw = 1'b1;
+    idma_req.opt.beo.decouple_aw = 1'b1;
+    idma_req.opt.compute.enable  = en;
+    idma_req.opt.compute.op      = op;
+    idma_req.opt.last            = 1'b1;
+    req_valid = 1'b1;
+    do @(posedge clk); while (!req_ready);
+    req_valid = 1'b0;
+    idma_req = '0;
+    while (!(rsp_valid && rsp_ready)) @(posedge clk);
+    repeat (20) @(posedge clk);
+  endtask
+
+  task automatic measure(input string name, input addr_t src, input addr_t dst,
+                         input int unsigned L, input logic en, input idma_pkg::compute_op_e op,
+                         output int unsigned r_util, output int unsigned w_util);
+    r_beats = 0; w_beats = 0; r_first = 0; r_last = 0; w_first = 0; w_last = 0;
+    do_xfer(src, dst, L, en, op);
+    r_util = util_pct(r_beats, r_first, r_last);
+    w_util = util_pct(w_beats, w_first, w_last);
+    $display("[MXPF] %-12s R %3d%% (%0d beats)  W %3d%% (%0d beats)  StrbWidth=%0d",
+             name, r_util, r_beats, w_util, w_beats, StrbWidth);
+  endtask
+
+  // pipelined issue: req_valid stays high across the K transfers, one rsp per transfer
+  task automatic measure_b2b(input string name, input addr_t src, input addr_t dst,
+                             input int unsigned L, input int unsigned K,
+                             input logic en, input idma_pkg::compute_op_e op,
+                             output int unsigned r_util, output int unsigned w_util);
+    r_beats = 0; w_beats = 0; r_first = 0; r_last = 0; w_first = 0; w_last = 0; rsp_cnt = 0;
+    for (int unsigned k = 0; k < K; k++) begin
+      idma_req = '0;
+      idma_req.length   = tf_len_t'(L);
+      idma_req.src_addr = src;
+      idma_req.dst_addr = dst + k * 'h0001_0000;
+      idma_req.opt.src_protocol = idma_pkg::AXI;
+      idma_req.opt.dst_protocol = idma_pkg::AXI;
+      idma_req.opt.src.burst    = axi_pkg::BURST_INCR;
+      idma_req.opt.dst.burst    = axi_pkg::BURST_INCR;
+      idma_req.opt.beo.decouple_rw = 1'b1;
+      idma_req.opt.beo.decouple_aw = 1'b1;
+      idma_req.opt.compute.enable  = en;
+      idma_req.opt.compute.op      = op;
+      idma_req.opt.last            = 1'b1;
+      req_valid = 1'b1;
+      do @(posedge clk); while (!req_ready);
+    end
+    req_valid = 1'b0;
+    idma_req = '0;
+    while (rsp_cnt < K) @(posedge clk);
+    repeat (20) @(posedge clk);
+    r_util = util_pct(r_beats, r_first, r_last);
+    w_util = util_pct(w_beats, w_first, w_last);
+    $display("[MXPF] %-12s R %3d%% (%0d beats)  W %3d%% (%0d beats)  StrbWidth=%0d",
+             name, r_util, r_beats, w_util, w_beats, StrbWidth);
+  endtask
+
+  localparam addr_t Src = 'h0010_0000, Dst = 'h0090_0000;
+  localparam int unsigned NbQ  = 512;
+  localparam int unsigned NbDq = 8 * StrbWidth;
+  localparam int unsigned NbB2b  = 128;
+  localparam int unsigned NbDqB2b = 2 * StrbWidth;
+  localparam int unsigned KB2b = 8;
+
+  initial begin
+    automatic int unsigned cp_r, cp_w, q32_r, q32_w, q16_r, q16_w, dq_r, dq_w;
+    automatic int unsigned bcp_r, bcp_w, bq_r, bq_w, bdq_r, bdq_w;
+    automatic int unsigned errs = 0;
+    req_valid = 1'b0; rsp_ready = 1'b1; idma_req = '0;
+    for (int unsigned i = 0; i < NbQ * 128; i++) i_axi_sim_mem.mem[Src + i] = 8'(i * 61 + 7);
+    @(posedge rst_n);
+    repeat (5) @(posedge clk);
+
+    measure("copy",        Src, Dst, NbQ * 128, 1'b0, idma_pkg::COMPUTE_NONE,      cp_r,  cp_w);
+    measure("mxquant32",   Src, Dst, NbQ * 128, 1'b1, idma_pkg::COMPUTE_MXQUANT,   q32_r, q32_w);
+    if (StrbWidth <= 64)
+      measure("mxquant16", Src, Dst, NbQ * 64,  1'b1, idma_pkg::COMPUTE_MXQUANT_FP16, q16_r, q16_w);
+    else begin q16_r = cp_r; q16_w = 100; end
+    measure("mxdequant",   Src, Dst, NbDq * 33, 1'b1, idma_pkg::COMPUTE_MXDEQUANT, dq_r,  dq_w);
+
+    // pipelined back-to-back streams: aggregate window includes inter-transfer boundaries
+    measure_b2b("b2b-copy",    Src, Dst, NbB2b * 128,  KB2b, 1'b0,
+                idma_pkg::COMPUTE_NONE,      bcp_r, bcp_w);
+    measure_b2b("b2b-quant32", Src, Dst, NbB2b * 128,  KB2b, 1'b1,
+                idma_pkg::COMPUTE_MXQUANT,   bq_r,  bq_w);
+    measure_b2b("b2b-dequant", Src, Dst, NbDqB2b * 33, KB2b, 1'b1,
+                idma_pkg::COMPUTE_MXDEQUANT, bdq_r, bdq_w);
+
+    // quant is read-bound, dequant write-bound; compare against the copy baseline
+    if (q32_r + UtilSlackPct < cp_r) begin
+      errs++; $display("[MXPF] FAIL mxquant32 R %0d%% vs copy %0d%%", q32_r, cp_r);
+    end
+    if (q16_r + UtilSlackPct < cp_r) begin
+      errs++; $display("[MXPF] FAIL mxquant16 R %0d%% vs copy %0d%%", q16_r, cp_r);
+    end
+    if (dq_w + UtilSlackPct < cp_w) begin
+      errs++; $display("[MXPF] FAIL mxdequant W %0d%% vs copy %0d%%", dq_w, cp_w);
+    end
+    // no bubbles between transfers on the wide configs (512b/1024b targets)
+    if (StrbWidth >= 64) begin
+      if (bq_r + UtilSlackPct < bcp_r) begin
+        errs++; $display("[MXPF] FAIL b2b-quant32 R %0d%% vs b2b-copy %0d%%", bq_r, bcp_r);
+      end
+      if (bdq_w + UtilSlackPct < bcp_w) begin
+        errs++; $display("[MXPF] FAIL b2b-dequant W %0d%% vs b2b-copy %0d%%", bdq_w, bcp_w);
+      end
+    end
+
+    if (errs == 0) $display("[MXPF] ALL PASS (StrbWidth=%0d)", StrbWidth);
+    else           $fatal(1, "[MXPF] FAIL: %0d utilization regressions", errs);
+    repeat (5) @(posedge clk);
+    $finish();
+  end
+
+  initial begin #400_000_000; $fatal(1, "[MXPF] timeout"); end
+
+endmodule

--- a/test/tb_idma_mxquant.sv
+++ b/test/tb_idma_mxquant.sv
@@ -125,8 +125,16 @@ module tb_idma_mxquant
     return sgn | exp | man;
   endfunction
 
-  // deterministic FP32 pattern; last 8 elements cover zero/subnormal/Inf/NaN/max
+  // deterministic FP32 pattern; block 0 all-tiny (scale clamp), block 1 Inf/NaN
+  // poisoned with finite lanes (scale-scan exclusion), last 8 elements specials
   function automatic logic [31:0] fp32_gen(input int unsigned e, input int unsigned total);
+    if (e < 32)
+      return 32'((e & 1) << 31) | 32'(((1 + (e % 13)) & 8'hFF) << 23) | 32'((e * 977) & 23'h7FFFFF);
+    if (e < 64) begin
+      if (e == 32) return 32'h7F80_0000;
+      if (e == 33) return 32'hFFC0_0001;
+      return 32'((e & 1) << 31) | 32'(((100 + (e % 30)) & 8'hFF) << 23) | 32'((e * 331) & 23'h7FFFFF);
+    end
     if (e + 8 >= total) begin
       unique case (e % 8)
         0: return 32'h0000_0000;

--- a/test/tb_idma_mxquant.sv
+++ b/test/tb_idma_mxquant.sv
@@ -1,0 +1,252 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// End-to-end FP16 -> MXFP8 quantization test: COMPUTE_MXQUANT_FP16 drives
+// 64B (32 FP16 elems) -> 33B (E8M0 scale + 32 E5M2) blocks through the rw_axi
+// backend. Checked byte-exact against the DPI-C golden (idma_mxquant_dpi.c).
+// Watchdogs surface a hang; one run crosses a 4K page boundary.
+
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+
+module tb_idma_mxquant
+  import idma_pkg::*;
+#(
+  parameter int unsigned DataWidth  = 64,
+  parameter int unsigned AddrWidth  = 32,
+  parameter int unsigned UserWidth  = 1,
+  parameter int unsigned AxiIdWidth = 12,
+  parameter int unsigned TFLenWidth = 32
+);
+
+  import "DPI-C" function void gm_load(input int idx, input int val);
+  import "DPI-C" function void gm_mxquant(input int num_blocks);
+  import "DPI-C" function void gm_mxquant_fp32(input int num_blocks);
+  import "DPI-C" function int  gm_get(input int idx);
+
+  localparam time TA = 1ns, TT = 9ns, TCK = 10ns;
+  localparam int unsigned StrbWidth = DataWidth / 8;
+  localparam int unsigned BlkInBytes  = 64; // 32 FP16 elems
+  localparam int unsigned BlkOutBytes = 33;
+
+  typedef logic [AddrWidth-1:0]  addr_t;
+  typedef logic [DataWidth-1:0]  data_t;
+  typedef logic [StrbWidth-1:0]  strb_t;
+  typedef logic [AxiIdWidth-1:0] id_t;
+  typedef logic [UserWidth-1:0]  user_t;
+  typedef logic [TFLenWidth-1:0] tf_len_t;
+
+  `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_chan_t, axi_w_chan_t, axi_ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(axi_rsp_t, axi_b_chan_t, axi_r_chan_t)
+
+  `IDMA_TYPEDEF_FULL_REQ_T(idma_req_t, id_t, addr_t, tf_len_t)
+  `IDMA_TYPEDEF_FULL_RSP_T(idma_rsp_t, addr_t)
+
+  typedef struct packed { axi_ar_chan_t ar_chan; } axi_read_meta_channel_t;
+  typedef struct packed { axi_read_meta_channel_t axi; } read_meta_channel_t;
+  typedef struct packed { axi_aw_chan_t aw_chan; } axi_write_meta_channel_t;
+  typedef struct packed { axi_write_meta_channel_t axi; } write_meta_channel_t;
+
+  logic clk, rst_n;
+  idma_req_t    idma_req;    logic req_valid, req_ready;
+  idma_rsp_t    idma_rsp;    logic rsp_valid, rsp_ready;
+  idma_eh_req_t idma_eh_req; logic eh_req_valid, eh_req_ready;
+  axi_req_t axi_read_req, axi_write_req, axi_req, axi_req_mem;
+  axi_rsp_t axi_read_rsp, axi_write_rsp, axi_rsp, axi_rsp_mem;
+  idma_busy_t busy;
+
+  assign idma_eh_req = '0;
+  assign eh_req_valid = 1'b0;
+
+  clk_rst_gen #(.ClkPeriod(TCK), .RstClkCycles(1)) i_clk_rst_gen (.clk_o(clk), .rst_no(rst_n));
+
+  axi_rw_join #(.axi_req_t(axi_req_t), .axi_resp_t(axi_rsp_t)) i_axi_rw_join (
+    .clk_i(clk), .rst_ni(rst_n),
+    .slv_read_req_i(axi_read_req),  .slv_read_resp_o(axi_read_rsp),
+    .slv_write_req_i(axi_write_req), .slv_write_resp_o(axi_write_rsp),
+    .mst_req_o(axi_req), .mst_resp_i(axi_rsp)
+  );
+  assign axi_req_mem = axi_req;
+  assign axi_rsp     = axi_rsp_mem;
+
+  axi_sim_mem #(
+    .AddrWidth(AddrWidth), .DataWidth(DataWidth), .IdWidth(AxiIdWidth), .UserWidth(UserWidth),
+    .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .WarnUninitialized(1'b0), .ClearErrOnAccess(1'b1), .ApplDelay(TA), .AcqDelay(TT)
+  ) i_axi_sim_mem (
+    .clk_i(clk), .rst_ni(rst_n), .axi_req_i(axi_req_mem), .axi_rsp_o(axi_rsp_mem),
+    .mon_r_last_o(), .mon_r_beat_count_o(), .mon_r_user_o(), .mon_r_id_o(),
+    .mon_r_data_o(), .mon_r_addr_o(), .mon_r_valid_o(),
+    .mon_w_last_o(), .mon_w_beat_count_o(), .mon_w_user_o(), .mon_w_id_o(),
+    .mon_w_data_o(), .mon_w_addr_o(), .mon_w_valid_o()
+  );
+
+  idma_backend_rw_axi #(
+    .CombinedShifter(1'b0), .DataWidth(DataWidth), .AddrWidth(AddrWidth), .AxiIdWidth(AxiIdWidth),
+    .UserWidth(UserWidth), .TFLenWidth(TFLenWidth), .MaskInvalidData(1'b1), .BufferDepth(3),
+    .EnableCompute(1'b1), .ComputeOps(idma_pkg::compute_enable_t'{mxquant: 1'b1, default: '0}),
+    .ComputeFullDuplex(1'b1),
+    .RAWCouplingAvail(1'b1), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
+    .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(StrbWidth), .MemSysDepth(0),
+    .idma_req_t(idma_req_t), .idma_rsp_t(idma_rsp_t), .idma_eh_req_t(idma_eh_req_t),
+    .idma_busy_t(idma_busy_t), .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .write_meta_channel_t(write_meta_channel_t), .read_meta_channel_t(read_meta_channel_t)
+  ) i_idma_backend (
+    .clk_i(clk), .rst_ni(rst_n), .testmode_i(1'b0),
+    .idma_req_i(idma_req), .req_valid_i(req_valid), .req_ready_o(req_ready),
+    .idma_rsp_o(idma_rsp), .rsp_valid_o(rsp_valid), .rsp_ready_i(rsp_ready),
+    .idma_eh_req_i(idma_eh_req), .eh_req_valid_i(eh_req_valid), .eh_req_ready_o(eh_req_ready),
+    .axi_read_req_o(axi_read_req), .axi_read_rsp_i(axi_read_rsp),
+    .axi_write_req_o(axi_write_req), .axi_write_rsp_i(axi_write_rsp), .busy_o(busy)
+  );
+
+  stream_watchdog #(.NumCycles(8000)) i_r_wd (.clk_i(clk), .rst_ni(rst_n), .valid_i(axi_rsp.r_valid), .ready_i(axi_req.r_ready));
+  stream_watchdog #(.NumCycles(8000)) i_w_wd (.clk_i(clk), .rst_ni(rst_n), .valid_i(axi_req.w_valid), .ready_i(axi_rsp.w_ready));
+
+  task automatic wr_mem(input addr_t a, input logic [7:0] d); i_axi_sim_mem.mem[a] = d; endtask
+  function automatic logic [7:0] rd_mem(input addr_t a);
+    return i_axi_sim_mem.mem.exists(a) ? i_axi_sim_mem.mem[a] : 8'hxx;
+  endfunction
+
+  // deterministic FP16 normal for global element index e
+  function automatic logic [15:0] fp16_gen(input int unsigned e);
+    automatic logic [15:0] sgn = 16'((e & 1) << 15);
+    automatic logic [15:0] exp = 16'((1 + (e % 30)) << 10);
+    automatic logic [15:0] man = 16'((e * 53) & 10'h3FF);
+    return sgn | exp | man;
+  endfunction
+
+  // deterministic FP32 pattern; last 8 elements cover zero/subnormal/Inf/NaN/max
+  function automatic logic [31:0] fp32_gen(input int unsigned e, input int unsigned total);
+    if (e + 8 >= total) begin
+      unique case (e % 8)
+        0: return 32'h0000_0000;
+        1: return 32'h8000_0000;
+        2: return 32'h0000_0345;
+        3: return 32'h7F80_0000;
+        4: return 32'hFF80_0000;
+        5: return 32'h7FC1_2345;
+        6: return 32'h7F7F_FFFF;
+        7: return 32'h0080_0000;
+      endcase
+    end
+    return 32'((e & 1) << 31) | 32'(((64 + (e % 128)) & 8'hFF) << 23) | 32'((e * 2654435761) & 23'h7FFFFF);
+  endfunction
+
+  // one num_blocks FP16->MXFP8 transfer; returns error count
+  task automatic do_mxquant(input addr_t src, input addr_t dst, input int unsigned num_blocks,
+                            output int unsigned errs);
+    automatic int unsigned L  = num_blocks * BlkInBytes;
+    automatic int unsigned WL = num_blocks * BlkOutBytes;
+    automatic logic [15:0] h;
+    errs = 0;
+    for (int unsigned el = 0; el < num_blocks*32; el++) begin
+      h = fp16_gen(el);
+      wr_mem(src + el*2,     h[7:0]);
+      wr_mem(src + el*2 + 1, h[15:8]);
+      gm_load(int'(el*2),     int'(h[7:0]));
+      gm_load(int'(el*2 + 1), int'(h[15:8]));
+    end
+    gm_mxquant(int'(num_blocks));
+    for (int unsigned i = 0; i < WL; i++) wr_mem(dst + i, 8'hA5);
+    idma_req = '0;
+    idma_req.length   = tf_len_t'(L);
+    idma_req.src_addr = src;
+    idma_req.dst_addr = dst;
+    idma_req.opt.src_protocol = idma_pkg::AXI;
+    idma_req.opt.dst_protocol = idma_pkg::AXI;
+    idma_req.opt.src.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.dst.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.beo.decouple_rw = 1'b1;
+    idma_req.opt.beo.decouple_aw = 1'b1;
+    idma_req.opt.compute.enable  = 1'b1;
+    idma_req.opt.compute.op      = idma_pkg::COMPUTE_MXQUANT_FP16;
+    idma_req.opt.last            = 1'b1;
+    req_valid = 1'b1;
+    do @(posedge clk); while (!req_ready);
+    req_valid = 1'b0;
+    idma_req = '0;
+    while (!(rsp_valid && rsp_ready)) @(posedge clk);
+    repeat (20) @(posedge clk);
+    for (int unsigned i = 0; i < WL; i++)
+      if (rd_mem(dst + i) !== 8'(gm_get(int'(i)))) begin
+        errs++; if (errs <= 8) $display("[MXQ] dst[%0d] blk%0d.%0d = %02h exp %02h",
+                                        i, i/BlkOutBytes, i%BlkOutBytes, rd_mem(dst+i), 8'(gm_get(int'(i))));
+      end
+  endtask
+
+  // one num_blocks FP32->MXFP8 transfer; returns error count
+  task automatic do_mxquant_fp32(input addr_t src, input addr_t dst, input int unsigned num_blocks,
+                                 output int unsigned errs);
+    automatic int unsigned L  = num_blocks * 128;
+    automatic int unsigned WL = num_blocks * BlkOutBytes;
+    automatic logic [31:0] w;
+    errs = 0;
+    for (int unsigned el = 0; el < num_blocks*32; el++) begin
+      w = fp32_gen(el, num_blocks*32);
+      for (int unsigned b = 0; b < 4; b++) begin
+        wr_mem(src + el*4 + b, w[b*8 +: 8]);
+        gm_load(int'(el*4 + b), int'(w[b*8 +: 8]));
+      end
+    end
+    gm_mxquant_fp32(int'(num_blocks));
+    for (int unsigned i = 0; i < WL; i++) wr_mem(dst + i, 8'hA5);
+    idma_req = '0;
+    idma_req.length   = tf_len_t'(L);
+    idma_req.src_addr = src;
+    idma_req.dst_addr = dst;
+    idma_req.opt.src_protocol = idma_pkg::AXI;
+    idma_req.opt.dst_protocol = idma_pkg::AXI;
+    idma_req.opt.src.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.dst.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.beo.decouple_rw = 1'b1;
+    idma_req.opt.beo.decouple_aw = 1'b1;
+    idma_req.opt.compute.enable  = 1'b1;
+    idma_req.opt.compute.op      = idma_pkg::COMPUTE_MXQUANT;
+    idma_req.opt.last            = 1'b1;
+    req_valid = 1'b1;
+    do @(posedge clk); while (!req_ready);
+    req_valid = 1'b0;
+    idma_req = '0;
+    while (!(rsp_valid && rsp_ready)) @(posedge clk);
+    repeat (20) @(posedge clk);
+    for (int unsigned i = 0; i < WL; i++)
+      if (rd_mem(dst + i) !== 8'(gm_get(int'(i)))) begin
+        errs++; if (errs <= 8) $display("[MXQ] fp32 dst[%0d] blk%0d.%0d = %02h exp %02h",
+                                        i, i/BlkOutBytes, i%BlkOutBytes, rd_mem(dst+i), 8'(gm_get(int'(i))));
+      end
+  endtask
+
+  initial begin
+    automatic int unsigned total = 0, e1, e2, e3;
+    req_valid = 1'b0; rsp_ready = 1'b1; idma_req = '0;
+    @(posedge rst_n);
+    repeat (5) @(posedge clk);
+
+    if (StrbWidth <= 64) begin
+      do_mxquant('h0000_2000, 'h0000_4000, 8, e1);   // 8 blocks, aligned
+      do_mxquant('h0000_6000, 'h0000_0F80, 6, e2);   // write (198B) crosses 4K boundary
+    end else begin
+      e1 = 0; e2 = 0;                                // FP16 quant capped at StrbWidth 64
+    end
+    do_mxquant_fp32('h0000_A000, 'h0000_D000, 8, e3);
+    total = e1 + e2 + e3;
+
+    if (total == 0) $display("[MXQ] ALL PASS (StrbWidth=%0d)", StrbWidth);
+    else            $fatal(1, "[MXQ] FAIL: %0d mismatches", total);
+    repeat (5) @(posedge clk);
+    $finish();
+  end
+
+  initial begin #80_000_000; $fatal(1, "[MXQ] timeout"); end
+
+endmodule

--- a/test/tb_idma_mxrand.sv
+++ b/test/tb_idma_mxrand.sv
@@ -1,0 +1,341 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// Constrained-random MX compute campaign: back-to-back transfers with a random
+// op per iteration (FP16/FP32 quant, dequant, plain copy), random block counts
+// and beat-aligned addresses biased toward 4K-crossing writes, all through an
+// AXI shim that injects random per-channel stalls. Byte-exact against the DPI-C
+// golden; canary bytes around each destination catch out-of-bounds writes.
+
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+
+module tb_idma_mxrand
+  import idma_pkg::*;
+#(
+  parameter int unsigned DataWidth  = 64,
+  parameter int unsigned AddrWidth  = 32,
+  parameter int unsigned UserWidth  = 1,
+  parameter int unsigned AxiIdWidth = 12,
+  parameter int unsigned TFLenWidth = 32,
+  parameter int unsigned NumXfers   = 40,
+  parameter int unsigned StallPct   = 40
+);
+
+  import "DPI-C" function void gm_load(input int idx, input int val);
+  import "DPI-C" function void gm_mxquant(input int num_blocks);
+  import "DPI-C" function void gm_mxquant_fp32(input int num_blocks);
+  import "DPI-C" function void gm_mxdequant(input int num_blocks);
+  import "DPI-C" function int  gm_get(input int idx);
+
+  localparam time TA = 1ns, TT = 9ns, TCK = 10ns;
+  localparam int unsigned StrbWidth = DataWidth / 8;
+
+  typedef logic [AddrWidth-1:0]  addr_t;
+  typedef logic [DataWidth-1:0]  data_t;
+  typedef logic [StrbWidth-1:0]  strb_t;
+  typedef logic [AxiIdWidth-1:0] id_t;
+  typedef logic [UserWidth-1:0]  user_t;
+  typedef logic [TFLenWidth-1:0] tf_len_t;
+
+  `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_chan_t, axi_w_chan_t, axi_ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(axi_rsp_t, axi_b_chan_t, axi_r_chan_t)
+
+  `IDMA_TYPEDEF_FULL_REQ_T(idma_req_t, id_t, addr_t, tf_len_t)
+  `IDMA_TYPEDEF_FULL_RSP_T(idma_rsp_t, addr_t)
+
+  typedef struct packed { axi_ar_chan_t ar_chan; } axi_read_meta_channel_t;
+  typedef struct packed { axi_read_meta_channel_t axi; } read_meta_channel_t;
+  typedef struct packed { axi_aw_chan_t aw_chan; } axi_write_meta_channel_t;
+  typedef struct packed { axi_write_meta_channel_t axi; } write_meta_channel_t;
+
+  logic clk, rst_n;
+  idma_req_t    idma_req;    logic req_valid, req_ready;
+  idma_rsp_t    idma_rsp;    logic rsp_valid, rsp_ready;
+  idma_eh_req_t idma_eh_req; logic eh_req_valid, eh_req_ready;
+  axi_req_t axi_read_req, axi_write_req, axi_req, axi_req_mem;
+  axi_rsp_t axi_read_rsp, axi_write_rsp, axi_rsp, axi_rsp_mem;
+  idma_busy_t busy;
+
+  assign idma_eh_req = '0;
+  assign eh_req_valid = 1'b0;
+
+  clk_rst_gen #(.ClkPeriod(TCK), .RstClkCycles(1)) i_clk_rst_gen (.clk_o(clk), .rst_no(rst_n));
+
+  axi_rw_join #(.axi_req_t(axi_req_t), .axi_resp_t(axi_rsp_t)) i_axi_rw_join (
+    .clk_i(clk), .rst_ni(rst_n),
+    .slv_read_req_i(axi_read_req),  .slv_read_resp_o(axi_read_rsp),
+    .slv_write_req_i(axi_write_req), .slv_write_resp_o(axi_write_rsp),
+    .mst_req_o(axi_req), .mst_resp_i(axi_rsp)
+  );
+
+  // random-stall shim: a channel's go bit may rise any cycle but only falls after its handshake
+  logic aw_go, w_go, ar_go, b_go, r_go;
+  function automatic logic go_next(input logic go, input logic vld, input logic rdy);
+    if (go && vld && !rdy) return 1'b1;
+    return ($urandom_range(99) >= StallPct);
+  endfunction
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) {aw_go, w_go, ar_go, b_go, r_go} <= '0;
+    else begin
+      aw_go <= go_next(aw_go, axi_req.aw_valid,    axi_rsp_mem.aw_ready);
+      w_go  <= go_next(w_go,  axi_req.w_valid,     axi_rsp_mem.w_ready);
+      ar_go <= go_next(ar_go, axi_req.ar_valid,    axi_rsp_mem.ar_ready);
+      b_go  <= go_next(b_go,  axi_rsp_mem.b_valid, axi_req.b_ready);
+      r_go  <= go_next(r_go,  axi_rsp_mem.r_valid, axi_req.r_ready);
+    end
+  end
+  always_comb begin
+    axi_req_mem = axi_req;
+    axi_rsp     = axi_rsp_mem;
+    axi_req_mem.aw_valid = axi_req.aw_valid & aw_go;
+    axi_req_mem.w_valid  = axi_req.w_valid  & w_go;
+    axi_req_mem.ar_valid = axi_req.ar_valid & ar_go;
+    axi_req_mem.b_ready  = axi_req.b_ready  & b_go;
+    axi_req_mem.r_ready  = axi_req.r_ready  & r_go;
+    axi_rsp.aw_ready     = axi_rsp_mem.aw_ready & aw_go;
+    axi_rsp.w_ready      = axi_rsp_mem.w_ready  & w_go;
+    axi_rsp.ar_ready     = axi_rsp_mem.ar_ready & ar_go;
+    axi_rsp.b_valid      = axi_rsp_mem.b_valid  & b_go;
+    axi_rsp.r_valid      = axi_rsp_mem.r_valid  & r_go;
+  end
+
+  axi_sim_mem #(
+    .AddrWidth(AddrWidth), .DataWidth(DataWidth), .IdWidth(AxiIdWidth), .UserWidth(UserWidth),
+    .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .WarnUninitialized(1'b0), .ClearErrOnAccess(1'b1), .ApplDelay(TA), .AcqDelay(TT)
+  ) i_axi_sim_mem (
+    .clk_i(clk), .rst_ni(rst_n), .axi_req_i(axi_req_mem), .axi_rsp_o(axi_rsp_mem),
+    .mon_r_last_o(), .mon_r_beat_count_o(), .mon_r_user_o(), .mon_r_id_o(),
+    .mon_r_data_o(), .mon_r_addr_o(), .mon_r_valid_o(),
+    .mon_w_last_o(), .mon_w_beat_count_o(), .mon_w_user_o(), .mon_w_id_o(),
+    .mon_w_data_o(), .mon_w_addr_o(), .mon_w_valid_o()
+  );
+
+  idma_backend_rw_axi #(
+    .CombinedShifter(1'b0), .DataWidth(DataWidth), .AddrWidth(AddrWidth), .AxiIdWidth(AxiIdWidth),
+    .UserWidth(UserWidth), .TFLenWidth(TFLenWidth), .MaskInvalidData(1'b1), .BufferDepth(3),
+    .EnableCompute(1'b1),
+    .ComputeOps(idma_pkg::compute_enable_t'{mxquant: 1'b1, mxdequant: 1'b1, default: '0}),
+    .ComputeFullDuplex(1'b1),
+    .RAWCouplingAvail(1'b1), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
+    .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(StrbWidth), .MemSysDepth(0),
+    .idma_req_t(idma_req_t), .idma_rsp_t(idma_rsp_t), .idma_eh_req_t(idma_eh_req_t),
+    .idma_busy_t(idma_busy_t), .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .write_meta_channel_t(write_meta_channel_t), .read_meta_channel_t(read_meta_channel_t)
+  ) i_idma_backend (
+    .clk_i(clk), .rst_ni(rst_n), .testmode_i(1'b0),
+    .idma_req_i(idma_req), .req_valid_i(req_valid), .req_ready_o(req_ready),
+    .idma_rsp_o(idma_rsp), .rsp_valid_o(rsp_valid), .rsp_ready_i(rsp_ready),
+    .idma_eh_req_i(idma_eh_req), .eh_req_valid_i(eh_req_valid), .eh_req_ready_o(eh_req_ready),
+    .axi_read_req_o(axi_read_req), .axi_read_rsp_i(axi_read_rsp),
+    .axi_write_req_o(axi_write_req), .axi_write_rsp_i(axi_write_rsp), .busy_o(busy)
+  );
+
+  int unsigned rsp_cnt;
+  always @(posedge clk) if (rsp_valid && rsp_ready) rsp_cnt <= rsp_cnt + 1;
+
+  task automatic wr_mem(input addr_t a, input logic [7:0] d); i_axi_sim_mem.mem[a] = d; endtask
+  function automatic logic [7:0] rd_mem(input addr_t a);
+    return i_axi_sim_mem.mem.exists(a) ? i_axi_sim_mem.mem[a] : 8'hxx;
+  endfunction
+
+  function automatic logic [15:0] fp16_gen(input int unsigned e);
+    automatic logic [15:0] sgn = 16'((e & 1) << 15);
+    automatic logic [15:0] exp = 16'((1 + (e % 30)) << 10);
+    automatic logic [15:0] man = 16'((e * 53) & 10'h3FF);
+    return sgn | exp | man;
+  endfunction
+
+  function automatic logic [31:0] fp32_gen(input int unsigned e);
+    automatic logic [31:0] sgn = 32'((e & 1) << 31);
+    automatic logic [31:0] exp = 32'(((64 + (e % 128)) & 8'hFF) << 23);
+    automatic logic [31:0] man = 32'((e * 2654435761) & 23'h7FFFFF);
+    return sgn | exp | man;
+  endfunction
+
+  task automatic do_xfer(input addr_t src, input addr_t dst, input int unsigned L,
+                         input logic en, input idma_pkg::compute_op_e op);
+    idma_req = '0;
+    idma_req.length   = tf_len_t'(L);
+    idma_req.src_addr = src;
+    idma_req.dst_addr = dst;
+    idma_req.opt.src_protocol = idma_pkg::AXI;
+    idma_req.opt.dst_protocol = idma_pkg::AXI;
+    idma_req.opt.src.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.dst.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.beo.decouple_rw = 1'b1;
+    idma_req.opt.beo.decouple_aw = 1'b1;
+    idma_req.opt.compute.enable  = en;
+    idma_req.opt.compute.op      = op;
+    idma_req.opt.last            = 1'b1;
+    req_valid = 1'b1;
+    do @(posedge clk); while (!req_ready);
+    req_valid = 1'b0;
+    idma_req = '0;
+    while (!(rsp_valid && rsp_ready)) @(posedge clk);
+    repeat (10) @(posedge clk);
+  endtask
+
+  localparam addr_t SrcBase = 'h0001_0000, DstBase = 'h0009_0000;
+  localparam int unsigned Margin = 64;
+
+  initial begin
+    automatic int unsigned errs = 0;
+    automatic logic [7:0]  golden [0:1023];
+    automatic logic [15:0] h;
+    automatic logic [31:0] w;
+    automatic addr_t src, dst;
+    automatic int unsigned op, nb, L, WL, salt;
+    automatic bit fp16;
+    req_valid = 1'b0; rsp_ready = 1'b1; idma_req = '0;
+    @(posedge rst_n);
+    repeat (5) @(posedge clk);
+
+    for (int unsigned x = 0; x < NumXfers; x++) begin
+      salt = x * 4099;
+      op = $urandom_range(2);
+      case (op)
+        0: begin  // plain copy, arbitrary alignment, compute idle
+          L  = $urandom_range(1, 1000); WL = L;
+          src = SrcBase + $urandom_range(4095);
+          dst = DstBase + $urandom_range(4095);
+          for (int unsigned i = 0; i < L; i++) begin
+            golden[i] = 8'((salt + i * 131) ^ (i >> 3));
+            wr_mem(src + i, golden[i]);
+          end
+        end
+        1: begin  // MX quant, FP16 below 1024b else FP32, dst biased toward 4K crossings
+          fp16 = (StrbWidth <= 64) && $urandom_range(1);
+          nb   = $urandom_range(1, 24);
+          L    = nb * (fp16 ? 64 : 128); WL = nb * 33;
+          src  = SrcBase + StrbWidth * $urandom_range(4096 / StrbWidth - 1);
+          dst  = $urandom_range(1) ? DstBase + 'h1000 - StrbWidth * $urandom_range(1, 4)
+                                   : DstBase + StrbWidth * $urandom_range(4096 / StrbWidth - 1);
+          for (int unsigned el = 0; el < nb * 32; el++) begin
+            if (fp16) begin
+              h = fp16_gen(salt + el);
+              for (int unsigned b = 0; b < 2; b++) begin
+                wr_mem(src + el*2 + b, h[b*8 +: 8]); gm_load(int'(el*2 + b), int'(h[b*8 +: 8]));
+              end
+            end else begin
+              w = fp32_gen(salt + el);
+              for (int unsigned b = 0; b < 4; b++) begin
+                wr_mem(src + el*4 + b, w[b*8 +: 8]); gm_load(int'(el*4 + b), int'(w[b*8 +: 8]));
+              end
+            end
+          end
+          if (fp16) gm_mxquant(int'(nb)); else gm_mxquant_fp32(int'(nb));
+        end
+        default: begin  // MX dequant, k blocks with k % StrbWidth == 0
+          nb = StrbWidth * ((StrbWidth >= 64) ? 1 : $urandom_range(1, 2));
+          L  = nb * 33; WL = nb * 128;
+          src = SrcBase + StrbWidth * $urandom_range(4096 / StrbWidth - 1);
+          dst = DstBase + StrbWidth * $urandom_range(4096 / StrbWidth - 1);
+          for (int unsigned i = 0; i < L; i++) begin
+            wr_mem(src + i, 8'((salt + i * 197) ^ (i >> 2)));
+            gm_load(int'(i), int'(8'((salt + i * 197) ^ (i >> 2))));
+          end
+          gm_mxdequant(int'(nb));
+        end
+      endcase
+
+      for (int unsigned i = 0; i < WL + 2 * Margin; i++) wr_mem(dst - Margin + i, 8'hC5);
+
+      case (op)
+        0:       do_xfer(src, dst, L, 1'b0, idma_pkg::COMPUTE_NONE);
+        1:       do_xfer(src, dst, L, 1'b1,
+                         fp16 ? idma_pkg::COMPUTE_MXQUANT_FP16 : idma_pkg::COMPUTE_MXQUANT);
+        default: do_xfer(src, dst, L, 1'b1, idma_pkg::COMPUTE_MXDEQUANT);
+      endcase
+
+      for (int unsigned i = 0; i < WL; i++) begin
+        automatic logic [7:0] exp_b = (op == 0) ? golden[i] : 8'(gm_get(int'(i)));
+        if (rd_mem(dst + i) !== exp_b) begin
+          errs++;
+          if (errs <= 8) $display("[MXRD] x%0d op%0d dst[%0d]=%02h exp %02h",
+                                  x, op, i, rd_mem(dst + i), exp_b);
+        end
+      end
+      for (int unsigned i = 0; i < Margin; i++) begin
+        if (rd_mem(dst - Margin + i) !== 8'hC5 || rd_mem(dst + WL + i) !== 8'hC5) begin
+          errs++;
+          if (errs <= 8) $display("[MXRD] x%0d op%0d canary hit near dst=%08h WL=%0d", x, op, dst, WL);
+        end
+      end
+    end
+
+    // pipelined same-config quant stream: lane-exact tail retire across transfer boundaries
+    begin
+      localparam int unsigned BK = 6, BNb = 24;
+      automatic logic [7:0] bgold [BK][BNb*33];
+      for (int unsigned k = 0; k < BK; k++) begin
+        for (int unsigned el = 0; el < BNb * 32; el++) begin
+          w = fp32_gen(k * 7919 + el);
+          for (int unsigned b = 0; b < 4; b++) begin
+            wr_mem(SrcBase + k * 'h2000 + el*4 + b, w[b*8 +: 8]);
+            gm_load(int'(el*4 + b), int'(w[b*8 +: 8]));
+          end
+        end
+        gm_mxquant_fp32(int'(BNb));
+        for (int unsigned i = 0; i < BNb * 33; i++) bgold[k][i] = 8'(gm_get(int'(i)));
+        for (int unsigned i = 0; i < BNb * 33 + 2 * Margin; i++)
+          wr_mem(DstBase + k * 'h2000 - Margin + i, 8'hC5);
+      end
+      rsp_cnt = 0;
+      for (int unsigned k = 0; k < BK; k++) begin
+        idma_req = '0;
+        idma_req.length   = tf_len_t'(BNb * 128);
+        idma_req.src_addr = SrcBase + k * 'h2000;
+        idma_req.dst_addr = DstBase + k * 'h2000;
+        idma_req.opt.src_protocol = idma_pkg::AXI;
+        idma_req.opt.dst_protocol = idma_pkg::AXI;
+        idma_req.opt.src.burst    = axi_pkg::BURST_INCR;
+        idma_req.opt.dst.burst    = axi_pkg::BURST_INCR;
+        idma_req.opt.beo.decouple_rw = 1'b1;
+        idma_req.opt.beo.decouple_aw = 1'b1;
+        idma_req.opt.compute.enable  = 1'b1;
+        idma_req.opt.compute.op      = idma_pkg::COMPUTE_MXQUANT;
+        idma_req.opt.last            = 1'b1;
+        req_valid = 1'b1;
+        do @(posedge clk); while (!req_ready);
+      end
+      req_valid = 1'b0;
+      idma_req = '0;
+      while (rsp_cnt < BK) @(posedge clk);
+      repeat (20) @(posedge clk);
+      for (int unsigned k = 0; k < BK; k++) begin
+        for (int unsigned i = 0; i < BNb * 33; i++)
+          if (rd_mem(DstBase + k * 'h2000 + i) !== bgold[k][i]) begin
+            errs++;
+            if (errs <= 8) $display("[MXRD] b2b k%0d dst[%0d]=%02h exp %02h",
+                                    k, i, rd_mem(DstBase + k * 'h2000 + i), bgold[k][i]);
+          end
+        for (int unsigned i = 0; i < Margin; i++)
+          if (rd_mem(DstBase + k * 'h2000 - Margin + i) !== 8'hC5 ||
+              rd_mem(DstBase + k * 'h2000 + BNb * 33 + i) !== 8'hC5) begin
+            errs++;
+            if (errs <= 8) $display("[MXRD] b2b k%0d canary hit", k);
+          end
+      end
+    end
+
+    if (errs == 0) $display("[MXRD] ALL PASS (%0d transfers, StrbWidth=%0d, StallPct=%0d)",
+                            NumXfers, StrbWidth, StallPct);
+    else           $fatal(1, "[MXRD] FAIL: %0d mismatches", errs);
+    repeat (5) @(posedge clk);
+    $finish();
+  end
+
+  initial begin #400_000_000; $fatal(1, "[MXRD] timeout"); end
+
+endmodule

--- a/test/tb_idma_mxrand.sv
+++ b/test/tb_idma_mxrand.sv
@@ -291,27 +291,38 @@ module tb_idma_mxrand
         for (int unsigned i = 0; i < BNb * 33 + 2 * Margin; i++)
           wr_mem(DstBase + k * 'h2000 - Margin + i, 8'hC5);
       end
+      for (int unsigned i = 0; i < 512; i++) begin
+        wr_mem(SrcBase + 'hC000 + i, 8'((i * 89 + 5) ^ (i >> 3)));
+        wr_mem(DstBase + 'hC000 + i, 8'hC5);
+      end
       rsp_cnt = 0;
-      for (int unsigned k = 0; k < BK; k++) begin
+      for (int unsigned k = 0; k <= BK; k++) begin
         idma_req = '0;
-        idma_req.length   = tf_len_t'(BNb * 128);
-        idma_req.src_addr = SrcBase + k * 'h2000;
-        idma_req.dst_addr = DstBase + k * 'h2000;
+        if (k < BK) begin
+          idma_req.length   = tf_len_t'(BNb * 128);
+          idma_req.src_addr = SrcBase + k * 'h2000;
+          idma_req.dst_addr = DstBase + k * 'h2000;
+          idma_req.opt.compute.enable = 1'b1;
+          idma_req.opt.compute.op     = idma_pkg::COMPUTE_MXQUANT;
+        end else begin
+          // different config issued pipelined: the hardware interlock must drain first
+          idma_req.length   = tf_len_t'(512);
+          idma_req.src_addr = SrcBase + 'hC000;
+          idma_req.dst_addr = DstBase + 'hC000;
+        end
         idma_req.opt.src_protocol = idma_pkg::AXI;
         idma_req.opt.dst_protocol = idma_pkg::AXI;
         idma_req.opt.src.burst    = axi_pkg::BURST_INCR;
         idma_req.opt.dst.burst    = axi_pkg::BURST_INCR;
         idma_req.opt.beo.decouple_rw = 1'b1;
         idma_req.opt.beo.decouple_aw = 1'b1;
-        idma_req.opt.compute.enable  = 1'b1;
-        idma_req.opt.compute.op      = idma_pkg::COMPUTE_MXQUANT;
         idma_req.opt.last            = 1'b1;
         req_valid = 1'b1;
         do @(posedge clk); while (!req_ready);
       end
       req_valid = 1'b0;
       idma_req = '0;
-      while (rsp_cnt < BK) @(posedge clk);
+      while (rsp_cnt < BK + 1) @(posedge clk);
       repeat (20) @(posedge clk);
       for (int unsigned k = 0; k < BK; k++) begin
         for (int unsigned i = 0; i < BNb * 33; i++)
@@ -327,6 +338,11 @@ module tb_idma_mxrand
             if (errs <= 8) $display("[MXRD] b2b k%0d canary hit", k);
           end
       end
+      for (int unsigned i = 0; i < 512; i++)
+        if (rd_mem(DstBase + 'hC000 + i) !== 8'((i * 89 + 5) ^ (i >> 3))) begin
+          errs++;
+          if (errs <= 8) $display("[MXRD] interlock copy dst[%0d] wrong", i);
+        end
     end
 
     if (errs == 0) $display("[MXRD] ALL PASS (%0d transfers, StrbWidth=%0d, StallPct=%0d)",

--- a/test/tb_idma_mxroundtrip.sv
+++ b/test/tb_idma_mxroundtrip.sv
@@ -1,0 +1,220 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// MX roundtrip: COMPUTE_MXQUANT_FP16 (src -> mid, 64B -> 33B blocks) followed
+// back-to-back by COMPUTE_MXDEQUANT (mid -> dst, 33B -> 128B) through one
+// rw_axi backend. Both stages checked byte-exact against the DPI-C golden
+// (idma_mxquant_dpi.c); quant->dequant is thus the exact E5M2 identity.
+
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+
+module tb_idma_mxroundtrip
+  import idma_pkg::*;
+#(
+  parameter int unsigned DataWidth  = 64,
+  parameter int unsigned AddrWidth  = 32,
+  parameter int unsigned UserWidth  = 1,
+  parameter int unsigned AxiIdWidth = 12,
+  parameter int unsigned TFLenWidth = 32
+);
+
+  import "DPI-C" function void gm_load(input int idx, input int val);
+  import "DPI-C" function void gm_mxquant(input int num_blocks);
+  import "DPI-C" function void gm_mxquant_fp32(input int num_blocks);
+  import "DPI-C" function void gm_mxdequant(input int num_blocks);
+  import "DPI-C" function int  gm_get(input int idx);
+
+  localparam time TA = 1ns, TT = 9ns, TCK = 10ns;
+  localparam int unsigned StrbWidth = DataWidth / 8;
+  localparam int unsigned NumBlocks = 2 * StrbWidth;  // k % StrbWidth == 0 for dequant
+
+  typedef logic [AddrWidth-1:0]  addr_t;
+  typedef logic [DataWidth-1:0]  data_t;
+  typedef logic [StrbWidth-1:0]  strb_t;
+  typedef logic [AxiIdWidth-1:0] id_t;
+  typedef logic [UserWidth-1:0]  user_t;
+  typedef logic [TFLenWidth-1:0] tf_len_t;
+
+  `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_chan_t, axi_w_chan_t, axi_ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(axi_rsp_t, axi_b_chan_t, axi_r_chan_t)
+
+  `IDMA_TYPEDEF_FULL_REQ_T(idma_req_t, id_t, addr_t, tf_len_t)
+  `IDMA_TYPEDEF_FULL_RSP_T(idma_rsp_t, addr_t)
+
+  typedef struct packed { axi_ar_chan_t ar_chan; } axi_read_meta_channel_t;
+  typedef struct packed { axi_read_meta_channel_t axi; } read_meta_channel_t;
+  typedef struct packed { axi_aw_chan_t aw_chan; } axi_write_meta_channel_t;
+  typedef struct packed { axi_write_meta_channel_t axi; } write_meta_channel_t;
+
+  logic clk, rst_n;
+  idma_req_t    idma_req;    logic req_valid, req_ready;
+  idma_rsp_t    idma_rsp;    logic rsp_valid, rsp_ready;
+  idma_eh_req_t idma_eh_req; logic eh_req_valid, eh_req_ready;
+  axi_req_t axi_read_req, axi_write_req, axi_req, axi_req_mem;
+  axi_rsp_t axi_read_rsp, axi_write_rsp, axi_rsp, axi_rsp_mem;
+  idma_busy_t busy;
+
+  assign idma_eh_req = '0;
+  assign eh_req_valid = 1'b0;
+
+  clk_rst_gen #(.ClkPeriod(TCK), .RstClkCycles(1)) i_clk_rst_gen (.clk_o(clk), .rst_no(rst_n));
+
+  axi_rw_join #(.axi_req_t(axi_req_t), .axi_resp_t(axi_rsp_t)) i_axi_rw_join (
+    .clk_i(clk), .rst_ni(rst_n),
+    .slv_read_req_i(axi_read_req),  .slv_read_resp_o(axi_read_rsp),
+    .slv_write_req_i(axi_write_req), .slv_write_resp_o(axi_write_rsp),
+    .mst_req_o(axi_req), .mst_resp_i(axi_rsp)
+  );
+  assign axi_req_mem = axi_req;
+  assign axi_rsp     = axi_rsp_mem;
+
+  axi_sim_mem #(
+    .AddrWidth(AddrWidth), .DataWidth(DataWidth), .IdWidth(AxiIdWidth), .UserWidth(UserWidth),
+    .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .WarnUninitialized(1'b0), .ClearErrOnAccess(1'b1), .ApplDelay(TA), .AcqDelay(TT)
+  ) i_axi_sim_mem (
+    .clk_i(clk), .rst_ni(rst_n), .axi_req_i(axi_req_mem), .axi_rsp_o(axi_rsp_mem),
+    .mon_r_last_o(), .mon_r_beat_count_o(), .mon_r_user_o(), .mon_r_id_o(),
+    .mon_r_data_o(), .mon_r_addr_o(), .mon_r_valid_o(),
+    .mon_w_last_o(), .mon_w_beat_count_o(), .mon_w_user_o(), .mon_w_id_o(),
+    .mon_w_data_o(), .mon_w_addr_o(), .mon_w_valid_o()
+  );
+
+  idma_backend_rw_axi #(
+    .CombinedShifter(1'b0), .DataWidth(DataWidth), .AddrWidth(AddrWidth), .AxiIdWidth(AxiIdWidth),
+    .UserWidth(UserWidth), .TFLenWidth(TFLenWidth), .MaskInvalidData(1'b1), .BufferDepth(3),
+    .EnableCompute(1'b1),
+    .ComputeOps(idma_pkg::compute_enable_t'{mxquant: 1'b1, mxdequant: 1'b1, default: '0}),
+    .ComputeFullDuplex(1'b1),
+    .RAWCouplingAvail(1'b1), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
+    .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(StrbWidth), .MemSysDepth(0),
+    .idma_req_t(idma_req_t), .idma_rsp_t(idma_rsp_t), .idma_eh_req_t(idma_eh_req_t),
+    .idma_busy_t(idma_busy_t), .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .write_meta_channel_t(write_meta_channel_t), .read_meta_channel_t(read_meta_channel_t)
+  ) i_idma_backend (
+    .clk_i(clk), .rst_ni(rst_n), .testmode_i(1'b0),
+    .idma_req_i(idma_req), .req_valid_i(req_valid), .req_ready_o(req_ready),
+    .idma_rsp_o(idma_rsp), .rsp_valid_o(rsp_valid), .rsp_ready_i(rsp_ready),
+    .idma_eh_req_i(idma_eh_req), .eh_req_valid_i(eh_req_valid), .eh_req_ready_o(eh_req_ready),
+    .axi_read_req_o(axi_read_req), .axi_read_rsp_i(axi_read_rsp),
+    .axi_write_req_o(axi_write_req), .axi_write_rsp_i(axi_write_rsp), .busy_o(busy)
+  );
+
+  stream_watchdog #(.NumCycles(8000)) i_r_wd (.clk_i(clk), .rst_ni(rst_n), .valid_i(axi_rsp.r_valid), .ready_i(axi_req.r_ready));
+  stream_watchdog #(.NumCycles(8000)) i_w_wd (.clk_i(clk), .rst_ni(rst_n), .valid_i(axi_req.w_valid), .ready_i(axi_rsp.w_ready));
+
+  task automatic wr_mem(input addr_t a, input logic [7:0] d); i_axi_sim_mem.mem[a] = d; endtask
+  function automatic logic [7:0] rd_mem(input addr_t a);
+    return i_axi_sim_mem.mem.exists(a) ? i_axi_sim_mem.mem[a] : 8'hxx;
+  endfunction
+
+  function automatic logic [15:0] fp16_gen(input int unsigned e);
+    automatic logic [15:0] sgn = 16'((e & 1) << 15);
+    automatic logic [15:0] exp = 16'((1 + (e % 30)) << 10);
+    automatic logic [15:0] man = 16'((e * 53) & 10'h3FF);
+    return sgn | exp | man;
+  endfunction
+
+  function automatic logic [31:0] fp32_gen(input int unsigned e);
+    automatic logic [31:0] sgn = 32'((e & 1) << 31);
+    automatic logic [31:0] exp = 32'(((64 + (e % 128)) & 8'hFF) << 23);
+    automatic logic [31:0] man = 32'((e * 2654435761) & 23'h7FFFFF);
+    return sgn | exp | man;
+  endfunction
+
+  task automatic do_xfer(input addr_t src, input addr_t dst, input int unsigned L,
+                         input idma_pkg::compute_op_e op);
+    idma_req = '0;
+    idma_req.length   = tf_len_t'(L);
+    idma_req.src_addr = src;
+    idma_req.dst_addr = dst;
+    idma_req.opt.src_protocol = idma_pkg::AXI;
+    idma_req.opt.dst_protocol = idma_pkg::AXI;
+    idma_req.opt.src.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.dst.burst    = axi_pkg::BURST_INCR;
+    idma_req.opt.beo.decouple_rw = 1'b1;
+    idma_req.opt.beo.decouple_aw = 1'b1;
+    idma_req.opt.compute.enable  = 1'b1;
+    idma_req.opt.compute.op      = op;
+    idma_req.opt.last            = 1'b1;
+    req_valid = 1'b1;
+    do @(posedge clk); while (!req_ready);
+    req_valid = 1'b0;
+    idma_req = '0;
+    while (!(rsp_valid && rsp_ready)) @(posedge clk);
+    repeat (20) @(posedge clk);
+  endtask
+
+  // FP16 quant leg up to StrbWidth 64 (512b); FP32 leg above (1024b)
+  localparam bit          QuantFp16 = StrbWidth <= 64;
+  localparam int unsigned QuantInBytes = QuantFp16 ? 64 : 128;
+
+  initial begin
+    automatic addr_t src = 'h0001_0000, mid = 'h0003_0000, dst = 'h0005_0000;
+    automatic int unsigned qL  = NumBlocks * QuantInBytes;
+    automatic int unsigned mL  = NumBlocks * 33;
+    automatic int unsigned dL  = NumBlocks * 128;
+    automatic int unsigned e1 = 0, e2 = 0;
+    automatic logic [15:0] h;
+    automatic logic [31:0] w;
+    req_valid = 1'b0; rsp_ready = 1'b1; idma_req = '0;
+    @(posedge rst_n);
+    repeat (5) @(posedge clk);
+
+    if (QuantFp16) begin
+      for (int unsigned el = 0; el < NumBlocks*32; el++) begin
+        h = fp16_gen(el);
+        wr_mem(src + el*2,     h[7:0]);
+        wr_mem(src + el*2 + 1, h[15:8]);
+        gm_load(int'(el*2),     int'(h[7:0]));
+        gm_load(int'(el*2 + 1), int'(h[15:8]));
+      end
+      gm_mxquant(int'(NumBlocks));
+    end else begin
+      for (int unsigned el = 0; el < NumBlocks*32; el++) begin
+        w = fp32_gen(el);
+        for (int unsigned b = 0; b < 4; b++) begin
+          wr_mem(src + el*4 + b, w[b*8 +: 8]);
+          gm_load(int'(el*4 + b), int'(w[b*8 +: 8]));
+        end
+      end
+      gm_mxquant_fp32(int'(NumBlocks));
+    end
+    for (int unsigned i = 0; i < mL; i++) wr_mem(mid + i, 8'hA5);
+    for (int unsigned i = 0; i < dL; i++) wr_mem(dst + i, 8'h5A);
+
+    do_xfer(src, mid, qL,
+            QuantFp16 ? idma_pkg::COMPUTE_MXQUANT_FP16 : idma_pkg::COMPUTE_MXQUANT);
+    for (int unsigned i = 0; i < mL; i++)
+      if (rd_mem(mid + i) !== 8'(gm_get(int'(i)))) begin
+        e1++; if (e1 <= 8) $display("[MXRT] quant mid[%0d]=%02h exp %02h", i, rd_mem(mid+i), 8'(gm_get(int'(i))));
+      end
+
+    for (int unsigned i = 0; i < mL; i++) gm_load(int'(i), int'(rd_mem(mid + i)));
+    gm_mxdequant(int'(NumBlocks));
+
+    do_xfer(mid, dst, mL, idma_pkg::COMPUTE_MXDEQUANT);
+    for (int unsigned i = 0; i < dL; i++)
+      if (rd_mem(dst + i) !== 8'(gm_get(int'(i)))) begin
+        e2++; if (e2 <= 8) $display("[MXRT] dequant dst[%0d]=%02h exp %02h", i, rd_mem(dst+i), 8'(gm_get(int'(i))));
+      end
+
+    if (e1 + e2 == 0) $display("[MXRT] ALL PASS (%0d blocks, StrbWidth=%0d)", NumBlocks, StrbWidth);
+    else              $fatal(1, "[MXRT] FAIL: quant=%0d dequant=%0d mismatches", e1, e2);
+    repeat (5) @(posedge clk);
+    $finish();
+  end
+
+  initial begin #80_000_000; $fatal(1, "[MXRT] timeout"); end
+
+endmodule

--- a/test/tb_idma_transpose_b2b.sv
+++ b/test/tb_idma_transpose_b2b.sv
@@ -108,7 +108,7 @@ module tb_idma_transpose_b2b
   idma_backend_rw_axi #(
     .CombinedShifter(1'b0), .DataWidth(DataWidth), .AddrWidth(AddrWidth), .AxiIdWidth(AxiIdWidth),
     .UserWidth(UserWidth), .TFLenWidth(TFLenWidth), .MaskInvalidData(1'b1), .BufferDepth(3),
-    .EnableCompute(1'b1), .ComputeOps(idma_pkg::compute_enable_t'{transpose: 1'b1}),
+    .EnableCompute(1'b1), .ComputeOps(idma_pkg::compute_enable_t'{transpose: 1'b1, default: '0}),
     .ComputeFullDuplex(1'b1),
     .RAWCouplingAvail(1'b1), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
     .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(StrbWidth), .MemSysDepth(0),

--- a/test/tb_idma_transpose_nd.sv
+++ b/test/tb_idma_transpose_nd.sv
@@ -125,7 +125,7 @@ module tb_idma_transpose_nd
   idma_backend_rw_axi #(
     .CombinedShifter(1'b0), .DataWidth(DataWidth), .AddrWidth(AddrWidth), .AxiIdWidth(AxiIdWidth),
     .UserWidth(UserWidth), .TFLenWidth(TFLenWidth), .MaskInvalidData(1'b1), .BufferDepth(BufferDepth),
-    .EnableCompute(1'b1), .ComputeOps(idma_pkg::compute_enable_t'{transpose: 1'b1}),
+    .EnableCompute(1'b1), .ComputeOps(idma_pkg::compute_enable_t'{transpose: 1'b1, default: '0}),
     .ComputeFullDuplex(1'b1),
     .RAWCouplingAvail(1'b1), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
     .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(AxIF), .MemSysDepth(0),

--- a/util/mario/legalizer.py
+++ b/util/mario/legalizer.py
@@ -9,7 +9,7 @@
 
 """ MARIO legalizer interaction"""
 from mako.template import Template
-from mario.util import indent_block, eval_key, prot_key
+from mario.util import indent_block, eval_key, prot_key, compute_eligible
 
 
 def prot_force_decouple(used_prots: list, db: dict) -> list:
@@ -66,6 +66,7 @@ def render_legalizer(prot_ids: dict, db: dict, tpl_file: str) -> str:
         context = {
             'name_uniqueifier': prot_id,
             'database': db,
+            'compute_eligible': compute_eligible(used_read_prots, used_write_prots, db),
             'used_read_protocols': used_read_prots,
             'used_write_protocols': used_write_prots,
             'used_protocols': prot_ids[prot_id]['used'],


### PR DESCRIPTION
## Summary

Adds size-changing on-the-fly compute (write byte count != read byte count) on top of the transpose/otf_compute framework, with MX (OCP microscaling) quantization and dequantization as the first ops. Based directly on `devel` (an earlier revision stacked on #166; the per-beat retire signal turned out to be unnecessary — see the retire note below — so #166 was withdrawn).

**Mechanism.** Per-op source:dest byte ratios in `idma_pkg` (`compute_in_bytes`/`compute_out_bytes`) program the legalizer write length, so the write burst's beat count matches the beats the compute engine emits. The compute seam presents per-lane valid (pack-buffer occupancy) with full strobes; the write manager's own beat mask gates acceptance, and the engine retires lane-exactly against the byte lanes the write port actually consumed (`buffer_out_ready`), so a partial tail beat pops only its own bytes — no drain FSM, no transport-layer state machine, and back-to-back transfers with an identical compute config pipeline with zero inter-transfer bubbles. The legalizer asserts fence the contract: input-granule alignment, beat-aligned src/dst, per-beat-capable destination protocols (no TileLink), the FP16 width cap, and that the requested op is elaborated (`EnableCompute` / `ComputeOps`).

**Retire note (transpose unchanged).** Transpose keeps devel's per-write-transaction retire (`w_dp_req_ready`) and its existing contract that every transpose write burst is single-beat (guaranteed by the midend strip decomposition, now made explicit by the `ComputeTransposeSingleBeat` assert — multi-beat transpose bursts mis-stream under *any* single-signal retire and were already unsupported on devel; a whole-tile "compact" transpose is future work). The MX ops do not use a scalar retire at all: they pop lane-exactly from `buffer_out_ready`, which the write ports already produce per beat. An earlier revision (#166) re-exposed a per-beat `w_beat_done` pulse for this; it is not needed and was dropped.

**Ops** (selected via `compute_cfg.compute_op`, same programming model as transpose):

| Op | Direction | Ratio | Width |
|---|---|---|---|
| `COMPUTE_MXQUANT` | FP32 -> MXFP8 | 128B -> 33B per 32-elem block | up to 1024b (StrbWidth 128) |
| `COMPUTE_MXQUANT_FP16` | FP16 -> MXFP8 | 64B -> 33B | up to 512b (StrbWidth 64) |
| `COMPUTE_MXDEQUANT` | MXFP8 -> FP32 | 33B -> 128B | length must be 33k with k % StrbWidth == 0 |

MX block layout is inline `[1B E8M0 scale][32B E5M2]`. The quantizer is RNE with full subnormal, saturation and Inf/NaN handling, bit-exact with the viDMA ALCU reference except two deliberate corrections (mirrored in the DPI golden): the E8M0 scale saturates instead of wrapping for all-tiny blocks, and Inf/NaN lanes are excluded from the shared-scale scan so a block's finite lanes survive. The split normal/subnormal rounding bands are load-bearing; do not merge them.

## Validation

Byte-exact against a DPI-C golden (`test/idma_mxquant_dpi.c`, pure integer pipeline) on Questa 2026.1 at every legal StrbWidth (DataWidth 32/64/128/256/512/1024):

- `tb_idma_mxquant`: FP16 and FP32 sources, a genuine partial 33B tail beat, a 4K page-crossing write.
- `tb_idma_mxroundtrip`: quant -> dequant back-to-back through one backend, byte-exact at both stages (the exact E5M2 identity); FP16 leg at 512b, FP32 leg at 1024b (256 blocks, 32KB legs).
- `tb_idma_mxrand`: constrained-random campaign — 40 serialized transfers per run with a random op each (FP16/FP32 quant, dequant, plain unaligned copy), random block counts, writes biased across 4K boundaries, behind an AXI shim injecting 40% random per-channel stalls; canary bytes fence each destination.
- `tb_idma_mxneg`: every compute guard assert proven to fire (11 cases, incl. the transpose single-beat and dequant length-overflow fences). Note this PR also adds `+define+INC_ASSERT` to the sim flow — without it `ASSERT_NEVER` compiles to nothing, so the legalizer guard asserts (including pre-existing ones) were inert in simulation.
- `tb_idma_transpose_b2b` / `tb_idma_transpose_nd` unchanged and green (backward compatibility).
- `tb_idma_mxperf`: steady-state throughput vs a plain-copy baseline on ideal memory — the bottleneck channel (quant: R, dequant: W) sustains 100% bus utilization at every StrbWidth, both for single transfers and for pipelined back-to-back streams (aggregate window across 8 transfers including the boundaries); the other channel sits at the compression ratio (e.g. 33/128). Three microarchitectural points make this hold: pack-buffer space only gates block-completing input beats, the dequant pack buffer carries one expanded-block window of refill-during-drain headroom, and lane-exact retire keeps tails sound across transfer boundaries. The pipelined quant stream is also checked byte-exact under the random-stall shim in `tb_idma_mxrand`.

## Known scope / disclosures

- Compute is functionally validated only on `idma_backend_rw_axi`. Size-changing compute on non-AXI src/dst is fenced with `NOT IMPLEMENTED` asserts (`ComputeMxSrcProtocol` / `ComputeMxDstProtocol`) until validated; OBI is the natural first candidate (its write ready is already per-beat). Transpose keeps its pre-existing protocol scope.
- Back-to-back compute transfers with an **identical** config pipeline freely (verified at 100% utilization). A config change (op, FP16 flag, params) is serialized **in hardware**: the request is held at the legalizer input until the datapath drained, so software needs no ordering rule. Verified with a different-config transfer issued pipelined behind a quant stream (byte-exact); the sub-unit $fatal asserts remain as backstops.
- Compute requires beat-aligned src/dst (asserted; all guard asserts covered by firing negative tests in `tb_idma_mxneg`).
- `ComputeOps` defaults to `'1`: existing `EnableCompute` designs gain the MX engines on regeneration (area); set `ComputeOps` explicitly to opt out.
- Synthesized standalone in a 12 nm technology at 1 GHz, timing met: quant 39.5k/71.5k cells (512b/1024b), dequant 37.4k/52.8k. The second commit restructures the engines for synthesis (hoisted completion datapath, generate-gated FP16, circular dequant buffer) — bit-exact and throughput-neutral, re-verified by the full suite. No in-system PnR data yet.
- Validated at `BufferDepth=3`, `MemSysDepth=0`, 1D transfers only.
