### PR TITLE
test: Sweep the MX roundtrip over both element formats

### DIFF
--- a/idma.mk
+++ b/idma.mk
@@ -439,12 +439,14 @@ idma_sim_tb_idma_transpose_b2b: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=32 tb_idma_transpose_b2b -do "run -all; quit"
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=64 tb_idma_transpose_b2b -do "run -all; quit"
 
-# MX sim across data widths; Questa hides $fatal, so grep the transcript
+# MX sim over data widths; $(3) tags the log, $(4) adds elaboration parameters
 define idma_run_mx_sim
 	cd $(IDMA_VSIM_DIR); set -e; for dw in $(2); do \
-	  $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=$$dw $(1) -do "run -all; quit" > $(1)_$$dw.log 2>&1 || true; \
-	  if grep -qE "Error:|Fatal:" $(1)_$$dw.log; then \
-	    echo "$(1) DW=$$dw FAILED (see $(1)_$$dw.log)"; tail -40 $(1)_$$dw.log; exit 1; fi; \
+	  $(VSIM) -c -t 1ps -voptargs=+acc -gDataWidth=$$dw $(4) $(1) \
+	    -do "run -all; quit" > $(1)_$(3)$$dw.log 2>&1 || true; \
+	  if grep -qE "Error:|Fatal:" $(1)_$(3)$$dw.log; then \
+	    echo "$(1) $(3)DW=$$dw FAILED (see $(1)_$(3)$$dw.log)"; \
+	    tail -40 $(1)_$(3)$$dw.log; exit 1; fi; \
 	done
 endef
 
@@ -452,19 +454,20 @@ endef
 idma_sim_tb_idma_mxquant: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
 	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_mxquant_dpi.c)
-	$(call idma_run_mx_sim,tb_idma_mxquant,32 64 256 512 1024)
+	$(call idma_run_mx_sim,tb_idma_mxquant,32 64 256 512 1024,,)
 
 .PHONY: idma_sim_tb_idma_mxroundtrip
 idma_sim_tb_idma_mxroundtrip: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
 	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_mxquant_dpi.c)
-	$(call idma_run_mx_sim,tb_idma_mxroundtrip,32 64 256 512 1024)
+	$(call idma_run_mx_sim,tb_idma_mxroundtrip,32 64 256 512,fp16_,-gQuantFp16=1)
+	$(call idma_run_mx_sim,tb_idma_mxroundtrip,32 64 256 512 1024,fp32_,-gQuantFp16=0)
 
 .PHONY: idma_sim_tb_idma_mxrand
 idma_sim_tb_idma_mxrand: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
 	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_mxquant_dpi.c)
-	$(call idma_run_mx_sim,tb_idma_mxrand,32 64 256 512 1024)
+	$(call idma_run_mx_sim,tb_idma_mxrand,32 64 256 512 1024,,)
 
 .PHONY: idma_sim_tb_idma_mxperf
 idma_sim_tb_idma_mxperf: $(IDMA_VSIM_DIR)/compile.tcl

--- a/test/tb_idma_mxroundtrip.sv
+++ b/test/tb_idma_mxroundtrip.sv
@@ -5,10 +5,9 @@
 // Authors:
 // - Daniel Keller <dankeller@iis.ee.ethz.ch>
 
-// MX roundtrip through one rw_axi backend: at <=512b FP16 -> MXFP8 -> FP16
-// (COMPUTE_MXQUANT_FP16 then COMPUTE_MXDEQUANT_FP16), above FP32 -> MXFP8 ->
-// FP32. Both stages checked byte-exact against the DPI-C golden
-// (idma_mxquant_dpi.c); quant->dequant is thus the exact E5M2 identity.
+// MX roundtrip through one rw_axi backend, quant then dequant, checked
+// byte-exact against the DPI-C golden (idma_mxquant_dpi.c); the roundtrip is
+// the exact E5M2 identity. QuantFp16 picks the element format of both legs.
 
 `include "axi/typedef.svh"
 `include "idma/typedef.svh"
@@ -20,7 +19,8 @@ module tb_idma_mxroundtrip
   parameter int unsigned AddrWidth  = 32,
   parameter int unsigned UserWidth  = 1,
   parameter int unsigned AxiIdWidth = 12,
-  parameter int unsigned TFLenWidth = 32
+  parameter int unsigned TFLenWidth = 32,
+  parameter bit          QuantFp16  = 1'b1
 );
 
   import "DPI-C" function void gm_load(input int idx, input int val);
@@ -42,7 +42,7 @@ module tb_idma_mxroundtrip
     .UserWidth(UserWidth), .TFLenWidth(TFLenWidth), .MaskInvalidData(1'b1), .BufferDepth(3),
     .EnableCompute(1'b1),
     .ComputeOps(idma_pkg::compute_enable_t'{mxquant: 1'b1, mxdequant: 1'b1,
-                                            mxfp16: (StrbWidth <= 64), default: '0}),
+                                            mxfp16: QuantFp16, default: '0}),
     .ComputeTuning('1),
     .RAWCouplingAvail(1'b1), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
     .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(StrbWidth),
@@ -102,8 +102,6 @@ module tb_idma_mxroundtrip
     repeat (20) @(posedge clk);
   endtask
 
-  // FP16 quant leg up to StrbWidth 64 (512b); FP32 leg above (1024b)
-  localparam bit          QuantFp16 = StrbWidth <= 64;
   localparam int unsigned QuantInBytes = QuantFp16 ? 64 : 128;
 
   initial begin


### PR DESCRIPTION
`tb_idma_mxroundtrip` derived its element format from the bus width, so each format was reachable only at some widths and never at the same one:

| | before | after |
|---|---|---|
| FP16 (`mxfp16 = 1`) | 32, 64, 256, 512 | 32, 64, 256, 512 |
| FP32 (`mxfp16 = 0`) | 1024 only | 32, 64, 256, 512, 1024 |

`QuantFp16` becomes a parameter that also gates the DUT's `mxfp16`, and the roundtrip runs both legs over the widths each elaborates for. The FP16 leg stops at a 512b bus because `compute_mxfp16_width` asserts `StrbWidth <= 64`; the FP32 leg has no such limit.

The gain is the `mxfp16 = 0` area opt-out, which downstream users pick to drop the FP16 paths. It was previously only reachable at a 1024b bus and is now covered at every width.

`tb_idma_mxquant` and `tb_idma_mxrand` already drive both element formats within a single run, so they keep the plain width sweep.

## Verification

19 configurations, all `ALL PASS` under Questa on top of devel `497c1f23`:

```
mxquant       32 64 256 512 1024                    5 runs
mxroundtrip   fp16: 32 64 256 512                   4 runs
              fp32: 32 64 256 512 1024              5 runs
mxrand        32 64 256 512 1024                    5 runs
```

## History

This PR previously narrowed the MX sweep to a 512b bus, because `tb_idma_mxrand` failed at 32, 64 and 512. That turned out to be the channel coupler defect fixed in #204, not an MX defect; with #204 merged every width passes. The narrowing is therefore dropped and only the format axis is kept, which is the part that adds coverage rather than removing it.
