### PR TITLE
docs: Set the Astro base path so GitHub project Pages renders assets

### DIFF
--- a/.github/authors-cfg.yaml
+++ b/.github/authors-cfg.yaml
@@ -29,6 +29,7 @@ exclude-ext:
   - json
   - toml
   - md
+  - mdx
   - lock
   - local
 

--- a/doc/site/astro.config.mjs
+++ b/doc/site/astro.config.mjs
@@ -9,6 +9,8 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
 export default defineConfig({
+  site: 'https://pulp-platform.github.io',
+  base: '/iDMA',
   integrations: [
     starlight({
       title: 'iDMA Documentation',

--- a/doc/site/src/content/docs/architecture/backend.md
+++ b/doc/site/src/content/docs/architecture/backend.md
@@ -7,7 +7,7 @@ description: The backend executes 1D transfers over concrete transport protocols
 
 The backend is the lowest layer of the iDMA pipeline. It takes 1D transfer requests from the midend and drives the actual bus transactions. Each backend variant targets a specific combination of read and write protocols. Generated modules follow the naming pattern `idma_backend_<variant>` (e.g., `idma_backend_rw_axi`, `idma_backend_r_obi_w_axi`).
 
-![Backend Architecture](/fig/backend.svg)
+![Backend Architecture](/iDMA/fig/backend.svg)
 
 ### Transfer Lifecycle
 
@@ -92,7 +92,7 @@ Each backend variant combines a set of read and write protocols:
 
 The active set is `IDMA_BACKEND_IDS` in `idma.mk`; extend it with `IDMA_ADD_IDS` for custom protocol combinations.
 
-![Variant Matrix](/fig/variant_matrix.svg)
+![Variant Matrix](/iDMA/fig/variant_matrix.svg)
 
 ## Legalizer
 
@@ -100,7 +100,7 @@ The legalizer decomposes a 1D transfer request into a sequence of protocol-legal
 
 The legalizer is pure control path: it does not touch the data. It computes page/burst boundaries, splits transfers accordingly, and emits `offset`, `tailer`, and `shift` values that the transport layer uses for data realignment.
 
-![Legalizer](/fig/legalizer.svg)
+![Legalizer](/iDMA/fig/legalizer.svg)
 
 ### Splitting Rules
 

--- a/doc/site/src/content/docs/architecture/frontend/snitch.md
+++ b/doc/site/src/content/docs/architecture/frontend/snitch.md
@@ -7,7 +7,7 @@ description: ISA-coupled frontend for Snitch cores using Xdma custom instruction
 
 The Snitch frontend (`idma_inst64_top`) is tightly coupled to the Snitch RISC-V core through custom Xdma ISA extensions. DMA transfers are launched directly from the instruction stream via the accelerator bus interface, eliminating register file overhead and enabling single-cycle transfer submission.
 
-![Snitch Integration](/fig/system_integration_alt.svg)
+![Snitch Integration](/iDMA/fig/system_integration_alt.svg)
 
 ## Xdma Instruction Set
 

--- a/doc/site/src/content/docs/architecture/hierarchy.md
+++ b/doc/site/src/content/docs/architecture/hierarchy.md
@@ -16,12 +16,12 @@ the latest repository state.
 
 ## Backend - `rw_axi`
 
-![idma_backend_synth_rw_axi](/fig/graph/idma_backend_synth_rw_axi.png)
+![idma_backend_synth_rw_axi](/iDMA/fig/graph/idma_backend_synth_rw_axi.png)
 
 ## ND Midend
 
-![idma_nd_midend_synth](/fig/graph/idma_nd_midend_synth.png)
+![idma_nd_midend_synth](/iDMA/fig/graph/idma_nd_midend_synth.png)
 
 ## Descriptor Frontend
 
-![idma_desc64_synth](/fig/graph/idma_desc64_synth.png)
+![idma_desc64_synth](/iDMA/fig/graph/idma_desc64_synth.png)

--- a/doc/site/src/content/docs/guides/system-integration.md
+++ b/doc/site/src/content/docs/guides/system-integration.md
@@ -7,9 +7,9 @@ description: How to wire iDMA into an SoC, including type macros, parameters, an
 
 This guide covers the practical steps for integrating iDMA into a system-on-chip: choosing a frontend/midend/backend combination, instantiating the type macros, wiring the bus interfaces, and setting the key parameters.
 
-![System Integration](/fig/system_integration.svg)
+![System Integration](/iDMA/fig/system_integration.svg)
 
-![System Integration (alternate view)](/fig/system_integration_alt.svg)
+![System Integration (alternate view)](/iDMA/fig/system_integration_alt.svg)
 
 ## Integration Steps
 

--- a/doc/site/src/content/docs/index.md
+++ b/doc/site/src/content/docs/index.md
@@ -11,7 +11,7 @@ iDMA moves data between memories and peripherals across different bus protocols 
 - **Midend**: optional ND/RT decomposition and multicore split.
 - **Backend**: protocol execution on the bus, with optional on-the-fly compute.
 
-![Architecture Overview](/fig/architecture_overview.svg)
+![Architecture Overview](/iDMA/fig/architecture_overview.svg)
 
 :::note[Figure placeholder]
 Diagram: end-to-end request lifecycle (frontend request, optional midend split, backend legalizer + transport, response).


### PR DESCRIPTION
The deployed Starlight site at https://pulp-platform.github.io/iDMA/ rendered unstyled: assets were emitted at root-absolute `/_astro/...` while project Pages serves under `/iDMA/`, so every CSS/JS 404'd.

Set `site`/`base` in `astro.config.mjs` and prefix the `public/` figure references with the base so images resolve too. Verified: a fresh `npm run build` emits `/iDMA/_astro/...` and every asset/link/image in `dist/` is base-correct.