### PR TITLE
frontend: Report the documented stall polarity in the inst64 events

### DIFF
--- a/src/frontend/inst64/idma_inst64_events.sv
+++ b/src/frontend/inst64/idma_inst64_events.sv
@@ -91,10 +91,6 @@ module idma_inst64_events #(
         events_o.obi_wr_req = obi_req_i.req && obi_res_i.gnt && obi_req_i.a.we;
         events_o.obi_rd_req = obi_req_i.req && obi_res_i.gnt && ~obi_req_i.a.we;
 
-        // buffer
-        events_o.w_stall = axi_rsp_i.w_ready && !axi_req_i.w_valid;
-        events_o.r_stall = !axi_req_i.r_ready &&  axi_rsp_i.r_valid;
-
         // busy
         events_o.dma_busy = busy_i;
     end

--- a/test/frontend/tb_idma_inst64_axi_copy.sv
+++ b/test/frontend/tb_idma_inst64_axi_copy.sv
@@ -87,12 +87,12 @@ module tb_idma_inst64_axi_copy;
         ev_field_ok[EvRDone  ] = ev.r_done   === (bus_req.r_ready && bus_res.r_valid);
         // r_bw duplicates r_done in the RTL; compare it to the pins, never to ev.r_done.
         ev_field_ok[EvRBw    ] = ev.r_bw     === (bus_req.r_ready && bus_res.r_valid);
-        ev_field_ok[EvRStall ] = ev.r_stall  === (!bus_req.r_ready && bus_res.r_valid);
+        ev_field_ok[EvRStall ] = ev.r_stall  === (bus_req.r_ready && !bus_res.r_valid);
 
         ev_field_ok[EvWValid ] = ev.w_valid  === bus_req.w_valid;
         ev_field_ok[EvWReady ] = ev.w_ready  === bus_res.w_ready;
         ev_field_ok[EvWDone  ] = ev.w_done   === w_hs;
-        ev_field_ok[EvWStall ] = ev.w_stall  === (bus_res.w_ready && !bus_req.w_valid);
+        ev_field_ok[EvWStall ] = ev.w_stall  === (bus_req.w_valid && !bus_res.w_ready);
         ev_field_ok[EvBytes  ] = ev.num_bytes_written ===
                                  (w_hs ? 32'($countones(bus_req.w.strb)) : 32'd0);
 


### PR DESCRIPTION
The Snitch cluster defines these counters explicitly, in `snitch_cluster_peripheral_reg.rdl`:

```
dma_r_stall     = 12  "Incremented whenever r_ready = 1 but r_valid = 0"
dma_w_stall     = 13  "Incremented whenever w_valid = 1 but w_ready = 0"
dma_buf_w_stall = 14  "Incremented whenever w_ready = 1 but w_valid = 0"
dma_buf_r_stall = 15  "Incremented whenever r_valid = 1 but r_ready = 0"
```

`snitch_cluster_peripheral.sv` maps each metric to the identically named `dma_events_t` field with no remapping, so that text is a direct contract on the field.

The two lines this removes are, verbatim, the definitions of **14 and 15 sitting in the fields for 12 and 13**, where they overrode the correct assignments made earlier in the same `always_comb`. Removing them restores 12 and 13:

| field | after this PR | RDL |
|---|---|---|
| `r_stall` | `r_ready && !r_valid` | whenever r_ready = 1 but r_valid = 0 |
| `w_stall` | `!w_ready && w_valid` | whenever w_valid = 1 but w_ready = 0 |

The asymmetry that remains is the intended one: iDMA drives `w_valid` but `r_ready`, so waiting on the fabric is valid-without-ready on AW, AR and W, and ready-without-valid on R.

### Why it looks like this today

Both pairs arrived in one commit (`097f6140`, PR #40) that flattened `axi_dma_perf_counters.sv`'s `if`-guarded set-only writes over a `'0` default into unconditional assignments. Under the guards the two conditions fed four separate counters; unconditional, the later pair simply clobbers the earlier one. Accidental, not a design decision.

### Testbench

`tb_idma_inst64_axi_copy` asserted the old behaviour, so its two goldens move with the RTL in the same commit. Verified both ways with Questa:

- with this change: `TEST PASSED`, rc=0
- with either side reverted: `Fatal: events.EvRStall disagrees with the AXI pins`, rc=2

Worth noting that no CI job runs that testbench today: it is reachable only through `make idma_sim_tb_idma_inst64_axi_copy`. Without running it by hand, devel would have stayed green while shipping RTL that contradicts its own assertions.

### Impact

This is a **silent** change to reported performance counters. Metric 13 currently counts mostly bus idle, since a registered W slice parks `WREADY` high; metric 12 currently reads near zero because inst64 ties `rsp_ready` high. Existing profiles change meaning with no version marker, so it wants a CHANGELOG line alongside #201.

No programmatic reader of these counters exists in `snitch_cluster` outside the RDL and its generated packages, so anyone reading them reads them against the RDL, which is to say against the corrected values.

### Not done here

Renaming the two lines to `buf_w_stall` / `buf_r_stall` rather than deleting them would fix 12 and 13 *and* light up 14 and 15, which read constant zero before and after this PR. The cost is integrators whose `dma_events_t` is narrower than the cluster's, including this repo's own testbench mirror in `test/frontend/idma_inst64_tb_pkg.sv`, which omits both fields. Left for a follow-up rather than folded in here.
