### PR TITLE
deps: Align the cc-v2 ecosystem pins on common_cells v2.0.0-beta.3

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -16,7 +16,7 @@ packages:
     - common_verification
     - tech_cells_generic
   axi_stream:
-    revision: 9028c32ab980cff29fcc13f1ee35d51dd806d108
+    revision: ce1547861f99ab3d8834d04aa36d2d4184a28df7
     version: null
     source:
       Git: https://github.com/pulp-platform/axi_stream.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -1,6 +1,6 @@
 packages:
   apb:
-    revision: 6a2bd0fe9f0822322104ac602fac5739fb063aa0
+    revision: 6ae8bf8d5eab5dc70d032231c01ab95e1c5774b9
     version: null
     source:
       Git: https://github.com/pulp-platform/apb.git
@@ -16,15 +16,15 @@ packages:
     - common_verification
     - tech_cells_generic
   axi_stream:
-    revision: 834639c9a39d00c063cef184164525416ef5b119
+    revision: 9028c32ab980cff29fcc13f1ee35d51dd806d108
     version: null
     source:
       Git: https://github.com/pulp-platform/axi_stream.git
     dependencies:
     - common_cells
   common_cells:
-    revision: 03d98106aa19952a10360d2230def85144a0008b
-    version: 2.0.0-beta.2
+    revision: 63b7c50d43e462b59506f69d341ff1e40202866d
+    version: 2.0.0-beta.3
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -15,7 +15,7 @@ package:
 
 dependencies:
   axi:                 { git: "https://github.com/pulp-platform/axi.git",                 rev: 0ccc838fe06aeeb857eb83c6be9a915c4bf99566 }
-  axi_stream:          { git: "https://github.com/pulp-platform/axi_stream.git",          rev: 9028c32ab980cff29fcc13f1ee35d51dd806d108 }
+  axi_stream:          { git: "https://github.com/pulp-platform/axi_stream.git",          rev: ce1547861f99ab3d8834d04aa36d2d4184a28df7 }
   common_cells:        { git: "https://github.com/pulp-platform/common_cells.git",        version: 2.0.0-beta.3 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.5  }
   apb:                 { git: "https://github.com/pulp-platform/apb.git",                 rev: 6ae8bf8d5eab5dc70d032231c01ab95e1c5774b9 }

--- a/Bender.yml
+++ b/Bender.yml
@@ -15,10 +15,10 @@ package:
 
 dependencies:
   axi:                 { git: "https://github.com/pulp-platform/axi.git",                 rev: 0ccc838fe06aeeb857eb83c6be9a915c4bf99566 }
-  axi_stream:          { git: "https://github.com/pulp-platform/axi_stream.git",          rev: 834639c9a39d00c063cef184164525416ef5b119 }
-  common_cells:        { git: "https://github.com/pulp-platform/common_cells.git",        version: 2.0.0-beta.2 }
+  axi_stream:          { git: "https://github.com/pulp-platform/axi_stream.git",          rev: 9028c32ab980cff29fcc13f1ee35d51dd806d108 }
+  common_cells:        { git: "https://github.com/pulp-platform/common_cells.git",        version: 2.0.0-beta.3 }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.5  }
-  apb:                 { git: "https://github.com/pulp-platform/apb.git",                 rev: 6a2bd0fe9f0822322104ac602fac5739fb063aa0 }
+  apb:                 { git: "https://github.com/pulp-platform/apb.git",                 rev: 6ae8bf8d5eab5dc70d032231c01ab95e1c5774b9 }
   obi:                 { git: "https://github.com/pulp-platform/obi.git",                 rev: b69af4aa00630efd14b1c5cbf9bac977f23ce840 }
 
 export_include_dirs:


### PR DESCRIPTION
Raises the `common_cells` floor to `v2.0.0-beta.3` (latest beta; downstream locks already resolve it) and advances the two stale cc-v2 ecosystem rev pins: `axi_stream` to the beta.3 bump on pulp-platform/axi_stream#6 (approved, pending merge — this pin can become a version constraint once that PR merges and tags), `apb` to its cc-v2 branch head (CDC parameter-name fix). `obi` is already at its cc-v2 head, and all pins verified branch-reachable so fresh checkouts resolve. `tb_idma_reg_frontend` passes in all three configs on the bumped deps.