### PR TITLE
ci: Make author-lint domain-based and license-agnostic

### DIFF
--- a/.github/authors-cfg.yaml
+++ b/.github/authors-cfg.yaml
@@ -6,10 +6,10 @@
 # - Thomas Benz <tbenz@iis.ee.ethz.ch>
 
 header-regex: >
-  (?:#\!/.*\n)*[/|#]+ Copyright ([0-9]+) ETH Zurich and University of Bologna\.\n[/|#]+ Solderpad Hardware License, Version 0\.51, see LICENSE for details\.\n[/|#]+ SPDX-License-Identifier: SHL-0\.51\n\n[/|#]+ Authors:\n((?:[/#]+ - [0-9A-Za-z ]+<[0-9A-Za-z\.]+@[0-9A-Za-z\.]+>\n)+)
+  (?:#\!/.*\n)*[/|#]+ Copyright ([0-9]+) [^\n]+\n(?:[/|#][^\n]*\n|\n)*?[/|#]+ SPDX-License-Identifier: (?:SHL-0\.51|Apache-2\.0)\n(?:[/|#][^\n]*\n|\n)*?[/|#]+ Authors:\n((?:[/|#]+ - [0-9A-Za-z .]+<[^\s>]+@[^\s>]+>\n)+)
 
 author-regex: >
-  ([0-9A-Za-z ]+)<([0-9A-Za-z\.]+@[0-9A-Za-z\.]+)>
+  ([0-9A-Za-z .]+)<([^\s>]+@[^\s>]+)>
 
 excludes:
   - LICENSE
@@ -41,10 +41,6 @@ allowed-years:
   - 2025
   - 2026
 
-allowed-authors:
-  Axel Vanoni: axvanoni@ethz.ch
-  Daniel Keller: dankeller@iis.ee.ethz.ch
-  Michael Rogenmoser: michaero@iis.ee.ethz.ch
-  Samuel Riedel: sriedel@iis.ee.ethz.ch
-  Thomas Benz: tbenz@iis.ee.ethz.ch
-  Tobias Senti: tsenti@ethz.ch
+allowed-domains:
+  - ethz.ch
+  - mosaic-soc.com

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
       uses: pulp-platform/pulp-actions/lint-license@v2.5.0
       with:
         license: |
-          Copyright (\d{4}(-\d{4})?\s)?(ETH Zurich and University of Bologna|lowRISC contributors).
+          Copyright (\d{4}(-\d{4})?\s)?.+
           (Solderpad Hardware License, Version 0.51|Licensed under the Apache License, Version 2.0), see LICENSE for details.
           SPDX-License-Identifier: (SHL-0.51|Apache-2.0)
         # Exclude generated headers (no license checker support for optional lines)

--- a/util/lint-authors.py
+++ b/util/lint-authors.py
@@ -62,16 +62,18 @@ def lint_authors(file: str, config: dict) -> int:
     # parse authors
     authors = re.findall(config['author-regex'], header_info[0][1])
 
-    # check for authors
+    # check each author's email domain against the allowed domains
     for author in authors:
-        if not author[0].strip() in config['allowed-authors']:
-            print(f' -> Unknown author {author[0].strip()}')
+        email = author[1].strip()
+        if email.count('@') != 1:
+            print(f' -> Malformed author email: {email}')
             return 1
-        # check email
-        else:
-            if author[1].strip() != config['allowed-authors'][author[0].strip()]:
-                print(f' -> Wrong email address {author[1].strip()}')
-                return 1
+        domain = email.split('@', 1)[1].lower()
+        allowed = all(domain.split('.')) and any(
+            domain == d or domain.endswith('.' + d) for d in config['allowed-domains'])
+        if not allowed:
+            print(f' -> Author email domain not allowed: {email}')
+            return 1
 
     # all checks pass
     return 0


### PR DESCRIPTION
Check attribution only: any copyright holder, any SPDX license line (value stays gated by lint-license), and authors by email domain. Unblocks the Mosaic-copyright files in #161. Verified: devel tree clean, req_replay.sv passes.