### PR TITLE
ci: Stop pinning the internal CI to the common-cells-v2 nonfree branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,9 +5,6 @@
 # Authors:
 # - Thomas Benz <tbenz@iis.ee.ethz.ch>
 
-variables:
-  IDMA_NONFREE_COMMIT: common-cells-v2
-
 default:
   interruptible: true
   hooks:


### PR DESCRIPTION
`.gitlab-ci.yml` pinned `IDMA_NONFREE_COMMIT` to the `common-cells-v2` branch. That branch has not moved since 2026-07-29, so the internal child pipeline built its checks against a nonfree tree that predates several landed changes.

Three failures on the devel pipeline trace to this single pin:

- `xrun-uvm-compile` and `vsim-compile-cov`: the coverage bind still wires the pre-#80 channel-coupler ports (`r_rsp_valid_i`, `r_rsp_ready_i`, `r_rsp_first_i`, `r_decouple_aw_i`), so elaboration fails with `xmelab: *E,CUVUNF`.
- `vsim-compile-cov`: the UVM top still includes the removed `idma/tracer.svh`, so `IDMA_TRACER_RW_AXI` is undefined after the per-id tracer split (#186).
- `jasper-elaborate`: `elaborate_all.tcl` does not exist on that branch.

Dropping the pin takes the `idma.mk` default of `deploy`, which carries all three fixes.

The `init` job was unaffected because the project-level CI/CD variable `IDMA_NONFREE_COMMIT=deploy` wins there; only the child pipeline inherited the stale YAML value, which is why the generated `ci.yml` looked current while the jobs consuming it did not.
