### PR TITLE
test: Make MX sim targets self-verifying and size the PRNG literal

### DIFF
--- a/idma.mk
+++ b/idma.mk
@@ -431,41 +431,39 @@ idma_sim_tb_idma_transpose_b2b: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_transpose_b2b -do "run -all; quit"
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_transpose_b2b -do "run -all; quit"
 
+# Run a self-checking MX sim across data widths. Questa does not propagate
+# $fatal to the exit code, so fail on any Error:/Fatal: in the run log.
+# $(1) = testbench, $(2) = space-separated data widths.
+define idma_run_mx_sim
+	cd $(IDMA_VSIM_DIR); set -e; for dw in $(2); do \
+	  $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=$$dw $(1) -do "run -all; quit" > $(1)_$$dw.log 2>&1 || true; \
+	  if grep -qE "Error:|Fatal:" $(1)_$$dw.log; then \
+	    echo "$(1) DW=$$dw FAILED (see $(1)_$$dw.log)"; tail -40 $(1)_$$dw.log; exit 1; fi; \
+	done
+endef
+
 .PHONY: idma_sim_tb_idma_mxquant
 idma_sim_tb_idma_mxquant: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
 	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_mxquant_dpi.c)
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_mxquant -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_mxquant -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=256 tb_idma_mxquant -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=512 tb_idma_mxquant -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=1024 tb_idma_mxquant -do "run -all; quit"
+	$(call idma_run_mx_sim,tb_idma_mxquant,32 64 256 512 1024)
 
 .PHONY: idma_sim_tb_idma_mxroundtrip
 idma_sim_tb_idma_mxroundtrip: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
 	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_mxquant_dpi.c)
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_mxroundtrip -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_mxroundtrip -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=256 tb_idma_mxroundtrip -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=512 tb_idma_mxroundtrip -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=1024 tb_idma_mxroundtrip -do "run -all; quit"
+	$(call idma_run_mx_sim,tb_idma_mxroundtrip,32 64 256 512 1024)
 
 .PHONY: idma_sim_tb_idma_mxrand
 idma_sim_tb_idma_mxrand: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
 	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_mxquant_dpi.c)
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_mxrand -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_mxrand -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=256 tb_idma_mxrand -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=512 tb_idma_mxrand -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=1024 tb_idma_mxrand -do "run -all; quit"
+	$(call idma_run_mx_sim,tb_idma_mxrand,32 64 256 512 1024)
 
 .PHONY: idma_sim_tb_idma_mxperf
 idma_sim_tb_idma_mxperf: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_mxperf -do "run -all; quit"
-	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_mxperf -do "run -all; quit"
+	$(call idma_run_mx_sim,tb_idma_mxperf,32 64)
 
 .PHONY: idma_sim_tb_idma_mxclear
 idma_sim_tb_idma_mxclear: $(IDMA_VSIM_DIR)/compile.tcl

--- a/test/tb_idma_mxquant.sv
+++ b/test/tb_idma_mxquant.sv
@@ -95,7 +95,7 @@ module tb_idma_mxquant
       endcase
     end
     return 32'((e & 1) << 31) | 32'(((64 + (e % 128)) & 8'hFF) << 23)
-           | 32'((e * 2654435761) & 23'h7FFFFF);
+           | 32'((e * 32'd2654435761) & 23'h7FFFFF);
   endfunction
 
   // one num_blocks FP16->MXFP8 transfer; returns error count

--- a/test/tb_idma_mxrand.sv
+++ b/test/tb_idma_mxrand.sv
@@ -102,7 +102,7 @@ module tb_idma_mxrand
   function automatic logic [31:0] fp32_gen(input int unsigned e);
     automatic logic [31:0] sgn = 32'((e & 1) << 31);
     automatic logic [31:0] exp = 32'(((64 + (e % 128)) & 8'hFF) << 23);
-    automatic logic [31:0] man = 32'((e * 2654435761) & 23'h7FFFFF);
+    automatic logic [31:0] man = 32'((e * 32'd2654435761) & 23'h7FFFFF);
     return sgn | exp | man;
   endfunction
 

--- a/test/tb_idma_mxroundtrip.sv
+++ b/test/tb_idma_mxroundtrip.sv
@@ -75,7 +75,7 @@ module tb_idma_mxroundtrip
   function automatic logic [31:0] fp32_gen(input int unsigned e);
     automatic logic [31:0] sgn = 32'((e & 1) << 31);
     automatic logic [31:0] exp = 32'(((64 + (e % 128)) & 8'hFF) << 23);
-    automatic logic [31:0] man = 32'((e * 2654435761) & 23'h7FFFFF);
+    automatic logic [31:0] man = 32'((e * 32'd2654435761) & 23'h7FFFFF);
     return sgn | exp | man;
   endfunction
 


### PR DESCRIPTION
mxquant/roundtrip/rand/perf now grep-assert their ALL PASS marker and fail on Error/Fatal so a skipped or non-running module cannot pass vacuously; size the 2654435761 PRNG literal to kill the vlog-2597 overflow warning. Verified under Questa 2026.1 that the guard both passes on good code and correctly fails when a sim does not print its pass marker.