### PR TITLE
ci: Make the simulations actually use ccache

### DIFF
--- a/.github/actions/verify-setup/action.yml
+++ b/.github/actions/verify-setup/action.yml
@@ -43,7 +43,7 @@ runs:
         fi
         bender --version
 
-    # ccache: verilator picks it up as OBJCACHE, so the model rebuilds hit it
+    # ubuntu's verilator ships OBJCACHE empty, so the sims pass OBJCACHE=ccache
     - if: inputs.verilator == 'true'
       shell: bash
       run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -154,7 +154,8 @@ jobs:
         run: uv run --locked make idma_hw_all
       -
         name: Simulate ${{ matrix.suite }}
-        run: uv run --locked make idma_verify_sim_${{ matrix.suite }} IDMA_VLT_MAKEFLAGS=-j4
+        run: uv run --locked make idma_verify_sim_${{ matrix.suite }} \
+          IDMA_VLT_MAKEFLAGS="-j4 OBJCACHE=ccache"
       -
         name: ccache statistics
         if: always()


### PR DESCRIPTION
The ccache added in #198 stores nothing. Confirmed on the first devel run after it merged:

```
Local storage:
  Cache size (GB): 0.0 / 2.0 ( 0.00%)
```

after a `mxquant` job that compiled five verilator models, and every compile line in that log reads

```
g++-14 -Os -I. -MMD -I/usr/share/verilator/include ...
```

with no `ccache` prefix.

**Cause.** #198 installed ccache and cached its directory on the assumption that verilator finds it by itself. That is true of the SEPP build used locally, whose `verilated.mk` has `OBJCACHE ?= ccache`, but ubuntu's package ships `OBJCACHE` empty, so nothing prefixes the compiler.

**Fix.** The simulation legs pass `OBJCACHE=ccache` to the sub-make.

**Verified the override reaches verilated.mk** rather than assuming: building with `OBJCACHE=/usr/bin/false` prefixes every compile line and fails the build, so a command-line make variable does get through `-MAKEFLAGS`.

The hit rate stays 0% on the first run after this lands, because the cache is still cold. The second run is the one to read.