### PR TITLE
backend: Gate the coupler AW release on a queued AW and tag the write datapath

### DIFF
--- a/jobs/jobs.json
+++ b/jobs/jobs.json
@@ -34,6 +34,47 @@
         "testbench": "tb_idma_backend_rw_axi",
         "synth_top": "idma_backend_synth_rw_axi"
     },
+    "rw_axi_stall" : {
+        "jobs" : {
+            "simple"          : "backend_rw_axi/simple.txt",
+            "same_dst"        : "backend_rw_axi/same_dst.txt",
+            "linear"          : "backend_rw_axi/linear.txt",
+            "huge"            : "backend_rw_axi/huge.txt",
+            "large"           : "backend_rw_axi/large.txt",
+            "medium"          : "backend_rw_axi/medium.txt",
+            "mixed"           : "backend_rw_axi/mixed.txt",
+            "small"           : "backend_rw_axi/small.txt",
+            "tiny"            : "backend_rw_axi/tiny.txt",
+            "error_simple"    : "backend_rw_axi/error_simple.txt",
+            "error_mixed"     : "backend_rw_axi/error_mixed.txt",
+            "zero_transfer"   : "backend_rw_axi/zero_transfer.txt"
+        },
+        "params" : {
+            "DataWidth"           : 32,
+            "AddrWidth"           : 32,
+            "UserWidth"           : 1,
+            "AxiIdWidth"          : 12,
+            "NumAxInFlight"       : 8,
+            "BufferDepth"         : 3,
+            "TFLenWidth"          : 32,
+            "MemSysDepth"         : 0,
+            "CombinedShifter"     : 1,
+            "MaskInvalidData"     : 1,
+            "RAWCouplingAvail"    : 1,
+            "HardwareLegalizer"   : 1,
+            "RejectZeroTransfers" : 1,
+            "ErrorHandling"       : 1
+        },
+        "tb_params" : {
+            "AXI_IdealMemory"     : 0,
+            "AXI_MemNumReqOutst"  : 2,
+            "AXI_MemLatency"      : 8,
+            "WatchDogNumCycles"   : 5000
+        },
+        "proc_id" : "rw_axi",
+        "testbench": "tb_idma_backend_rw_axi",
+        "synth_top": "idma_backend_synth_rw_axi"
+    },
     "r_axi_w_obi" : {
         "jobs" : {
             "simple"          : "backend_r_axi_w_obi/simple.txt",
@@ -512,7 +553,7 @@
             { "top" : "tb_idma_mxrand",
               "why" : "verilator only: transfer 1 never completes, even at NumXfers=1 StallPct=0" },
             { "top" : "tb_idma_rt_midend", "why" : "fails under --assert on cc_rr_arb_tree lock" },
-            { "top" : "the 88 directed job files", "why" : "verilator cannot drive the class-based stimulus" }
+            { "top" : "the directed backend job runs", "why" : "verilator cannot drive the class-based stimulus" }
         ]
     }
 }

--- a/jobs/jobs.json
+++ b/jobs/jobs.json
@@ -461,6 +461,24 @@
             ]
         }
     },
+    "mxperf" : {
+        "jobs" : {
+        },
+        "params" : {
+            "AddrWidth"   : 32,
+            "UserWidth"   : 1,
+            "AxiIdWidth"  : 12,
+            "TFLenWidth"  : 32
+        },
+        "testbench" : "tb_idma_mxperf",
+        "verify" : {
+            "token" : "[MXPF] ALL PASS",
+            "legs" : [
+                { "tag" : "mxperf_32", "params" : { "DataWidth" : 32 } },
+                { "tag" : "mxperf_64", "params" : { "DataWidth" : 64 } }
+            ]
+        }
+    },
     "_verify" : {
         "elab_widths" : [32, 64, 512, 1024],
         "elab_compute" : [
@@ -487,10 +505,12 @@
         ],
         "tops_untested" : [
             { "top" : "tb_idma_nd_midend_b2b", "why" : "hangs ([B2B] timeout); latent reset/LFSR race" },
-            { "top" : "tb_idma_transpose_nd", "why" : "AW outside the destination allocation at 80 ns" },
-            { "top" : "tb_idma_transpose_b2b", "why" : "stream_watchdog trip after 4000 idle cycles" },
-            { "top" : "tb_idma_mxrand", "why" : "testbench timeout at 400 ms of simulated time" },
-            { "top" : "tb_idma_mxperf", "why" : "hangs on the first compute transfer" },
+            { "top" : "tb_idma_transpose_nd",
+              "why" : "verilator only: the ND response never fires once the first case drains" },
+            { "top" : "tb_idma_transpose_b2b",
+              "why" : "verilator only: the first geometry never completes, watchdog trip" },
+            { "top" : "tb_idma_mxrand",
+              "why" : "verilator only: transfer 1 never completes, even at NumXfers=1 StallPct=0" },
             { "top" : "tb_idma_rt_midend", "why" : "fails under --assert on cc_rr_arb_tree lock" },
             { "top" : "the 88 directed job files", "why" : "verilator cannot drive the class-based stimulus" }
         ]

--- a/src/backend/idma_channel_coupler.sv
+++ b/src/backend/idma_channel_coupler.sv
@@ -35,6 +35,8 @@ module idma_channel_coupler #(
     input  logic w_req_ready_i,
     /// First W request
     input  logic w_req_first_i,
+    /// Does the `W` burst belong to a decoupled request?
+    input  logic w_decouple_aw_i,
     /// Is the `AW` in the queue a decoupled request?
     input  logic aw_decouple_aw_i,
 
@@ -56,7 +58,7 @@ module idma_channel_coupler #(
 );
 
     /// The width of the credit counter keeping track of the transfers
-    localparam int unsigned CounterWidth = cc_pkg::idx_width(NumAxInFlight);
+    localparam int unsigned CounterWidth = cc_pkg::cnt_width(NumAxInFlight);
 
     /// Credit counter type
     typedef logic [CounterWidth-1:0] cnt_t;
@@ -82,12 +84,11 @@ module idma_channel_coupler #(
 
     // counter to keep track of AR to send
     cnt_t aw_to_send_d, aw_to_send_q;
-    cnt_t aw_to_stall_d, aw_to_stall_q;
 
     logic aw_stall_d, aw_stall_q;
 
     // first signal -> a W has data that needs to free an AW
-    assign first = w_req_valid_i & w_req_first_i & ~aw_stall_q;
+    assign first = w_req_valid_i & w_req_first_i & ~aw_stall_q & ~w_decouple_aw_i;
     assign aw_stall_d = w_req_valid_i & ~w_req_ready_i;
 
     // stream fifo to hold AWs back
@@ -132,40 +133,30 @@ module idma_channel_coupler #(
 
         // defaults
         aw_to_send_d = aw_to_send_q;
-        aw_to_stall_d = aw_to_stall_q;
+        aw_sent      = 1'b0;
 
-        // if we bypass the logic
-        aw_sent = aw_decoupled_head & aw_valid;
-        // if the AW is decoupled, we need to keep track of the sent AWs
-        if (aw_decoupled_head & aw_valid & aw_to_send_q == '0) begin
-            aw_to_stall_d = aw_to_stall_q + 1;
-            if (aw_ready_decoupled & first) begin
-                aw_to_stall_d = aw_to_stall_q;
+        // a decoupled AW at the head is released without consuming a credit
+        if (aw_valid & aw_decoupled_head) begin
+            aw_sent = 1'b1;
+            if (first) begin
+                aw_to_send_d = aw_to_send_q + 1;
             end
         end
 
-        if (aw_to_stall_q != '0) begin
-            if (first && !(aw_decoupled_head & aw_valid)) begin
-                aw_to_stall_d = aw_to_stall_q - 1;
-            end
-        end else begin
-            // first is asserted and aw is ready -> just send AW out
-            // without changing the credit counter value
-            if (aw_ready_decoupled & first) begin
-                aw_sent = 1'b1;
-            end
-
-            // if first is asserted and aw is not ready -> increment
-            // credit counter
-            else if (!aw_ready_decoupled & first) begin
+        // a coupled AW at the head is released against a credit
+        else if (aw_valid & (first | (aw_to_send_q != '0))) begin
+            aw_sent = 1'b1;
+            // the credit is consumed only once the AW is actually accepted
+            if (aw_ready_decoupled & !first) begin
+                aw_to_send_d = aw_to_send_q - 1;
+            end else if (!aw_ready_decoupled & first) begin
                 aw_to_send_d = aw_to_send_q + 1;
             end
+        end
 
-            // if not first, aw is ready and we have credit -> count down
-            else if (aw_ready_decoupled & !first & aw_to_send_q != '0) begin
-                aw_sent = 1'b1;
-                aw_to_send_d = aw_to_send_q - 1;
-            end
+        // no AW can be released this cycle -> bank the credit
+        else if (first) begin
+            aw_to_send_d = aw_to_send_q + 1;
         end
     end
 
@@ -193,7 +184,6 @@ module idma_channel_coupler #(
 
     // state
     `FF(aw_to_send_q, aw_to_send_d, '0, clk_i, rst_ni)
-    `FF(aw_to_stall_q, aw_to_stall_d, '0, clk_i, rst_ni)
     `FF(aw_stall_q, aw_stall_d, '0, clk_i, rst_ni)
 
 

--- a/src/backend/tpl/idma_backend.sv.tpl
+++ b/src/backend/tpl/idma_backend.sv.tpl
@@ -852,6 +852,28 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
 
     if (RAWCouplingAvail) begin : gen_r_aw_coupler
 % if one_read_port and one_write_port and (used_read_protocols[0] == used_write_protocols[0]):
+        // per-transfer decouple_aw tag travelling with the write datapath request
+        logic w_decouple_aw_out;
+
+        // mirrors i_w_dp_req exactly: same depth, same push valid, same pop ready
+        cc_stream_fifo_optimal_wrap #(
+            .Depth     ( NumAxInFlight + ComputeFifoDepth ),
+            .data_t    ( logic                            ),
+            .PrintInfo ( PrintFifoInfo                    )
+        ) i_w_decouple_aw (
+            .clk_i      ( clk_i               ),
+            .rst_ni     ( rst_ni              ),
+            .clr_i      ( 1'b0                ),
+            .flush_i    ( 1'b0                ),
+            .usage_o    ( /* NOT CONNECTED */ ),
+            .data_i     ( w_req.decouple_aw   ),
+            .valid_i    ( w_valid             ),
+            .ready_o    ( /* NOT CONNECTED */ ),
+            .data_o     ( w_decouple_aw_out   ),
+            .valid_o    ( /* NOT CONNECTED */ ),
+            .ready_i    ( w_dp_req_out_ready  )
+        );
+
         // instantiate the channel coupler
         idma_channel_coupler #(
             .NumAxInFlight   ( NumAxInFlight               ),
@@ -871,6 +893,7 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
             .w_req_valid_i    ( w_chan_valid                ),
             .w_req_ready_i    ( w_chan_ready                ),
             .w_req_first_i    ( w_chan_first                ),
+            .w_decouple_aw_i  ( w_decouple_aw_out           ),
             .aw_decouple_aw_i ( \
 % if one_write_port:
 w_req.decouple_aw\

--- a/util/idma_params.py
+++ b/util/idma_params.py
@@ -15,6 +15,11 @@ Both slang and verilator take those flags verbatim. slang silently ignores a
 ``-G`` whose parameter does not exist, so every name is checked against the
 module header here; an unknown or misspelled parameter is a hard error rather
 than a configuration that quietly does not apply.
+
+An entry may carry a ``tb_params`` block next to ``params``. Those are applied
+only when the requested top is the entry's testbench, so a knob the synthesis
+wrapper does not have (a memory model, a watchdog) can still be part of the
+configuration a testbench is elaborated and simulated in.
 """
 
 import argparse
@@ -137,7 +142,10 @@ def main():
     seen = set()
     base = {}
     for name, body in matches:
-        params = body.get('params', {})
+        params = dict(body.get('params', {}))
+        # testbench-only knobs; the synthesis wrapper does not declare them
+        if body.get('testbench') == args.top:
+            params.update(body.get('tb_params', {}))
         unknown = sorted(set(params) - declared)
         if unknown:
             raise SystemExit('error: {} names parameter(s) {} that module {} does not '

--- a/util/run_vlt_sim.py
+++ b/util/run_vlt_sim.py
@@ -101,9 +101,10 @@ def main():
     build_log = os.path.join(workdir, tag + '_build.log')
     run_log = os.path.join(workdir, tag + '_run.log')
 
+    # 1ns/1ps like slang and questa; the default 1ps unit fires a 400 ms guard at 400 us
     build = shlex.split(args.verilator) + [
         '--binary', '--timing', '--assert', '-Wno-fatal', '--error-limit', '1000',
-        '-CFLAGS', '-O2',
+        '-CFLAGS', '-O2', '--timescale', '1ns/1ps',
         '--unroll-count', '4096', '--unroll-stmts', '200000',
         '-Mdir', objdir, '-o', 'simv',
         '-f', os.path.abspath(args.flist), '--top-module', args.top,

--- a/verify.mk
+++ b/verify.mk
@@ -63,6 +63,14 @@ define idma_elab_cfg
 	  $(IDMA_SOURCE_GLOBS) > $(IDMA_VERIFY_DIR)/$1.cfg
 endef
 
+# The same for a testbench $1: the jobs.json sets only, tb_params included
+define idma_elab_cfg_tb
+	mkdir -p $(IDMA_VERIFY_DIR)
+	$(PYTHON) $(IDMA_UTIL_DIR)/idma_params.py --top $1 \
+	  --jobs $(IDMA_ROOT)/$(IDMA_JOBS_JSON) \
+	  $(IDMA_SOURCE_GLOBS) > $(IDMA_VERIFY_DIR)/$1.cfg
+endef
+
 # Filelists
 $(IDMA_VLT_DIR)/idma_verify.f: $(IDMA_BENDER_FILES) $(IDMA_FULL_RTL) $(IDMA_INCLUDE_ALL)
 	mkdir -p $(IDMA_VLT_DIR)
@@ -105,10 +113,20 @@ idma_slang_elab: $(IDMA_SLANG_DIR)/synth.f
 	  echo "idma_slang_elab: $(IDMA_TOP) FAILED"; exit $$rc
 
 # slang only; verilator cannot parse the verification stack
+# One run per jobs.json configuration: a memory model reached by no entry is a
+# generate branch no gate ever elaborates
 idma_slang_tb: $(IDMA_SLANG_DIR)/tb.f
 	@test -n "$(IDMA_TOP)" || { echo "error: set IDMA_TOP=<module>"; exit 1; }
-	$(SLANG) -f $(IDMA_SLANG_DIR)/tb.f --top $(IDMA_TOP) \
-	  $(IDMA_SLANG_ARGS) $(IDMA_SLANG_TB_ARGS)
+	$(call idma_elab_cfg_tb,$(IDMA_TOP))
+	@test -s $(IDMA_VERIFY_DIR)/$(IDMA_TOP).cfg || \
+	  { echo "error: no configurations for $(IDMA_TOP)"; exit 1; }
+	@rc=0; while read -r cfg flags; do \
+	  echo "--- slang $(IDMA_TOP) [$$cfg] $$flags ---"; \
+	  $(SLANG) -f $(IDMA_SLANG_DIR)/tb.f --top $(IDMA_TOP) \
+	    $(IDMA_SLANG_ARGS) $(IDMA_SLANG_TB_ARGS) $$flags || rc=1; \
+	done < $(IDMA_VERIFY_DIR)/$(IDMA_TOP).cfg; \
+	test $$rc -eq 0 && echo "idma_slang_tb: $(IDMA_TOP) OK" || \
+	  echo "idma_slang_tb: $(IDMA_TOP) FAILED"; exit $$rc
 
 # One backend variant: synthesis top under both front ends, plus its testbench
 idma_verify_backend:


### PR DESCRIPTION
Fixes #190. On devel `idma_channel_coupler` releases an AW while its AW store is
empty, and miscounts AW credits under AW backpressure, so AW desynchronises from
W until the transfer hangs.

## Root cause

Two defects in the same block.

**1. AW released with nothing queued.** `aw_sent` is driven from `first` and
`aw_ready_decoupled` without qualifying on `aw_valid`, so the coupler asserts
`aw_valid_o` while the AW store is empty and presents a stale AW payload.
Measured at the pins: 82 AWs emitted for 81 queue pushes. That is an AXI4
write-pairing violation on its own, independent of any counter.

**2. The credit surrogate counts cycles, not AWs.** Before #80, `first` came off
the R side, where it carried `r_decouple_aw_i` and therefore pulsed only for
**coupled** transfers. #80 moved it to the W side, which carries no tag, and
added `aw_to_stall` as a scalar surrogate for the lost per-transfer bit. The
increment keys off a level:

```systemverilog
if (aw_decoupled_head & aw_valid & aw_to_send_q == '0)
    aw_to_stall_d = aw_to_stall_q + 1;
```

`aw_decoupled_head & aw_valid` holds for **every cycle** a decoupled AW waits at
the queue head, so under AW backpressure the counter charges stall cycles rather
than AWs. Measured on unmodified devel at a 512b bus, three consecutive cycles
increment with `aw_ready = 0`:

```
   time(ps)   stall     aw_valid aw_ready aw_dec_head aw_ready_i
     1610000   0->1       1        0        1          0
     1620000   1->2       1        0        1          0
     1630000   2->3       1        0        1          0
     1640000   3->4       1        1        1          1
```

A stall-cycle count has no relation to `NumAxInFlight`, so it saturates at the
counter maximum and wraps. On devel `CounterWidth = cc_pkg::idx_width(64) = 6`,
so `aw_to_stall_q` tops out at 63 and wraps there; no counter width would have
contained a cycle count.

## Fix

Both halves are needed.

**Gate every `aw_sent` on a non-empty AW queue.** An AW is only released when one
is actually queued. This is the half that stops the illegal AW, and it is the
half `tb_idma_mxrand` exercises: a build of this change with the gate but without
the tag still passes mxrand.

**Give the W side its per-transfer tag back.** The backend template mirrors the
write datapath request queue with a FIFO carrying `w_req.decouple_aw` (same
depth, same push valid, same pop ready), and the coupler re-qualifies `first`
from it:

```systemverilog
assign first = w_req_valid_i & w_req_first_i & ~aw_stall_q & ~w_decouple_aw_i;
```

`first` again pulses only for coupled transfers. This is the half that bounds the
credit counter and preserves RAW coupling, and it is why `aw_to_stall` can be
deleted outright rather than resized.

Deleting `aw_to_stall` is the containment fix, because it counted stall cycles
and would have wrapped at any width. `CounterWidth` also moves from `idx_width`,
which sizes an index over N values, to `cc_pkg::cnt_width`, which sizes a count
reaching N; that is defensive one-bit padding, not the containment.

## Severity on devel

Measured on a from-scratch build of base 757d54b5, Questa 2023.4:

- 7 of the 12 stock `jobs/backend_rw_axi/*.txt` deadlock once AW backpressure
  exists, under the `rw_axi_stall` configuration added below.
- Silent data corruption at DataWidth 32: `tb_idma_transpose_b2b` reports 838
  total mismatches, `tb_idma_transpose_nd` reports 1974.
- `tb_idma_mxperf` runs to its 400 ms timeout at DataWidth 32 and 64.

All of the above are green with this change.

## Verification

`tb_idma_mxrand` error lines by DataWidth, from independent from-scratch
rebuilds of base 757d54b5:

| | 32 | 64 | 256 | 512 | 1024 |
|---|---|---|---|---|---|
| devel | 2 | 1 | 0 | 9 | 0 |
| this PR | 0 | 0 | 0 | 0 | 0 |

The widths that fail also end in `** Fatal: [MXRD] timeout`, which an error-line
count does not include, so these counts understate the failure.

Rebuilt from the template in a clean worktree: `make idma_hw_all` regenerates
with no drift, Questa compiles with 0 errors, verible clean.

## Regression coverage

Before this branch nothing in `jobs/jobs.json` set `AXI_IdealMemory`,
`AXI_MemLatency` or `AXI_MemNumReqOutst`. Every backend run therefore used the
ideal memory path, where `axi_sim_mem` holds `aw_ready` high unconditionally, so
no gate in the tree has ever applied AW backpressure. The coupled `R`-`AW` path
is only reachable once an AW is made to wait, which is how a coupler that
asserts `aw_valid` over an empty AW store, and a credit counter that saturates
at its maximum and wraps, both stayed green.

`rw_axi_stall` is a new entry in the verification database. It reruns the twelve
stock `jobs/backend_rw_axi/*.txt` files over the throttled memory path that the
generated backend testbench already carries but nothing selected:

    NumAxInFlight      8
    AXI_IdealMemory    0
    AXI_MemNumReqOutst 2
    AXI_MemLatency     8
    WatchDogNumCycles  5000

No testbench or RTL source changes: the throttle and the multicut are already in
`test/tpl/tb_idma_backend.sv.tpl` behind `AXI_IdealMemory`. The leg is a pure
elaboration-parameter configuration, so the existing `rw_axi` leg is byte for
byte the run it was.

| leg | 757d54b5 (devel) | this branch |
|-----|------------------|-------------|
| `rw_axi` (ideal memory, unchanged) | 12/12 pass | 12/12 pass |
| `rw_axi_stall` (throttled memory) | 5/12 pass, 7 fail | 12/12 pass |

The seven failures on devel are `huge`, `large`, `medium`, `mixed`, `same_dst`,
`small` and `tiny`, all of them a deadlock reported by the write watchdog, and
`large`, `medium` and `small` additionally report the transfer as never acked.

`WatchDogNumCycles` is raised to 5000 for this leg because it had to be. At the
stock 100 the identical configuration fails `same_dst` on a healthy tree, so the
stock watchdog reports the fix and the defect alike and discriminates nothing.

The generated backend testbenches cannot be simulated by verilator, which is
recorded in `_verify.tops_untested`, so `rw_axi_stall` simulates wherever the
other directed job runs simulate. In the license-free flow it still adds a
second verilator and slang elaboration of `idma_backend_synth_rw_axi` at
`NumAxInFlight=8`, a slang elaboration of `tb_idma_backend_rw_axi` in the
throttled-memory configuration, and the `check_jobs.py` hygiene checks over the
new entry. `idma_slang_tb` now elaborates one run per database configuration
instead of one default run, so the `axi_throttle` plus `axi_multicut` generate
branch is elaborated for the first time; a generate-if only elaborates the
branch it takes, so that arm had no gate at all.

A database entry may now carry `tb_params` next to `params`. Those are applied
only when the requested top is the entry's testbench. The memory model and the
watchdog are testbench parameters, and `idma_params.py` rejects a `-G` the
requested module does not declare, which is the check that would otherwise have
to be relaxed to let the synthesis wrapper share the entry.

## Quarantined tops

`_verify.tops_untested` held four tops out of the public flow with reasons this
branch disproves. All four pass under Questa here:

| top | Questa on this branch |
|-----|-----------------------|
| `tb_idma_transpose_nd` | `[TPN] ALL PASS` at DataWidth 32 and 64 |
| `tb_idma_transpose_b2b` | `[B2BT] ALL PASS` at DataWidth 32 and 64 |
| `tb_idma_mxrand` | `[MXRD] ALL PASS` at DataWidth 32, 64, 256, 512, 1024 |
| `tb_idma_mxperf` | `[MXPF] ALL PASS` at DataWidth 32 and 64 |

`tb_idma_mxperf` is un-quarantined and runs as the `mxperf` suite at DataWidth 32
and 64. It was never broken; the verilator runs had no time base. Without
`--timescale`, verilator defaults to a 1 ps time unit, so the testbench's own
`#400_000_000` guard fires at 400 us of simulated time instead of 400 ms, and the
run needs 571 us. `run_vlt_sim.py` now builds with `--timescale 1ns/1ps`, the base
the slang elaboration (`IDMA_SLANG_TB_ARGS`) and Questa already use. Same tree,
same testbench: without the flag `[400000000] %Fatal: tb_idma_mxperf.sv:208:
[MXPF] timeout`, with the flag `[MXPF] ALL PASS` and `$finish` at 571 us. Every
suite already in the database was re-run under the new time base and still
passes: 28 legs across `mxquant`, `mxroundtrip`, `transpose`,
`transpose_midend`, `mxclear`, `mxneg` and the new `mxperf`, on verilator 5.046
and on 5.020, the version CI installs from apt.

The other three still fail under verilator here and stay out, but their entries
named causes this branch fixes, so they now carry the measured symptom:

- `tb_idma_transpose_nd`, was "AW outside the destination allocation at 80 ns",
  now "verilator only: the ND response never fires once the first case drains".
- `tb_idma_transpose_b2b`, was "stream_watchdog trip after 4000 idle cycles",
  now "verilator only: the first geometry never completes, watchdog trip".
- `tb_idma_mxrand`, was "testbench timeout at 400 ms of simulated time", now
  "verilator only: transfer 1 never completes, even at NumXfers=1 StallPct=0".

For `tb_idma_transpose_nd` the AW check the old reason named no longer fires, so
this branch gets past the point where devel failed under verilator: the first
geometry's AXI traffic drains normally, the ND midend never raises
`nd_rsp_valid`, and the watchdog trips 2000 idle cycles later at 20.23 us.
`tb_idma_transpose_b2b` is the same shape one level up, tripping at 40.23 us.
`tb_idma_mxrand` is not the time base: with `1ns/1ps` the guard fires at a true
400 ms with no output, and a single transfer with the stall shim transparent
(`-GNumXfers=1 -GStallPct=0`) does not complete either. These three verilator
divergences pre-date this branch and deserve their own investigation.

`tb_idma_nd_midend_b2b` and `tb_idma_rt_midend` keep their entries unchanged.

## Not a revert, and not a regression against v0.6.5

v0.6.5 is not a clean reference. Its own coupler loses AW credits and deadlocks
in 8 of 36 unit configurations, and it additionally has the AW starvation that
#80 fixed. This change keeps the #80 starvation fix and adds the queue gate and
the per-transfer tag, so it is strictly better than both v0.6.5 and devel and
carries no released-behaviour regression risk.

Two alternatives that kept the surrogate and invented a bound were rejected: one
sized it `4*NumAxInFlight + 16` while conceding the real bound was unknown, the
other used a `WriteQueueDepth` that is never driven, silently collapses to
`2*NumAxInFlight`, and then `$fatal`s at DW=32.

## Notes for review

The defect needs `RAWCouplingAvail = 1`, transfers with `decouple_aw = 1`, and
genuine AW backpressure. Against an always-ready memory model the level condition
lasts a single cycle and the old code is accidentally correct, which is why the
default job suite is green today; add real AW backpressure and 7 of its 12 jobs
deadlock. Nothing here is compute-specific, the compute tests are simply the ones
that inject stalls and run a deep write queue.

`RAWCouplingAvail` defaults to 1 in the generated synth wrappers, but only 2 of
19 `jobs.json` entries enable it. Worth adding non-MX coverage of this path in a
follow-up.

`rw_axi_stall` is the first `jobs.json` entry to reuse another entry's `proc_id`
and `synth_top`. `check_jobs.py`, `idma_params.py` and `run_verify.py` all handle
it; whatever generates the Questa simulation matrix from this database lives
outside this repo and should be checked to fan out over the new entry rather than
collide on the shared `proc_id`.
