### PR TITLE
frontend: Align desc64 addrmap symbol references with generated svpkg

### DIFF
--- a/src/frontend/desc64/idma_desc64_reg_wrapper.sv
+++ b/src/frontend/desc64/idma_desc64_reg_wrapper.sv
@@ -26,8 +26,8 @@ import idma_desc64_reg_pkg::idma_desc64_reg__in_t; #(
     input  logic                  input_addr_ready_i
 );
 
-    import idma_desc64_addrmap_pkg::IDMA_DESC64_REG_DESC_ADDR_BASE_ADDR;
-    import idma_desc64_addrmap_pkg::IDMA_DESC64_REG_STATUS_BASE_ADDR;
+    import idma_desc64_addrmap_pkg::IDMA_DESC64_DESC_ADDR_BASE_ADDR;
+    import idma_desc64_addrmap_pkg::IDMA_DESC64_STATUS_BASE_ADDR;
 
     logic     apb_psel, apb_psel_q, apb_penable, apb_pready;
     logic     input_addr_valid_q, input_addr_valid_d;
@@ -55,7 +55,7 @@ import idma_desc64_reg_pkg::idma_desc64_reg__in_t; #(
     assign apb_penable = apb_psel_q & apb_req_i.penable;
 
     always_comb begin
-        if (apb_req_i.paddr == IDMA_DESC64_REG_DESC_ADDR_BASE_ADDR) begin
+        if (apb_req_i.paddr == IDMA_DESC64_DESC_ADDR_BASE_ADDR) begin
             apb_psel = apb_req_i.psel & input_addr_ready_i;
         end else begin
             apb_psel = apb_req_i.psel;
@@ -66,7 +66,7 @@ import idma_desc64_reg_pkg::idma_desc64_reg__in_t; #(
 
     always_comb begin
         // only take into account the fifo if a write is going to it
-        if (apb_req_i.paddr == IDMA_DESC64_REG_DESC_ADDR_BASE_ADDR) begin
+        if (apb_req_i.paddr == IDMA_DESC64_DESC_ADDR_BASE_ADDR) begin
             apb_rsp_o.pready = apb_pready & (input_addr_ready_i | ~input_addr_valid_q);
         end else begin
             apb_rsp_o.pready = apb_pready;

--- a/test/frontend/tb_idma_desc64_bench.sv
+++ b/test/frontend/tb_idma_desc64_bench.sv
@@ -16,8 +16,8 @@
 
 /// Benchmarking TB for the descriptor-based frontend
 module tb_idma_desc64_bench
-    import idma_desc64_addrmap_pkg::IDMA_DESC64_REG_DESC_ADDR_BASE_ADDR;
-    import idma_desc64_addrmap_pkg::IDMA_DESC64_REG_STATUS_BASE_ADDR;
+    import idma_desc64_addrmap_pkg::IDMA_DESC64_DESC_ADDR_BASE_ADDR;
+    import idma_desc64_addrmap_pkg::IDMA_DESC64_STATUS_BASE_ADDR;
     import rand_verif_pkg::rand_wait;
     import axi_pkg::*;
     import apb_test::apb_driver; #(
@@ -635,7 +635,7 @@ module tb_idma_desc64_bench
             current_stimulus_group = generated_stimuli.pop_front();
 
             i_apb_driver.write(
-                .addr(IDMA_DESC64_REG_DESC_ADDR_BASE_ADDR) ,
+                .addr(IDMA_DESC64_DESC_ADDR_BASE_ADDR) ,
                 .data(current_stimulus_group[0].base),
                 .strb(8'hff)                         ,
                 .err (error)
@@ -874,7 +874,7 @@ module tb_idma_desc64_bench
                     automatic logic [63:0] status;
                     automatic logic error;
                     i_apb_driver.read(
-                        .addr(IDMA_DESC64_REG_STATUS_BASE_ADDR),
+                        .addr(IDMA_DESC64_STATUS_BASE_ADDR),
                         .data(status),
                         .err (error)
                     );

--- a/test/frontend/tb_idma_desc64_top.sv
+++ b/test/frontend/tb_idma_desc64_top.sv
@@ -15,8 +15,8 @@
 
 /// VIP for the descriptor-based frontend
 module tb_idma_desc64_top
-    import idma_desc64_addrmap_pkg::IDMA_DESC64_REG_DESC_ADDR_BASE_ADDR;
-    import idma_desc64_addrmap_pkg::IDMA_DESC64_REG_STATUS_BASE_ADDR;
+    import idma_desc64_addrmap_pkg::IDMA_DESC64_DESC_ADDR_BASE_ADDR;
+    import idma_desc64_addrmap_pkg::IDMA_DESC64_STATUS_BASE_ADDR;
     import rand_verif_pkg::rand_wait;
     import axi_pkg::*;
     import apb_test::apb_driver; #(
@@ -419,7 +419,7 @@ module tb_idma_desc64_top
             current_stimulus_group = generated_stimuli.pop_front();
 
             i_apb_driver.write(
-                .addr (IDMA_DESC64_REG_DESC_ADDR_BASE_ADDR),
+                .addr (IDMA_DESC64_DESC_ADDR_BASE_ADDR),
                 .data (current_stimulus_group[0].base),
                 .strb (8'hff)                         ,
                 .err  (error)
@@ -713,7 +713,7 @@ module tb_idma_desc64_top
                     automatic logic [63:0] status;
                     automatic logic error;
                     i_apb_driver.read(
-                        .addr(idma_desc64_addrmap_pkg::IDMA_DESC64_REG_STATUS_BASE_ADDR),
+                        .addr(idma_desc64_addrmap_pkg::IDMA_DESC64_STATUS_BASE_ADDR),
                         .data(status),
                         .err(error)
                     );


### PR DESCRIPTION
The desc64 reg wrapper and both desc64 testbenches imported `IDMA_DESC64_REG_DESC_ADDR_BASE_ADDR` / `IDMA_DESC64_REG_STATUS_BASE_ADDR`, but the PeakRDL svpkg is generated with `--base_name idma_desc64` (matching the reg-frontend convention) and emits `IDMA_DESC64_DESC_ADDR_BASE_ADDR` / `IDMA_DESC64_STATUS_BASE_ADDR`. The stale `_REG_` infix broke the full Questa sim compile with undefined package members.

Drop the infix in the three hand-written consumers so they match the generated addrmap package. No generator or RDL change; the reg_pkg `IDMA_DESC64_REG_TOP_MIN_ADDR_WIDTH` parameter is unaffected. Full sim compile now clean (4 desc64 errors -> 0) and `tb_idma_desc64_top` elaborates.