### PR TITLE
test: Watch the real INIT handshake and skip zero-length stream jobs

### DIFF
--- a/src/db/idma_axi_stream.yml
+++ b/src/db/idma_axi_stream.yml
@@ -169,6 +169,8 @@ write_bridge_template: |
         // Handle writes
         while(axis_jobs.size() > 0) begin
             current_job = axis_jobs.pop_front();
+            // a zero-length transfer emits no beats; waiting for one would steal the next job's
+            if (current_job.length == 0) continue;
             address = { current_job.dst_addr[AddrWidth-1:OffsetWidth], {{OffsetWidth}{1'b0}} };
             axis_obi_write_req.a.addr = address;
 

--- a/test/tpl/tb_idma_backend.sv.tpl
+++ b/test/tpl/tb_idma_backend.sv.tpl
@@ -591,6 +591,8 @@ ${p}_${database[p]['write_meta_channel']}_width\
  && !(axi_req.w_valid && axi_rsp.w_ready)\
                 % elif p2 == 'obi':
  && !(obi_write_req.req && obi_write_rsp.gnt)\
+                % elif p2 == 'init':
+ && !(init_write_req.req_valid && init_write_rsp.req_ready)\
                 % else:
  && !(${p2}_axi_req.w_valid && ${p2}_axi_rsp.w_ready)\
                 % endif
@@ -601,6 +603,8 @@ ${p}_${database[p]['write_meta_channel']}_width\
         .valid_i(axi_req.w_valid), .ready_i(axi_rsp.w_ready));
         % elif protocol == 'obi':
         .valid_i(obi_write_req.req), .ready_i(obi_write_rsp.gnt));
+        % elif protocol == 'init':
+        .valid_i(init_write_req.req_valid), .ready_i(init_write_rsp.req_ready));
         % else:
         .valid_i(${protocol}_axi_req.w_valid), .ready_i(${protocol}_axi_rsp.w_ready));
         % endif


### PR DESCRIPTION
Two independent testbench defects behind the red `vsim-sim-random` legs. Neither is an RTL problem; the RTL bug that accounts for the remaining leg is filed separately.

### 1. The INIT write watchdog watched a dead wire
The write-side `stream_watchdog` generator has no `init` case, so INIT fell through to the generic AXI-shaped binding `init_axi_req.w_valid` / `init_axi_rsp.w_ready`. The testbench ties both `init_axi_read_req` and `init_axi_write_req` to `'0` before joining them, so that valid is a compile-time constant 0. The real INIT write handshake is `init_write_req.req_valid` / `init_write_rsp.req_ready`.

Effect: on any INIT-destination transfer the watchdog expired after `WatchDogNumCycles` (100) while the DMA was working perfectly. Measured on the minimal case (one 4096 B transfer, OBI to INIT): it trips at exactly 1020 ns, while `i_idma_init_write.write_happening` toggles 88 times and the OBI read memory 82 times, and the read watchdog counter stays healthy.

This is not a weakening: the watchdog still fires after 100 genuinely idle cycles, it just observes the handshake it was always meant to.

### 2. The AXI-Stream write model mis-attributed jobs after a zero-length transfer
The model pops every job whose destination is AXI Stream, including zero-length ones, then blocks on `wait(axis_write_req.tvalid)`. A rejected zero-length transfer emits no beats, so the model consumed the **next** job's packet and wrote it at the zero-length job's destination, desynchronising by one job for the rest of the run. The read model was never affected because its `while (address < src_addr + length)` loop is a natural no-op at length 0; that asymmetry is the bug.

Worth noting why it hid for so long: `compare_mem` skips any byte reading `0xff`, so a mis-attributed job usually compares vacuously against untouched memory and passes. It only becomes a hard `Mismatch!` once a later, longer job has already overwritten the region.

### Verified
Regenerated and recompiled clean, then re-ran the previously failing legs with the CI gate (`! grep Error:` and `! grep Fatal:`):
- `snitch_write` seed 0: **PASS** (was tripping the write watchdog at 1020 ns)
- `rw_axi_rw_axis` seeds 0 and 2: **PASS**
- `rw_axi_rw_axis` seed 1: **still fails**, and correctly so. It no longer produces the bogus `Mismatch!`; it now hangs honestly on the RTL defect filed separately, so this PR deliberately does not turn it green.

10 of the 11 red legs are fixed here. No seed was pinned or skipped, no watchdog relaxed, no gate weakened, and the random job generator is untouched.