### PR TITLE
ci: Bump actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     -
       name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -30,7 +30,7 @@ jobs:
       run: uv run --locked scripts/list-contributors | tee contributions.txt
     -
       name: Upload contributions.txt
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: contributions
         path: contributions.txt
@@ -42,7 +42,7 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     -
       name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -53,7 +53,7 @@ jobs:
       run: uv run --locked scripts/list-todos | tee open_todos.txt
     -
       name: Upload todos.txt
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: open_todos
         path: open_todos.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       -
         name: Cache Bender database
         uses: ./.github/actions/bender-db-cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
           fetch-depth: 0
     -

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       -
         name: Cache Bender database
         uses: ./.github/actions/bender-db-cache
@@ -51,7 +51,7 @@ jobs:
         run: uv run --locked make idma_doc_all
       -
         name: Create publish docs
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: target/doc/html
 
@@ -69,4 +69,4 @@ jobs:
       -
         name: Deploy to Github Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     -
       name: Check license
       uses: pulp-platform/pulp-actions/lint-license@v2.5.0
@@ -37,7 +37,7 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     -
       name: Run Verible
       uses: chipsalliance/verible-linter-action@main
@@ -76,28 +76,27 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       -
         name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       -
         name: Lint Python
-        uses: py-actions/flake8@v2
-        with:
-          max-line-length: "100"
-          ignore: E128
+        run: |
+          pip install flake8
+          flake8 --max-line-length 100 --extend-ignore E128 .
 
   lint-yaml:
     runs-on: ubuntu-latest
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       -
         name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       -
@@ -111,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       -
@@ -127,7 +126,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       -
         name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/promote-to-master.yml
+++ b/.github/workflows/promote-to-master.yml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Open or update devel -> master PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const sha   = context.payload.workflow_run.head_sha;

--- a/.github/workflows/retarget-to-devel.yml
+++ b/.github/workflows/retarget-to-devel.yml
@@ -30,7 +30,7 @@ jobs:
       issues: write
     steps:
       - name: Retarget to devel and comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr      = context.payload.pull_request.number;


### PR DESCRIPTION
GitHub is retiring the Node 20 runtime; pinned actions still on it are force-run on Node 24 with a deprecation warning and will eventually hard-fail. This bumps every affected action to its Node-24 major:

- `actions/checkout@v4` -> `@v5`
- `actions/setup-python@v5` -> `@v6`
- `actions/upload-artifact@v4` -> `@v5`
- `actions/upload-pages-artifact@v3` -> `@v5` (docs.yml)
- `actions/github-script@v7` -> `@v8` (promote-to-master.yml, retarget-to-devel.yml)
- `actions/deploy-pages@v4` -> `@v5` (docs.yml)

It also drops the unmaintained `py-actions/flake8@v2` action (itself Node-20) in the `lint-python` job, replacing it with a direct flake8 run: `flake8 --max-line-length 100 --extend-ignore E128 .`. This lints the whole tree (util/ plus doc/src/conf.py) with the standard extend-ignore idiom; verified 0 errors.

The `lint-license` job is left as-is; migrating it to REUSE is a separate future item.
