### PR TITLE
ci: Elaborate the synthesis tops and inst64 frontend in public CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
     uses: ./.github/workflows/analyze.yml
     secrets: inherit
 
+  elaborate:
+    needs: lint
+    uses: ./.github/workflows/elaborate.yml
+    secrets: inherit
+
   gitlab-ci:
     needs: build
     uses: ./.github/workflows/gitlab-ci.yml

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -1,0 +1,47 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author:
+# - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+name: elaborate
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+
+  # Elaborate every synthesis top plus the snitch_cluster-gated inst64 frontend
+  # (which has no public concrete instance otherwise), so fork PRs that skip the
+  # proprietary EDA sims still catch port, parameter and connectivity errors.
+  # ubuntu-24.04 ships Verilator 5.x via apt.
+  elaborate:
+    runs-on: ubuntu-24.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Cache Bender database
+        uses: ./.github/actions/bender-db-cache
+      -
+        name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      -
+        name: Install Bender
+        uses: pulp-platform/pulp-actions/bender-install@v2.5.0
+        with:
+          version: 0.32.0
+      -
+        name: Install Verilator
+        run: sudo apt-get update && sudo apt-get install -y verilator
+      -
+        name: Generate RTL
+        run: uv run --locked make idma_hw_all
+      -
+        name: Elaborate synthesis tops and inst64 frontend
+        run: uv run --locked make idma_lint_all

--- a/Bender.yml
+++ b/Bender.yml
@@ -150,3 +150,9 @@ sources:
     files:
       - test/tb_idma_backend_multihead.sv
       - test/tb_idma_backend_multihead_rw.sv
+
+  # inst64 frontend lint/elaboration wrapper: a public concrete-typed top so CI
+  # can verilator --lint-only the snitch_cluster-gated idma_inst64_top
+  - target: all(snitch_cluster, lint)
+    files:
+      - test/idma_inst64_lint.sv

--- a/idma.mk
+++ b/idma.mk
@@ -596,6 +596,36 @@ $(IDMA_VLT_DIR)/%_elab.log: $(IDMA_BENDER_FILES) $(IDMA_FULL_TB) $(IDMA_FULL_RTL
 idma_verilator_clean:
 	rm -rf $(IDMA_VLT_DIR)
 
+# inst64 frontend elaboration gate: bind the snitch_cluster-gated idma_inst64_top
+# to concrete types (test/idma_inst64_lint.sv) and verilator --lint-only it, so
+# public CI catches frontend port/param/elaboration errors. Run after idma_hw_all.
+.PHONY: idma_lint_inst64
+idma_lint_inst64:
+	mkdir -p $(IDMA_VLT_DIR)
+	$(BENDER) script verilator -t rtl -t snitch_cluster -t lint > $(IDMA_VLT_DIR)/idma_inst64_lint.f
+	$(VERILATOR) --lint-only -Wno-fatal --timing -f $(IDMA_VLT_DIR)/idma_inst64_lint.f --top-module idma_inst64_lint
+
+# Synthesis-wrapper elaboration gate: verilator elaborates every synth top so a
+# port, parameter or connectivity break is caught without the proprietary EDA
+# sims (which fork PRs never run). Run after idma_hw_all.
+IDMA_LINT_TOPS ?= $(addprefix idma_backend_synth_,$(IDMA_BACKEND_IDS)) \
+                  idma_desc64_synth \
+                  idma_nd_midend_synth \
+                  idma_mp_midend_synth \
+                  idma_rt_midend_synth
+
+.PHONY: idma_lint_elab
+idma_lint_elab:
+	mkdir -p $(IDMA_VLT_DIR)
+	$(BENDER) script verilator -t rtl -t synth > $(IDMA_VLT_DIR)/idma_elab.f
+	@rc=0; for top in $(IDMA_LINT_TOPS); do \
+	  echo "--- elaborating $$top ---"; \
+	  $(VERILATOR) --lint-only -Wno-fatal --timing -f $(IDMA_VLT_DIR)/idma_elab.f --top-module $$top || rc=1; \
+	done; exit $$rc
+
+.PHONY: idma_lint_all
+idma_lint_all: idma_lint_elab idma_lint_inst64
+
 
 # ---------------
 # Trace

--- a/test/idma_inst64_lint.sv
+++ b/test/idma_inst64_lint.sv
@@ -1,0 +1,140 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+`include "axi/typedef.svh"
+`include "obi/typedef.svh"
+
+/// Lint/elaboration wrapper for the snitch_cluster-gated idma_inst64_top.
+/// idma_inst64_top is a fully type-parameterized generic with no concrete
+/// instance in the public tree, so no lint tool can elaborate it standalone.
+/// This binds concrete AXI/OBI/INIT/acc types (transpose enabled) and ties the
+/// ports off so public CI can elaborate the frontend:
+///   verilator --lint-only --top-module idma_inst64_lint
+/// It carries no behaviour; it exists only to give the generic a concrete top.
+module idma_inst64_lint #(
+    parameter int unsigned AxiDataWidth = 32'd512,
+    parameter int unsigned AxiAddrWidth = 32'd64,
+    parameter int unsigned AxiUserWidth = 32'd1,
+    parameter int unsigned AxiIdWidth   = 32'd3,
+    parameter int unsigned NumChannels  = 32'd1
+)(
+    input  logic clk_i,
+    input  logic rst_ni
+);
+
+  typedef logic [AxiAddrWidth-1:0]   axi_addr_t;
+  typedef logic [AxiDataWidth-1:0]   axi_data_t;
+  typedef logic [AxiDataWidth/8-1:0] axi_strb_t;
+  typedef logic [AxiUserWidth-1:0]   axi_user_t;
+  typedef logic [AxiIdWidth-1:0]     axi_id_t;
+
+  `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, axi_addr_t, axi_id_t, axi_user_t)
+  `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, axi_data_t, axi_strb_t, axi_user_t)
+  `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, axi_id_t, axi_user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, axi_addr_t, axi_id_t, axi_user_t)
+  `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, axi_data_t, axi_id_t, axi_user_t)
+  `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_chan_t, axi_w_chan_t, axi_ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(axi_resp_t, axi_b_chan_t, axi_r_chan_t)
+
+  typedef logic [AxiDataWidth/8-1:0] obi_strb_t;
+  `OBI_TYPEDEF_MINIMAL_A_OPTIONAL(obi_a_optional_t)
+  `OBI_TYPEDEF_MINIMAL_R_OPTIONAL(obi_r_optional_t)
+  `OBI_TYPEDEF_TYPE_A_CHAN_T(obi_a_chan_t, axi_addr_t, axi_data_t, obi_strb_t, axi_id_t,
+                             obi_a_optional_t)
+  `OBI_TYPEDEF_TYPE_R_CHAN_T(obi_r_chan_t, axi_data_t, axi_id_t, obi_r_optional_t)
+  `OBI_TYPEDEF_REQ_T(obi_req_t, obi_a_chan_t)
+  `OBI_TYPEDEF_RSP_T(obi_res_t, obi_r_chan_t)
+
+  // INIT meta-channel types (mirror src/db/idma_init.yml)
+  typedef struct packed {
+    logic [AxiAddrWidth-1:0]   cfg;
+    logic [AxiDataWidth-1:0]   term;
+    logic [AxiDataWidth/8-1:0] strb;
+    logic [AxiIdWidth-1:0]     id;
+  } init_req_chan_t;
+  typedef struct packed { init_req_chan_t req_chan; logic req_valid; logic rsp_ready; } init_req_t;
+  typedef struct packed { logic [AxiDataWidth-1:0] init; } init_rsp_chan_t;
+  typedef struct packed { init_rsp_chan_t rsp_chan; logic rsp_valid; logic req_ready; } init_rsp_t;
+
+  typedef axi_pkg::xbar_rule_64_t addr_rule_t;
+
+  // Snitch accelerator bus (the inst64 frontend decodes data_op/argb)
+  typedef struct packed {
+    logic [31:0] id;
+    logic [31:0] data_op;
+    logic [63:0] data_arga;
+    logic [63:0] data_argb;
+  } acc_req_t;
+  typedef struct packed { logic [31:0] id; logic [63:0] data; logic error; } acc_res_t;
+
+  typedef struct packed {
+    logic           aw_valid, aw_ready, aw_done, aw_stall;
+    axi_pkg::len_t  aw_len;
+    axi_pkg::size_t aw_size;
+    logic           ar_valid, ar_ready, ar_done, ar_stall;
+    axi_pkg::len_t  ar_len;
+    axi_pkg::size_t ar_size;
+    logic           r_valid, r_ready, r_done, r_bw, r_stall;
+    logic           w_valid, w_ready, w_done, w_stall;
+    logic [31:0]    num_bytes_written;
+    logic           b_valid, b_ready, b_done;
+    logic           obi_wr_req, obi_rd_req;
+    logic           dma_busy;
+  } dma_events_t;
+
+  axi_req_t  [NumChannels-1:0] axi_req;
+  obi_req_t  [NumChannels-1:0] obi_req;
+  dma_events_t [NumChannels-1:0] events;
+  logic      [NumChannels-1:0] busy;
+  acc_res_t  acc_res;
+  logic      acc_req_ready, acc_res_valid;
+
+  idma_inst64_top #(
+    .AxiDataWidth    ( AxiDataWidth    ),
+    .AxiAddrWidth    ( AxiAddrWidth    ),
+    .AxiUserWidth    ( AxiUserWidth    ),
+    .AxiIdWidth      ( AxiIdWidth      ),
+    .NumAxInFlight   ( 32'd3           ),
+    .DMAReqFifoDepth ( 32'd3           ),
+    .NumChannels     ( NumChannels     ),
+    .DMATracing      ( 1'b0            ),
+    .axi_ar_chan_t   ( axi_ar_chan_t   ),
+    .axi_aw_chan_t   ( axi_aw_chan_t   ),
+    .axi_req_t       ( axi_req_t       ),
+    .axi_res_t       ( axi_resp_t      ),
+    .init_req_chan_t ( init_req_chan_t ),
+    .init_rsp_chan_t ( init_rsp_chan_t ),
+    .init_req_t      ( init_req_t      ),
+    .init_rsp_t      ( init_rsp_t      ),
+    .obi_a_chan_t    ( obi_a_chan_t    ),
+    .obi_r_chan_t    ( obi_r_chan_t    ),
+    .obi_req_t       ( obi_req_t       ),
+    .obi_res_t       ( obi_res_t       ),
+    .acc_req_t       ( acc_req_t       ),
+    .acc_res_t       ( acc_res_t       ),
+    .dma_events_t    ( dma_events_t    ),
+    .addr_rule_t     ( addr_rule_t     )
+  ) i_dut (
+    .clk_i           ( clk_i        ),
+    .rst_ni          ( rst_ni       ),
+    .axi_req_o       ( axi_req      ),
+    .axi_res_i       ( '0           ),
+    .obi_req_o       ( obi_req      ),
+    .obi_res_i       ( '0           ),
+    .busy_o          ( busy         ),
+    .acc_req_i       ( '0           ),
+    .acc_req_valid_i ( 1'b0         ),
+    .acc_req_ready_o ( acc_req_ready ),
+    .acc_res_o       ( acc_res      ),
+    .acc_res_valid_o ( acc_res_valid ),
+    .acc_res_ready_i ( 1'b0         ),
+    .hart_id_i       ( 32'h0        ),
+    .events_o        ( events       ),
+    .addr_map_i      ( '0           )
+  );
+
+endmodule


### PR DESCRIPTION
Public CI is lint and codegen only: no job elaborates RTL, so a port, parameter or connectivity break passes every gate. The EDA sims that would catch it run on the GitLab mirror and are skipped for fork PRs. PR #80 removing coupler ports is exactly this class.

Adds an `elaborate` workflow running `make idma_lint_all`:
- `idma_lint_elab` elaborates all 12 synthesis tops (8 backend variants, desc64, nd/mp/rt midends) with verilator.
- `idma_lint_inst64` elaborates the snitch_cluster-gated inst64 frontend through a concrete-typed wrapper (`test/idma_inst64_lint.sv`), since `idma_inst64_top` has all-`logic` parameters and no public concrete instance. inst64 was previously covered by nothing but syntax analysis.

### Verified locally (verilator 5.020, matching ubuntu-24.04)
- clean devel: all 12 tops plus inst64 elaborate, exit 0.
- non-vacuity: renaming `w_req_valid_i` in `idma_channel_coupler.sv` (a #80-class break) fails the gate with `Can't find definition of variable` and exit 2.

### Why not `pulp-actions/slang`
Evaluated it first. It is advisory by construction and cannot gate: `run_slang.py` exits 0 regardless of compile errors ("so the CI step continues and reviewdog can annotate"), and although reviewdog runs with `-fail-level=error`, that step is marked `continue-on-error: true`. It is a good complement for inline PR annotations and can be added alongside, but it would not fail a #80-class break. Happy to add it as an annotation layer if preferred.

### Side finding
Building the inst64 wrapper surfaced that `idma_inst64_events.sv` requires `obi_wr_req`/`obi_rd_req` members in the integrator-supplied `dma_events_t`, and that `ComputeEnable`/`testmode_i` no longer exist. There is no canonical public definition of `dma_events_t`, so snitch_cluster, the nonfree formal wrapper and this lint wrapper each hand-roll it and drift silently.