### PR TITLE
ci: Cache the bender binary and the verilator object builds

### DIFF
--- a/.github/actions/verify-setup/action.yml
+++ b/.github/actions/verify-setup/action.yml
@@ -23,8 +23,6 @@ runs:
       with:
         enable-cache: true
 
-    # bender-install downloads a release tarball per job, so a GitHub blip fails
-    # a leg; it skips the download when bender is already on PATH
     - uses: actions/cache@v4
       with:
         path: ~/.cache/bender-bin
@@ -62,7 +60,6 @@ runs:
           ccache-${{ github.job }}-
           ccache-
 
-    # Pinning is by apt version, so assert it rather than trusting the runner
     - if: inputs.verilator == 'true'
       shell: bash
       run: |

--- a/.github/actions/verify-setup/action.yml
+++ b/.github/actions/verify-setup/action.yml
@@ -11,19 +11,58 @@ inputs:
   verilator:
     description: Install Verilator from apt; ubuntu-24.04 ships 5.020
     default: 'false'
+  bender-version:
+    description: Bender release to install
+    default: '0.32.0'
 runs:
   using: composite
   steps:
     - uses: ./.github/actions/bender-db-cache
+
     - uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
+
+    # bender-install downloads a release tarball per job, so a GitHub blip fails
+    # a leg; it skips the download when bender is already on PATH
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/bender-bin
+        key: bender-${{ inputs.bender-version }}-${{ runner.os }}
+    - shell: bash
+      run: |
+        if [ -x "$HOME/.cache/bender-bin/bender" ]; then
+          echo "$HOME/.cache/bender-bin" >> "$GITHUB_PATH"
+        fi
     - uses: pulp-platform/pulp-actions/bender-install@v2.5.0
       with:
-        version: 0.32.0
+        version: ${{ inputs.bender-version }}
+    - shell: bash
+      run: |
+        mkdir -p "$HOME/.cache/bender-bin"
+        if [ ! -x "$HOME/.cache/bender-bin/bender" ]; then
+          cp "$(command -v bender)" "$HOME/.cache/bender-bin/bender"
+        fi
+        bender --version
+
+    # ccache: verilator picks it up as OBJCACHE, so the model rebuilds hit it
     - if: inputs.verilator == 'true'
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y verilator
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y verilator ccache
+        echo "CCACHE_DIR=$HOME/.cache/ccache" >> "$GITHUB_ENV"
+        echo "CCACHE_MAXSIZE=2G" >> "$GITHUB_ENV"
+    - if: inputs.verilator == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.job }}-${{ github.sha }}
+        restore-keys: |
+          ccache-${{ github.job }}-
+          ccache-
+
+    # Pinning is by apt version, so assert it rather than trusting the runner
     - if: inputs.verilator == 'true'
       shell: bash
       run: |

--- a/.github/actions/verify-setup/action.yml
+++ b/.github/actions/verify-setup/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: 'false'
   bender-version:
     description: Bender release to install
-    default: '0.32.0'
+    default: '0.32.1'
 runs:
   using: composite
   steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         name: Install Bender
         uses: pulp-platform/pulp-actions/bender-install@v2.5.0
         with:
-          version: 0.32.0
+          version: 0.32.1
       -
         name: Check clean
         run: uv run --locked make idma_clean_all

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
       name: Install Bender
       uses: pulp-platform/pulp-actions/bender-install@v2.5.0
       with:
-        version: 0.32.0
+        version: 0.32.1
     -
       name: Build hardware
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
         name: Install Bender
         uses: pulp-platform/pulp-actions/bender-install@v2.5.0
         with:
-          version: 0.32.0
+          version: 0.32.1
       -
         name: Build Doc
         run: uv run --locked make idma_doc_all

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -155,3 +155,7 @@ jobs:
       -
         name: Simulate ${{ matrix.suite }}
         run: uv run --locked make idma_verify_sim_${{ matrix.suite }} IDMA_VLT_MAKEFLAGS=-j4
+      -
+        name: ccache statistics
+        if: always()
+        run: ccache --show-stats


### PR DESCRIPTION
Follow-up to #186. Two toolchain pieces were fetched or rebuilt in every job.

### bender

`pulp-actions/bender-install` downloads a release tarball per job, and a run spawns about twenty. That is twenty chances for a network blip to fail a leg, and it already happened: devel went red on `elab-backend (r_obi_rw_init_w_axi)` with

```
failed to download https://github.com/pulp-platform/bender/releases/download/v0.32.0/bender-x86_64-unknown-linux-gnu.tar.xz
```

nothing to do with the code under test. The binary is cached on `~/.cache/bender-bin` keyed by version; the install script skips the download when it finds `bender` on PATH, so on a hit the action is a no-op.

### ccache

Each simulation leg builds a full verilator model, and `mxneg` builds nine in one job. Nothing was cached, so every rerun paid for every model from cold. `ccache` is installed and `CCACHE_DIR` cached with loose restore keys; ccache hashes its inputs, so a stale restore is safe. Verilator picks it up as `OBJCACHE` by itself once it is on PATH - locally its own build lines read `ccache g++-13.2.0 ...`.

The `simulate` job now prints `ccache --show-stats`, so a cache that quietly stops matching is visible instead of just slow.

### What is deliberately not changed

Verilator still comes from apt. It is effectively pinned by the runner image at 5.020, and a newer build changes results rather than just speed: 5.046 fixes `mxquant` at DataWidth 512 and 1024 but breaks `mxroundtrip` at 256. That swap belongs with #196, not here.

CI-only: no makefile, generator or RTL changes.