### PR TITLE
ci: Give each matrix leg its own ccache key

### DIFF
--- a/.github/actions/verify-setup/action.yml
+++ b/.github/actions/verify-setup/action.yml
@@ -14,6 +14,11 @@ inputs:
   bender-version:
     description: Bender release to install
     default: '0.32.1'
+  ccache-key:
+    description: >
+      Distinguishes this job's ccache from its siblings. Matrix legs share a job
+      id, so a shared key makes them race and all but one fail to save.
+    default: shared
 runs:
   using: composite
   steps:
@@ -55,10 +60,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/ccache
-        key: ccache-${{ github.job }}-${{ github.sha }}
+        key: ccache-${{ inputs.ccache-key }}-${{ github.sha }}
         restore-keys: |
-          ccache-${{ github.job }}-
-          ccache-
+          ccache-${{ inputs.ccache-key }}-
 
     - if: inputs.verilator == 'true'
       shell: bash

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -53,6 +53,7 @@ jobs:
         uses: ./.github/actions/verify-setup
         with:
           verilator: 'true'
+          ccache-key: elab-${{ matrix.id }}
       -
         name: Generate RTL
         run: uv run --locked make idma_hw_all
@@ -149,6 +150,7 @@ jobs:
         uses: ./.github/actions/verify-setup
         with:
           verilator: 'true'
+          ccache-key: sim-${{ matrix.suite }}
       -
         name: Generate RTL
         run: uv run --locked make idma_hw_all


### PR DESCRIPTION
Second defect from #198, found by reading the devel logs after #199 landed.

#199 fixed the compiler prefix - the logs now show `ccache g++-14 ...` - but the cache still could not persist:

```
Failed to save: Unable to reserve cache with key ccache-simulate-4d88f80d...
```

`github.job` is the job **id**, identical for every matrix leg, so all six simulation legs used one key and raced. One saved, five failed. The five that failed would also have restored a different suite's objects on the next run.

Verified across the legs of one run - same key on all of them:

| leg | key |
|---|---|
| simulate (transpose_midend) | `ccache-simulate-4d88f80d...` |
| simulate (mxclear) | `ccache-simulate-4d88f80d...` |
| simulate (mxquant) | `ccache-simulate-4d88f80d...` |
| simulate (mxroundtrip) | `ccache-simulate-4d88f80d...` |
| simulate (transpose) | `ccache-simulate-4d88f80d...` |

The key now comes from the matrix value (`sim-<suite>`, `elab-<id>`), passed in as an action input since a composite action cannot read `matrix` itself.

Intra-job caching already works: `mxquant` reported `Hits: 16 / 156 (10.26%)` on a cold cache, the five widths sharing common objects. Cross-run hits need this fix plus one more run.