### PR TITLE
backend: Add the dual-operand compute path for two-read-head backends

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -165,3 +165,5 @@ sources:
     files:
       - test/tb_idma_backend_multihead.sv
       - test/tb_idma_backend_multihead_rw.sv
+      - test/tb_idma_dual.sv
+      - test/tb_idma_dualneg.sv

--- a/doc/site/src/content/docs/architecture/compute.md
+++ b/doc/site/src/content/docs/architecture/compute.md
@@ -28,10 +28,10 @@ Compute is configured at two levels:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `EnableCompute` | `bit` | Elaborate the compute engine at all |
-| `ComputeOps` | `idma_pkg::compute_enable_t` | Per-op enable mask: `transpose`, `mxquant`, `mxdequant`, `mxfp16`, `alu`, `alu_mul` |
+| `ComputeOps` | `idma_pkg::compute_enable_t` | Per-op enable mask: `transpose`, `mxquant`, `mxdequant`, `mxfp16`, `alu`, `alu_mul`, `dual` |
 | `ComputeTuning` | `idma_pkg::compute_tuning_t` | Implementation knobs (`transpose_full_duplex`) |
 
-`mxfp16` gates the FP16 source/destination paths of the MX ops and `alu_mul` the ALU multiplier; leaving them off drops that area. An op (or ALU function) requested at run time but not elaborated is caught by the legalizer (`ComputeOpUnsupported`) and a simulation assertion in the dispatcher.
+`mxfp16` gates the FP16 source/destination paths of the MX ops and `alu_mul` the ALU multiplier; leaving them off drops that area. `dual` elaborates the second operand stream for the two-operand ALU functions (see [Two-Operand Transfers](#two-operand-transfers)) and only takes effect on backends with a single write port and one read protocol with at least two heads (`2r_axi_w_axi`). An op (or ALU function) requested at run time but not elaborated is caught by the legalizer (`ComputeOpUnsupported`, `ComputeOperandsUnsupported`) and a simulation assertion in the dispatcher.
 
 **Per transfer** (`idma_req_t.opt.compute`, type `idma_pkg::compute_options_t`):
 
@@ -88,8 +88,25 @@ The block scale is currently an internal signed 2's-complement value, not the OC
 | `ALU_ANDI` | `x & imm` | `alu` |
 | `ALU_ORI` | `x \| imm` | `alu` |
 | `ALU_XORI` | `x ^ imm` | `alu` |
+| `ALU_ADD` | `a + b` | `alu`, `dual` |
+| `ALU_SUB` | `a - b` | `alu`, `dual` |
+| `ALU_MUL` | `a * b` | `alu`, `alu_mul`, `dual` |
+| `ALU_AND` | `a & b` | `alu`, `dual` |
+| `ALU_OR` | `a \| b` | `alu`, `dual` |
+| `ALU_XOR` | `a ^ b` | `alu`, `dual` |
+| `ALU_AXPY` | `imm * a + b` | `alu`, `alu_mul`, `dual` |
 
-The unit is combinational and passes the per-lane valid/ready of the dataflow buffer straight through, so it has no alignment or length constraints beyond a plain copy and no internal state to drain. `tb_idma_alu` checks it byte-exact against a DPI-C golden across misaligned bases, partial tail beats, page crossings and multi-burst lengths.
+The unit is combinational and passes the per-lane valid/ready of the dataflow buffer straight through, so it has no alignment or length constraints beyond a plain copy and no internal state to drain. `tb_idma_alu` checks the single-operand functions byte-exact against a DPI-C golden across misaligned bases, partial tail beats, page crossings and multi-burst lengths; `tb_idma_dual` does the same for the two-operand functions on `2r_axi_w_axi`.
+
+## Two-Operand Transfers
+
+On a backend with two read heads and `ComputeOps.dual` set, a two-operand ALU function consumes two concurrent read streams: operand `a` from one head, operand `b` from the other. Software issues an **operand pair**: a normal transfer with the two-operand op (source `a`, the destination, `src_head` of `a`) immediately followed by its **operand-only partner** with the same compute configuration and length, source `b` and the other `src_head`. The partner writes nothing; its destination is ignored.
+
+- The legalizer parks the partner and interleaves the read bursts of both operands (`a`, `b`, `a`, ...); the first operand's reads only start once the partner is accepted, so neither stream can run ahead further than the per-head request queues hold. Each partner then completes with a single operand-only burst after the first operand's last write, so both requests get their response in order (the partner's never overtakes the first's).
+- The transport layer queues requests per read head (a role, `a` or `b`, sits on one head at a time), shifts each head's data into its own dataflow buffer and joins the two buffers lane by lane in front of the compute engine: a lane is presented once both operands hold it and popped from both when written. An operand that arrives early stalls in its buffer until the other has caught up.
+- Operand-only bursts issue no AW and no W; their response is fabricated once every earlier B has returned.
+
+Constraints (legalizer assertions): the request after a two-operand request must be its partner with the same compute configuration (`ComputeOperandPair`), the same length (`ComputeOperandLength`) and another read head (`ComputeOperandHead`); a two-operand function on a backend without the second stream is rejected (`ComputeOperandsUnsupported`). The two operands may be misaligned independently. Both requests use the AXI ID and options of the first for the write side; the partner's `src` AXI options apply to its reads. Error handling is not available with compute in general.
 
 ## Size-Changing Transfers
 
@@ -110,6 +127,8 @@ and forces `decouple_rw` / `decouple_aw` on for any compute transfer. Constraint
 | `ComputeMxSrcProtocol` / `ComputeMxDstProtocol` | size-changing ops are AXI-only on src and dst (OBI is a TODO) |
 | `ComputeDstTilelink` | compute retires per beat, so a TileLink destination is not supported |
 | `ComputeMxdequantLengthFits` | dequant output length must fit the `length` field width |
+| `ComputeOperandsUnsupported` | two-operand functions need `dual` on a two-read-head backend |
+| `ComputeOperandPair` / `ComputeOperandLength` / `ComputeOperandHead` | the operand-only partner follows immediately with the same config and length on another head |
 
 ## Source Files
 
@@ -120,4 +139,4 @@ and forces `decouple_rw` / `decouple_aw` on for any compute transfer. Constraint
 - `src/idma_float_pkg.sv` - FP32/FP16 <-> MXFP8 cast math and block scale
 - `src/idma_pkg.sv` - `compute_options_t`, `compute_op_e`, `alu_func_e`, `compute_enable_t`, MX block geometry
 - `src/backend/tpl/idma_legalizer.sv.tpl` - size-changing length calc and compute constraints
-- `src/backend/tpl/idma_transport_layer.sv.tpl` - engine instantiation (`gen_compute`)
+- `src/backend/tpl/idma_transport_layer.sv.tpl` - engine instantiation (`gen_compute`), operand streams (`gen_operand_streams`) and the operand-only write bypass

--- a/doc/site/src/content/docs/architecture/frontend/register.md
+++ b/doc/site/src/content/docs/architecture/frontend/register.md
@@ -107,7 +107,7 @@ Read when `compute_op` is `alu`; sampled together with `compute_cfg`.
 
 | Bits | Field | Description |
 |------|-------|-------------|
-| 3:0 | `alu_func` | Byte-wise function (`idma_pkg::alu_func_e`): `not`, `addi`, `subi`, `muli`, `andi`, `ori`, `xori` |
+| 3:0 | `alu_func` | Byte-wise function (`idma_pkg::alu_func_e`): `not`, `addi`, `subi`, `muli`, `andi`, `ori`, `xori`; two-operand `add`, `sub`, `mul`, `and`, `or`, `xor`, `axpy` (multi-head backends, not reachable from this frontend as it sets no `src_head`) |
 | 11:4 | `alu_imm` | 8-bit immediate, broadcast to every byte lane |
 | 31:12 | - | Reserved |
 

--- a/doc/site/src/content/docs/guides/verification.mdx
+++ b/doc/site/src/content/docs/guides/verification.mdx
@@ -169,7 +169,9 @@ The on-the-fly compute engines have dedicated self-checking testbenches, checked
 | `idma_sim_tb_idma_transpose_b2b` | ND midend -> `rw_axi` | Two back-to-back transposes to distinct destinations |
 | `idma_sim_tb_idma_mxquant` | `rw_axi` backend, `COMPUTE_MXQUANT{,_FP16}` | FP32/FP16 -> MXFP8 33 B blocks, golden `idma_mxquant_dpi.c`; one run crosses a 4K page |
 | `idma_sim_tb_idma_alu` | `rw_axi` backend, `COMPUTE_ALU` | Every ALU function over misaligned, tail-beat, page-crossing and multi-burst geometries at `DataWidth` 32..1024 under random AXI stalls, golden `idma_alu_dpi.c` |
-| `idma_sim_tb_idma_mxneg` | `rw_axi` backend | One illegal compute request per case; each legalizer guard must fire (cases 14-16 cover the ALU) |
+| `idma_sim_tb_idma_mxneg` | `rw_axi` backend | One illegal compute request per case; each legalizer guard must fire (cases 14-17 cover the ALU) |
+| `idma_sim_tb_idma_dual` | `2r_axi_w_axi` backend, two-operand `COMPUTE_ALU` | Operand pairs over independently misaligned, page-crossing and multi-burst geometries on both head assignments, single-operand ops and copies on either head, random stalls on all three AXI ports, golden `idma_alu_dpi.c`; builds the multi-head RTL in and restores the default set afterwards |
+| `idma_sim_tb_idma_dualneg` | `2r_axi_w_axi` backend | Operand-pair guards: mismatched partner, length, head, missing second stream |
 
 These `idma_sim_tb_*` targets drive Questa directly (they source `compile.tcl` and run under vsim), so they are Questa-only; pass the tool binaries through the `VSIM` / `VLOG` / `VLIB` variables:
 

--- a/idma.mk
+++ b/idma.mk
@@ -494,7 +494,7 @@ idma_sim_tb_idma_mxneg: $(IDMA_VSIM_DIR)/compile.tcl
 	         "10 ComputeTransposeSingleBeat 64 1 1 1 1" "11 ComputeMxdequantLengthFits 64 1 1 1 1" \
 	         "12 ComputeMxFp16Width 1024 1 1 1 1" "13 not.elaborated 64 1 0 1 1" \
 	         "14 ComputeOpUnsupported 64 1 1 0 1" "15 ComputeOpUnsupported 64 1 1 1 0" \
-	         "16 ComputeOpUnsupported 64 1 1 1 1"; do \
+	         "16 ComputeOpUnsupported 64 1 1 1 1" "17 ComputeOperandsUnsupported 64 1 1 1 1"; do \
 	  set -- $$c; \
 	  $(VSIM) -c -t 1ps -voptargs=+acc -gNegCase=$$1 -gDataWidth=$$3 -gEnDequant=$$4 -gEnFp16=$$5 \
 	    -gEnAlu=$$6 -gEnAluMul=$$7 \
@@ -508,6 +508,39 @@ idma_sim_tb_idma_alu: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
 	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_alu_dpi.c)
 	$(call idma_run_mx_sim,tb_idma_alu,32 64 128 256 512 1024)
+
+# Multi-head sims need the out-of-tree ids in the RTL; build them in, run, then restore
+IDMA_MH_SIM_IDS := 2r_axi_w_axi
+$(IDMA_VSIM_DIR)/compile_multihead.tcl: $(IDMA_BENDER_FILES)
+	$(MAKE) idma_hw_all IDMA_ADD_IDS="$(IDMA_MH_SIM_IDS)"
+	$(call idma_generate_vsim, $@, -t sim -t test -t idma_test -t synth -t rtl -t asic -t snitch_cluster -t multihead,../../..)
+
+define idma_restore_default_rtl
+	rm -f $(IDMA_FULL_RTL) $(IDMA_FULL_TB) $(IDMA_VSIM_DIR)/compile_multihead.tcl
+	$(MAKE) idma_hw_all
+endef
+
+.PHONY: idma_sim_tb_idma_dual
+idma_sim_tb_idma_dual: $(IDMA_VSIM_DIR)/compile_multihead.tcl
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile_multihead.tcl; quit"
+	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_alu_dpi.c)
+	$(call idma_run_mx_sim,tb_idma_dual,32 64 128 256 512 1024)
+	$(call idma_restore_default_rtl)
+
+# each case must print its guard assert; case 4 needs the second operand stream compiled out
+.PHONY: idma_sim_tb_idma_dualneg
+idma_sim_tb_idma_dualneg: $(IDMA_VSIM_DIR)/compile_multihead.tcl
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile_multihead.tcl; quit"
+	cd $(IDMA_VSIM_DIR); set -e; \
+	for c in "1 ComputeOperandPair 1" "2 ComputeOperandLength 1" "3 ComputeOperandHead 1" \
+	         "4 ComputeOperandsUnsupported 0"; do \
+	  set -- $$c; \
+	  $(VSIM) -c -t 1ps -voptargs=+acc -gNegCase=$$1 -gEnDual=$$3 \
+	    tb_idma_dualneg -do "run -all; quit" > dualneg_$$1.log 2>&1 || true; \
+	  if grep -qE "(ASSERT FAILED.*$$2|$$2)" dualneg_$$1.log; then echo "[DUALNEG] case $$1 $$2 FIRED"; \
+	  else echo "[DUALNEG] case $$1 $$2 DID NOT FIRE (see dualneg_$$1.log)"; exit 1; fi; \
+	done
+	$(call idma_restore_default_rtl)
 
 .PHONY: idma_sim_tb_idma_transpose_midend
 idma_sim_tb_idma_transpose_midend: $(IDMA_VSIM_DIR)/compile.tcl

--- a/jobs/jobs.json
+++ b/jobs/jobs.json
@@ -455,7 +455,8 @@
                 { "tag" : "mxneg_13", "params" : { "NegCase" : 13, "DataWidth" : 64, "EnDequant" : 1, "EnFp16" : 0 }, "token" : "ComputeOpUnsupported" },
                 { "tag" : "mxneg_14", "params" : { "NegCase" : 14, "DataWidth" : 64, "EnAlu" : 0 }, "token" : "ComputeOpUnsupported" },
                 { "tag" : "mxneg_15", "params" : { "NegCase" : 15, "DataWidth" : 64, "EnAluMul" : 0 }, "token" : "ComputeOpUnsupported" },
-                { "tag" : "mxneg_16", "params" : { "NegCase" : 16, "DataWidth" : 64 }, "token" : "ComputeOpUnsupported" }
+                { "tag" : "mxneg_16", "params" : { "NegCase" : 16, "DataWidth" : 64 }, "token" : "ComputeOpUnsupported" },
+                { "tag" : "mxneg_17", "params" : { "NegCase" : 17, "DataWidth" : 64 }, "token" : "ComputeOperandsUnsupported" }
             ],
             "exclude" : [
                 { "case" : 4,  "why" : "DataWidth 1024 SIGSEGVs on verilator 5.020; passes on 5.046" },
@@ -490,11 +491,11 @@
     "_verify" : {
         "elab_widths" : [32, 64, 512, 1024],
         "elab_compute" : [
-            { "width" : 64, "ops" : 63, "tuning" : 1 },
-            { "width" : 512, "ops" : 63, "tuning" : 1 },
-            { "width" : 64, "ops" : 32, "tuning" : 0 },
-            { "width" : 64, "ops" : 24, "tuning" : 1 },
-            { "width" : 64, "ops" : 2, "tuning" : 1 }
+            { "width" : 64, "ops" : 127, "tuning" : 1 },
+            { "width" : 512, "ops" : 127, "tuning" : 1 },
+            { "width" : 64, "ops" : 64, "tuning" : 0 },
+            { "width" : 64, "ops" : 48, "tuning" : 1 },
+            { "width" : 64, "ops" : 4, "tuning" : 1 }
         ],
         "elab_shared_tops" : [
             "idma_desc64_synth", "idma_nd_midend_synth",
@@ -510,7 +511,10 @@
         "guards_untested" : [
             { "guard" : "ComputeMxFp16Width", "why" : "only reachable from the excluded 1024 cases" },
             { "guard" : "ComputeMxdequantLengthFits", "why" : "case 11 is never accepted" },
-            { "guard" : "ComputeDstTilelink", "why" : "no TileLink backend variant exists" }
+            { "guard" : "ComputeDstTilelink", "why" : "no TileLink backend variant exists" },
+            { "guard" : "ComputeOperandPair", "why" : "multi-head only; fired by idma_sim_tb_idma_dualneg (Questa)" },
+            { "guard" : "ComputeOperandLength", "why" : "multi-head only; fired by idma_sim_tb_idma_dualneg (Questa)" },
+            { "guard" : "ComputeOperandHead", "why" : "multi-head only; fired by idma_sim_tb_idma_dualneg (Questa)" }
         ],
         "tops_untested" : [
             { "top" : "tb_idma_nd_midend_b2b", "why" : "hangs ([B2B] timeout); latent reset/LFSR race" },

--- a/src/backend/idma_axi_read.sv
+++ b/src/backend/idma_axi_read.sv
@@ -160,12 +160,12 @@ module idma_axi_read #(
 
     // the buffer can be pushed to if all the masked FIFO buffers (mask_in) are ready.
     assign in_ready = &(buffer_in_ready_i | ~mask_in);
-    // the read can accept data if the buffer is ready and the response channel is ready
-    assign read_req_o.r_ready = in_ready & r_dp_ready_i;
+    // the read can accept data if a request is present and buffer and response channel are ready
+    assign read_req_o.r_ready = in_ready & r_dp_ready_i & r_dp_valid_i;
 
     // once valid data is applied, it can be pushed in all the selected (mask_in) buffers
     // be sure the response channel is ready
-    assign in_valid          = read_rsp_i.r_valid & in_ready & r_dp_ready_i;
+    assign in_valid          = read_rsp_i.r_valid & in_ready & r_dp_ready_i & r_dp_valid_i;
     assign buffer_in_valid_o = in_valid ? mask_in : '0;
 
     // r_dp_ready_o is triggered by the last element arriving from the read

--- a/src/backend/idma_otf_alu.sv
+++ b/src/backend/idma_otf_alu.sv
@@ -8,20 +8,23 @@
 /// Byte-wise SIMD ALU: every byte lane is an independent 8-bit operand, arithmetic
 /// wraps modulo 256. Combinational per lane, so valid/ready pass through lane by lane
 /// and any alignment or tail beat is handled by the dataflow buffer as in a plain copy.
+/// Two-operand functions read `data_b_i` for `b`; the caller joins the two streams.
 module idma_otf_alu #(
   /// Byte lanes per beat (= DataWidth/8)
   parameter int unsigned StrbWidth = 32'd8,
-  /// Elaborate the multiplier (ALU_MULI); without it the function is a pass-through
+  /// Elaborate the multiplier (ALU_MULI/MUL/AXPY); without it those pass `a` through
   parameter bit          MulEn     = 1'b0
 ) (
   /// Function and byte immediate, stable for the transfer
   input  idma_pkg::alu_func_e             func_i,
   input  logic [idma_pkg::AluImmWidth-1:0] imm_i,
 
-  /// Input beat stream, per-lane handshake
+  /// Input beat stream (operand a), per-lane handshake
   input  logic [StrbWidth-1:0][7:0] data_i,
   input  logic [StrbWidth-1:0]      lane_valid_i,
   output logic [StrbWidth-1:0]      lane_ready_o,
+  /// Second operand stream (b), lane-aligned with `data_i`
+  input  logic [StrbWidth-1:0][7:0] data_b_i,
 
   /// Output beat stream, per-lane handshake
   output logic [StrbWidth-1:0][7:0] data_o,
@@ -39,6 +42,13 @@ module idma_otf_alu #(
         idma_pkg::ALU_ANDI: data_o[j] = data_i[j] & imm_i;
         idma_pkg::ALU_ORI:  data_o[j] = data_i[j] | imm_i;
         idma_pkg::ALU_XORI: data_o[j] = data_i[j] ^ imm_i;
+        idma_pkg::ALU_ADD:  data_o[j] = data_i[j] + data_b_i[j];
+        idma_pkg::ALU_SUB:  data_o[j] = data_i[j] - data_b_i[j];
+        idma_pkg::ALU_MUL:  data_o[j] = MulEn ? 8'(data_i[j] * data_b_i[j]) : data_i[j];
+        idma_pkg::ALU_AND:  data_o[j] = data_i[j] & data_b_i[j];
+        idma_pkg::ALU_OR:   data_o[j] = data_i[j] | data_b_i[j];
+        idma_pkg::ALU_XOR:  data_o[j] = data_i[j] ^ data_b_i[j];
+        idma_pkg::ALU_AXPY: data_o[j] = MulEn ? 8'(imm_i * data_i[j] + data_b_i[j]) : data_i[j];
         default:            data_o[j] = data_i[j];
       endcase
     end

--- a/src/backend/idma_otf_compute.sv
+++ b/src/backend/idma_otf_compute.sv
@@ -14,7 +14,9 @@ module idma_otf_compute #(
   /// Compile-time per-op feature enables
   parameter idma_pkg::compute_enable_t ComputeEnable = '0,
   /// Implementation tuning knobs
-  parameter idma_pkg::compute_tuning_t ComputeTuning = '1
+  parameter idma_pkg::compute_tuning_t ComputeTuning = '1,
+  /// Operand streams presented on `data_i` (2: a second, lane-aligned stream for dual ops)
+  parameter int unsigned NumOperands = 32'd1
 ) (
   input  logic clk_i,
   input  logic rst_ni,
@@ -25,10 +27,10 @@ module idma_otf_compute #(
   /// A supported compute op is armed for this transfer
   output logic                       active_o,
 
-  /// Input beat stream (from the dataflow buffer): per-lane valid/ready
-  input  logic [StrbWidth-1:0][7:0] data_i,
-  input  logic [StrbWidth-1:0]      lane_valid_i,
-  output logic [StrbWidth-1:0]      lane_ready_o,
+  /// Input beat stream(s) (from the dataflow buffers): per-lane valid/ready of the joined beat
+  input  logic [NumOperands*StrbWidth-1:0][7:0] data_i,
+  input  logic [StrbWidth-1:0]                  lane_valid_i,
+  output logic [StrbWidth-1:0]                  lane_ready_o,
 
   /// Output beat stream: per-lane valid (occupancy) + per-byte strobe (edge mask)
   output logic [StrbWidth-1:0][7:0] data_o,
@@ -65,6 +67,15 @@ module idma_otf_compute #(
   logic beat_valid;
   assign beat_valid = &lane_valid_i;
 
+  // operand split: a is always present, b only when a second stream is elaborated
+  logic [StrbWidth-1:0][7:0] data_a, data_b;
+  assign data_a = data_i[StrbWidth-1:0];
+  if (NumOperands > 1) begin : gen_operand_b
+    assign data_b = data_i[2*StrbWidth-1:StrbWidth];
+  end else begin : gen_no_operand_b
+    assign data_b = '0;
+  end
+
   // transpose sub-unit
   logic [StrbWidth-1:0][7:0] tp_data;
   logic [StrbWidth-1:0]      tp_strb;
@@ -82,7 +93,7 @@ module idma_otf_compute #(
       .transp_mode_i   ( eff_compute.params.transpose.mode       ),
       .tensor_size_m_i ( eff_compute.params.transpose.tensor_m   ),
       .tensor_size_n_i ( eff_compute.params.transpose.tensor_n   ),
-      .data_i          ( data_i                                  ),
+      .data_i          ( data_a                                  ),
       .valid_i         ( beat_valid & sel_transpose              ),
       .ready_o         ( tp_in_ready                             ),
       .data_o          ( tp_data                                 ),
@@ -108,7 +119,7 @@ module idma_otf_compute #(
       .rst_ni,
       .clear_i      ( ~sel_mxquant          ),
       .src_fmt_i    ( mx_fmt                ),
-      .data_i       ( data_i                ),
+      .data_i       ( data_a                ),
       .valid_i      ( beat_valid & sel_mxquant ),
       .ready_o      ( mx_in_ready           ),
       .data_o       ( mx_data               ),
@@ -135,7 +146,7 @@ module idma_otf_compute #(
       .rst_ni,
       .clear_i      ( ~sel_mxdequant          ),
       .dst_fmt_i    ( mx_fmt                  ),
-      .data_i       ( data_i                  ),
+      .data_i       ( data_a                  ),
       .valid_i      ( beat_valid & sel_mxdequant ),
       .ready_o      ( dq_in_ready             ),
       .data_o       ( dq_data                 ),
@@ -159,9 +170,10 @@ module idma_otf_compute #(
     ) i_idma_otf_alu (
       .func_i       ( eff_compute.params.alu.func ),
       .imm_i        ( eff_compute.params.alu.imm  ),
-      .data_i       ( data_i                      ),
+      .data_i       ( data_a                      ),
       .lane_valid_i ( lane_valid_i & {StrbWidth{sel_alu}} ),
       .lane_ready_o ( alu_lane_ready              ),
+      .data_b_i     ( data_b                      ),
       .data_o       ( alu_data                    ),
       .lane_valid_o ( alu_lane_valid              ),
       .lane_ready_i ( lane_ready_i & {StrbWidth{sel_alu}} )
@@ -215,6 +227,10 @@ module idma_otf_compute #(
     assert (idma_pkg::compute_op_supported(ComputeEnable, compute_i))
       else $fatal(1, "idma_otf_compute: compute op %0d not elaborated (ComputeEnable)",
                   compute_i.op);
+  // a two-operand op needs the second stream elaborated (legalizer fence reports first)
+  always @(posedge clk_i) if (rst_ni && cfg_valid_i && compute_i.enable)
+    assert (idma_pkg::compute_operands(compute_i) <= NumOperands)
+      else $fatal(1, "idma_otf_compute: two-operand op without a second operand stream");
   // backstop: the backend request interlock must never let a differing config in while busy
   always @(posedge clk_i) if (rst_ni && cfg_valid_i && (compute_i != latched_q))
     assert (!(mx_busy || dq_busy))

--- a/src/backend/tpl/idma_backend.sv.tpl
+++ b/src/backend/tpl/idma_backend.sv.tpl
@@ -220,6 +220,9 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
         offset_t              shift;
         logic                 decouple_aw;
         logic                 is_single;
+% if dual_operand_eligible:
+        logic                 operand_b;  // burst of the second (operand-only) stream
+% endif
     } r_dp_req_t;
 
     /// The datapath read response type provides feedback from the read part of the datapath:
@@ -249,6 +252,9 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
         axi_pkg::len_t        num_beats;
         logic                 is_single;
         idma_pkg::compute_options_t compute;
+% if dual_operand_eligible:
+        logic                 operand_only;  // completes without writing (operand-only transfer)
+% endif
     } w_dp_req_t;
 
     /// The datapath write response type provides feedback from the write part of the datapath:
@@ -443,6 +449,9 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
     // Compute config serialization interlock
     //--------------------------------------
     logic req_valid_leg, leg_ready;
+% if dual_operand_eligible:
+    logic leg_operand_pair;
+% endif
 % if compute_eligible:
     if (EnableCompute) begin : gen_compute_cfg_gate
         // a request whose compute config differs from the last accepted one waits
@@ -451,7 +460,13 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
         logic backend_active, cmp_cfg_stall;
         assign backend_active = busy_o.buffer_busy | busy_o.r_dp_busy | busy_o.w_dp_busy |
                                 busy_o.r_leg_busy | busy_o.w_leg_busy | busy_o.raw_coupler_busy;
+% if dual_operand_eligible:
+        // an operand pair shares one config; its partner passes so the legalizer can check it
+        assign cmp_cfg_stall  = req_valid & (idma_req_i.opt.compute != cmp_cfg_q) & backend_active &
+                                ~leg_operand_pair;
+% else:
         assign cmp_cfg_stall  = req_valid & (idma_req_i.opt.compute != cmp_cfg_q) & backend_active;
+% endif
         assign req_valid_leg  = req_valid & ~cmp_cfg_stall;
         assign req_ready_o    = leg_ready & ~cmp_cfg_stall;
         always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -501,10 +516,19 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
             .flush_i   ( legalizer_flush   ),
             .kill_i    ( legalizer_kill    ),
             .r_busy_o  ( busy_o.r_leg_busy ),
+% if dual_operand_eligible:
+            .w_busy_o  ( busy_o.w_leg_busy ),
+            .operand_pair_o ( leg_operand_pair )
+% else:
             .w_busy_o  ( busy_o.w_leg_busy )
+% endif
         );
 
     end else begin : gen_no_hw_legalizer
+% if dual_operand_eligible:
+        // NOT IMPLEMENTED: operand pairs need the hardware legalizer
+        assign leg_operand_pair = 1'b0;
+% endif
         // stream fork is used to synchronize the two decoupled channels without the need for a
         // FIFO here.
         cc_stream_fork #(
@@ -532,7 +556,12 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
             tailer:       OffsetWidth'(idma_req_i.length + idma_req_i.src_addr[OffsetWidth-1:0]),
             shift:        OffsetWidth'(idma_req_i.src_addr[OffsetWidth-1:0]),
             decouple_aw:  idma_req_i.opt.beo.decouple_aw,
+% if dual_operand_eligible:
+            is_single:    len == '0,
+            operand_b:    1'b0
+% else:
             is_single:    len == '0
+% endif
         };
 
         // assemble write datapath request
@@ -544,7 +573,12 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
             shift:        OffsetWidth'(- idma_req_i.dst_addr[OffsetWidth-1:0]),
             num_beats:    len,
             is_single:    len == '0,
+% if dual_operand_eligible:
+            compute:      idma_req_i.opt.compute,
+            operand_only: 1'b0
+% else:
             compute:      idma_req_i.opt.compute
+% endif
         };
 
         // if the legalizer is bypassed; every burst is the last of the 1D transfer
@@ -563,7 +597,12 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
 
     // data path, meta channels, and last queues have to be ready for the legalizer to be ready
     assign r_ready = r_dp_req_in_ready & ar_ready;
+% if dual_operand_eligible:
+    // an operand-only burst issues no AW
+    assign w_ready = w_dp_req_in_ready & (aw_ready | w_req.w_dp_req.operand_only) & w_last_ready;
+% else:
     assign w_ready = w_dp_req_in_ready & aw_ready & w_last_ready;
+% endif
 
 
     //--------------------------------------
@@ -758,6 +797,9 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
         .ComputeOps                  ( ComputeOps                  ),
         .ComputeTuning               ( ComputeTuning               ),
 % endif
+% if dual_operand_eligible:
+        .MetaFifoDepth               ( MetaFifoDepth               ),
+% endif
         .PrintFifoInfo               ( PrintFifoInfo               ),
         .r_dp_req_t                  ( r_dp_req_t                  ),
         .w_dp_req_t                  ( w_dp_req_t                  ),
@@ -914,7 +956,11 @@ w_req.decouple_aw || (w_req.w_dp_req.dst_protocol inside {\
 % else:           
  w_meta_req_tagged           ),
 % endif
+% if dual_operand_eligible:
+            .aw_valid_i       ( w_valid & ~w_req.w_dp_req.operand_only ),
+% else:
             .aw_valid_i       ( w_valid                     ),
+% endif
             .aw_ready_o       ( aw_ready                    ),
             .aw_req_o         ( aw_req_dp                   ),
             .aw_valid_o       ( aw_valid_dp                 ),
@@ -959,7 +1005,11 @@ w_req.decouple_aw || (w_req.w_dp_req.dst_protocol inside {\
     % else:
  w_meta_req_tagged         ),
     % endif
+% if dual_operand_eligible:
+            .valid_i   ( w_valid && aw_ready && !w_req.w_dp_req.operand_only ),
+% else:
             .valid_i   ( w_valid && aw_ready        ),
+% endif
             .ready_o   ( aw_ready                   ),
             .data_o    ( aw_req_dp                  ),
             .valid_o   ( aw_valid_dp                ),
@@ -979,7 +1029,11 @@ w_req.decouple_aw || (w_req.w_dp_req.dst_protocol inside {\
             .clk_i      ( clk_i             ),
             .rst_ni     ( rst_ni            ),
             .clr_i      ( 1'b0              ),
+% if dual_operand_eligible:
+            .valid_i    ( w_valid & ~w_req.w_dp_req.operand_only ),
+% else:
             .valid_i    ( w_valid           ),
+% endif
             .ready_o    ( aw_ready          ),
             .data_i     (\
     % if one_write_port:

--- a/src/backend/tpl/idma_legalizer.sv.tpl
+++ b/src/backend/tpl/idma_legalizer.sv.tpl
@@ -77,7 +77,13 @@ module idma_legalizer_${name_uniqueifier} #(
     /// Read machine of the legalizer is busy
     output logic r_busy_o,
     /// Write machine of the legalizer is busy
+% if dual_operand_eligible:
+    output logic w_busy_o,
+    /// A two-operand request waits for its operand-only partner
+    output logic operand_pair_o
+% else:
     output logic w_busy_o
+% endif
 );
 % if len(used_protocols) != 1:
     function int unsigned max_size(input int unsigned a, b);
@@ -183,6 +189,21 @@ ${database[p]['max_beats_per_burst']} * StrbWidth > ${database[p]['page_size']}\
     page_len_t w_num_bytes;
     offset_t   w_addr_offset;
     logic      w_done;
+% if dual_operand_eligible:
+
+    // operand pair: the parked partner interleaves its reads and completes with one ghost burst
+    idma_mut_tf_t     pair_tf_d,   pair_tf_q;
+    idma_mut_tf_t     pair_w_tf_d, pair_w_tf_q;
+    idma_mut_tf_opt_t pair_opt_d,  pair_opt_q;
+    logic [$bits(req_i.length)-1:0] pair_len_d, pair_len_q;
+    logic expect_b_d, expect_b_q, ghost_pending_d, ghost_pending_q, w_ghost_d, w_ghost_q;
+    logic r_operand_b_d, r_operand_b_q, dual_req, swap, ghost_load;
+    idma_mut_tf_t     r_tf_adv, w_tf_adv;
+    idma_mut_tf_opt_t opt_tf_adv;
+
+    assign dual_req = req_i.opt.compute.enable &
+                      (idma_pkg::compute_operands(req_i.opt.compute) == 32'd2);
+% endif
 
 
     //--------------------------------------
@@ -404,6 +425,19 @@ w_num_bytes_to_pb = w_page_num_bytes_to_pb;
         r_tf_d   = r_tf_q;
         w_tf_d   = w_tf_q;
         opt_tf_d = opt_tf_q;
+% if dual_operand_eligible:
+        pair_tf_d       = pair_tf_q;
+        pair_w_tf_d     = pair_w_tf_q;
+        pair_opt_d      = pair_opt_q;
+        pair_len_d      = pair_len_q;
+        expect_b_d      = expect_b_q;
+        ghost_pending_d = ghost_pending_q;
+        w_ghost_d       = w_ghost_q;
+        r_operand_b_d   = r_operand_b_q;
+        r_tf_adv        = r_tf_q;
+        w_tf_adv        = w_tf_q;
+        opt_tf_adv      = opt_tf_q;
+% endif
 
         // default: not done
         r_done = 1'b0;
@@ -458,6 +492,49 @@ w_num_bytes_to_pb = w_page_num_bytes_to_pb;
             w_done = 1'b1;
         end
 
+% if dual_operand_eligible:
+        //--------------------------------------
+        // Operand pair
+        //--------------------------------------
+        // the parked read tracker swaps in after every accepted burst of the active one
+        swap = pair_tf_q.valid & r_ready_i & !flush_i;
+        if (swap) begin
+            pair_tf_d               = r_tf_d;
+            r_tf_d                  = pair_tf_q;
+            opt_tf_d.src_head       = pair_opt_q.src_head;
+            opt_tf_d.src_protocol   = pair_opt_q.src_protocol;
+            opt_tf_d.read_shift     = pair_opt_q.read_shift;
+            opt_tf_d.src_axi_opt    = pair_opt_q.src_axi_opt;
+            opt_tf_d.src_max_llen   = pair_opt_q.src_max_llen;
+            opt_tf_d.src_reduce_len = pair_opt_q.src_reduce_len;
+            pair_opt_d.src_head       = opt_tf_q.src_head;
+            pair_opt_d.src_protocol   = opt_tf_q.src_protocol;
+            pair_opt_d.read_shift     = opt_tf_q.read_shift;
+            pair_opt_d.src_axi_opt    = opt_tf_q.src_axi_opt;
+            pair_opt_d.src_max_llen   = opt_tf_q.src_max_llen;
+            pair_opt_d.src_reduce_len = opt_tf_q.src_reduce_len;
+            r_operand_b_d           = ~r_operand_b_q;
+        end
+        // once the first operand's writes are issued, the partner's completion burst follows
+        ghost_load = ghost_pending_q & ~w_ghost_q & w_ready_i & !flush_i & (~w_tf_q.valid | w_done);
+        if (ghost_load) begin
+            w_tf_d                = pair_w_tf_q;
+            opt_tf_d.dst_protocol = pair_opt_q.dst_protocol;
+            opt_tf_d.dst_head     = pair_opt_q.dst_head;
+            opt_tf_d.write_shift  = pair_opt_q.write_shift;
+            opt_tf_d.dst_axi_opt  = pair_opt_q.dst_axi_opt;
+            opt_tf_d.super_last   = pair_opt_q.super_last;
+            w_ghost_d             = 1'b1;
+        end
+        if (w_ghost_q & w_tf_q.valid & w_ready_i & !flush_i) begin
+            ghost_pending_d = 1'b0;
+            w_ghost_d       = 1'b0;
+        end
+        r_tf_adv   = r_tf_d;
+        w_tf_adv   = w_tf_d;
+        opt_tf_adv = opt_tf_d;
+
+% endif
         //--------------------------------------
         // Refill
         //--------------------------------------
@@ -525,6 +602,24 @@ w_num_bytes_to_pb = w_page_num_bytes_to_pb;
                 opt_tf_d.read_shift  =   req_i.src_addr[OffsetWidth-1:0];
                 opt_tf_d.write_shift = - req_i.dst_addr[OffsetWidth-1:0];
             end
+% if dual_operand_eligible:
+            if (expect_b_q) begin
+                // operand-only partner: park it and keep the first operand's trackers running
+                pair_tf_d          = r_tf_d;
+                pair_w_tf_d        = w_tf_d;
+                pair_w_tf_d.length = 'd1;
+                pair_opt_d         = opt_tf_d;
+                r_tf_d             = r_tf_adv;
+                w_tf_d             = w_tf_adv;
+                opt_tf_d           = opt_tf_adv;
+                expect_b_d         = 1'b0;
+                ghost_pending_d    = 1'b1;
+            end else begin
+                expect_b_d    = dual_req;
+                pair_len_d    = req_i.length;
+                r_operand_b_d = 1'b0;
+            end
+% endif
         end
     end
 
@@ -561,7 +656,12 @@ ${database[protocol]['legalizer_read_meta_channel']}
         tailer:       OffsetWidth'(r_num_bytes + r_addr_offset),
         shift:        opt_tf_q.read_shift,
         decouple_aw:  opt_tf_q.decouple_aw,
+% if dual_operand_eligible:
+        is_single:    r_num_bytes <= StrbWidth,
+        operand_b:    r_operand_b_q
+% else:
         is_single:    r_num_bytes <= StrbWidth
+% endif
     };
 
     // Write meta channel and data path
@@ -634,6 +734,9 @@ ${database[protocol]['legalizer_write_data_path']}
     // busy output
     assign r_busy_o = r_tf_q.valid;
     assign w_busy_o = w_tf_q.valid;
+% if dual_operand_eligible:
+    assign operand_pair_o = expect_b_q;
+% endif
 
 
     //--------------------------------------
@@ -668,11 +771,20 @@ ${database[protocol]['legalizer_write_data_path']}
  })\
         % endif       
 ) begin
+% if dual_operand_eligible:
+            // a two-operand request reads only once its partner is here, so the bursts interleave
+            r_tf_ena  = (r_ready_i & !flush_i & !expect_b_q) | kill_i;
+            w_tf_ena  = (w_ready_i & !flush_i) | kill_i;
+
+            r_valid_o = r_tf_q.valid & r_ready_i & !flush_i & !expect_b_q;
+            w_valid_o = w_tf_q.valid & w_ready_i & !flush_i;
+% else:
             r_tf_ena  = (r_ready_i & !flush_i) | kill_i;
             w_tf_ena  = (w_ready_i & !flush_i) | kill_i;
 
             r_valid_o = r_tf_q.valid & r_ready_i & !flush_i;
             w_valid_o = w_tf_q.valid & w_ready_i & !flush_i;
+% endif
         end else begin
             r_tf_ena  = (r_ready_i & w_ready_i & !flush_i) | kill_i;
             w_tf_ena  = (r_ready_i & w_ready_i & !flush_i) | kill_i;
@@ -683,7 +795,13 @@ ${database[protocol]['legalizer_write_data_path']}
     end
 
     // load next idma request: if both machines are done!
+% if dual_operand_eligible:
+    assign ready_o = expect_b_q ? !flush_i :
+                     r_done & ~pair_tf_q.valid & w_done & ~(ghost_pending_q & ~w_ghost_q) &
+                     r_ready_i & w_ready_i & !flush_i;
+% else:
     assign ready_o = r_done & w_done & r_ready_i & w_ready_i & !flush_i;
+% endif
 
 
     //--------------------------------------
@@ -692,6 +810,16 @@ ${database[protocol]['legalizer_write_data_path']}
     `FF (opt_tf_q, opt_tf_d,           '0, clk_i, rst_ni)
     `FFL(r_tf_q,   r_tf_d,   r_tf_ena, '0, clk_i, rst_ni)
     `FFL(w_tf_q,   w_tf_d,   w_tf_ena, '0, clk_i, rst_ni)
+% if dual_operand_eligible:
+    `FF (pair_tf_q,       pair_tf_d,       '0, clk_i, rst_ni)
+    `FF (pair_w_tf_q,     pair_w_tf_d,     '0, clk_i, rst_ni)
+    `FF (pair_opt_q,      pair_opt_d,      '0, clk_i, rst_ni)
+    `FF (pair_len_q,      pair_len_d,      '0, clk_i, rst_ni)
+    `FF (expect_b_q,      expect_b_d,      '0, clk_i, rst_ni)
+    `FF (ghost_pending_q, ghost_pending_d, '0, clk_i, rst_ni)
+    `FF (w_ghost_q,       w_ghost_d,       '0, clk_i, rst_ni)
+    `FF (r_operand_b_q,   r_operand_b_d,   '0, clk_i, rst_ni)
+% endif
 
 
     //--------------------------------------
@@ -755,6 +883,22 @@ ${database[protocol]['legalizer_write_data_path']}
                   ~(EnableCompute &
                     idma_pkg::compute_op_supported(ComputeOps, req_i.opt.compute))),
                   clk_i, !rst_ni)
+% endif
+% if dual_operand_eligible:
+    // a two-operand op needs the second operand stream elaborated
+    `ASSERT_NEVER(ComputeOperandsUnsupported, (ready_o & valid_i & dual_req &
+                  ~(EnableCompute & ComputeOps.dual)), clk_i, !rst_ni)
+    // the request after a two-operand request is its partner: same op and length, other head
+    `ASSERT_NEVER(ComputeOperandPair, (ready_o & valid_i & expect_b_q &
+                  ~(dual_req & (req_i.opt.compute == opt_tf_q.compute))), clk_i, !rst_ni)
+    `ASSERT_NEVER(ComputeOperandLength, (ready_o & valid_i & expect_b_q &
+                  (req_i.length != pair_len_q)), clk_i, !rst_ni)
+    `ASSERT_NEVER(ComputeOperandHead, (ready_o & valid_i & expect_b_q &
+                  (req_i.opt.src_head == opt_tf_q.src_head)), clk_i, !rst_ni)
+% elif compute_eligible:
+    // NOT IMPLEMENTED: two-operand ops need a multi-head read backend
+    `ASSERT_NEVER(ComputeOperandsUnsupported, (ready_o & valid_i & req_i.opt.compute.enable &
+                  (idma_pkg::compute_operands(req_i.opt.compute) == 32'd2)), clk_i, !rst_ni)
 % endif
 
 endmodule

--- a/src/backend/tpl/idma_transport_layer.sv.tpl
+++ b/src/backend/tpl/idma_transport_layer.sv.tpl
@@ -29,6 +29,10 @@ module idma_transport_layer_${name_uniqueifier} #(
     /// Implementation tuning knobs for the compute engines
     parameter idma_pkg::compute_tuning_t ComputeTuning = '1,
 % endif
+% if dual_operand_eligible:
+    /// Write bursts that can be in flight; bounds the operand-only completion counter
+    parameter int unsigned MetaFifoDepth = 32'd8,
+% endif
     /// Print the info of the FIFO configuration
     parameter bit PrintFifoInfo = 1'b0,
     /// `r_dp_req_t` type:
@@ -279,6 +283,30 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
 % if one_write_port:
     assign w_dp_ready_o = w_dp_req_ready;
 % endif
+% if dual_operand_eligible:
+<%
+    drp = dual_read_protocol
+    dmh = mh_format['ar'][drp]
+%>
+    /// Operand streams: 2 when the compute engine has the second (b) stream
+    localparam int unsigned NumOperands = (EnableCompute && ComputeOps.dual) ? 32'd2 : 32'd1;
+
+    // per-head read request handles (single-stream mux or per-head queues, see below)
+    r_dp_req_t ${dmh}${drp}_r_dp_req_h;
+    logic      ${dmh}${drp}_r_dp_valid_h;
+    logic      ${dmh}${drp}_r_dp_rsp_ready_h;
+    strb_t     ${dmh}${drp}_buffer_in_ready_h;
+    logic      r_dp_queued;
+
+    // second operand buffer output and the join with the first
+    byte_t [StrbWidth-1:0] buffer_b_out;
+    strb_t                 buffer_b_out_valid, buffer_b_ready;
+    logic                  cmp_dual;
+
+    // write port behind the operand-only bypass
+    logic      w_port_dp_valid, w_port_dp_ready, w_port_rsp_valid, w_port_rsp_ready;
+    w_dp_rsp_t w_port_dp_rsp;
+% endif
 
     //--------------------------------------
     // Read Ports
@@ -288,7 +316,173 @@ _rsp_t ${mh_format['aw'][protocol]}${protocol}_write_rsp_i,
 ${rendered_read_ports[read_port]}
 
 % endfor
-% if not one_read_port:
+% if dual_operand_eligible:
+    //--------------------------------------
+    // Read Multiplexers / Operand Streams
+    //--------------------------------------
+
+    always_comb begin : gen_read_meta_channel_multiplexer
+        case(ar_req_i.src_protocol)
+        idma_pkg::${database[drp]['protocol_enum']}: ar_ready_o = ${drp}_ar_ready [ar_req_i.src_head];
+        default:       ar_ready_o = 1'b0;
+        endcase
+    end
+
+    // request whose beats enter the first operand buffer (selects the read shift)
+    r_dp_req_t buffer_in_req;
+
+    if (NumOperands == 32'd2) begin : gen_operand_streams
+        // per-head fall-through queues run both operands at once; a role sits on one head at a time
+        logic [${dual_num_heads}-1:0] head_role_b, head_act_a, head_act_b, head_hold_a, head_hold_b;
+        logic [${dual_num_heads}-1:0] head_sel, head_q_ready;
+        strb_t                   buffer_b_in_valid, buffer_b_in_ready;
+        byte_t [StrbWidth-1:0]   buffer_b_in, buffer_b_in_shifted;
+        byte_t [2*StrbWidth-1:0] buffer_b_in_tmp;
+        r_dp_req_t               buffer_b_in_req;
+
+        for (genvar h = 0; h < ${dual_num_heads}; h++) begin : gen_head_queue
+            logic [cc_pkg::cnt_width(2)-1:0] head_q_usage;
+            assign head_role_b[h] = ${drp}_r_dp_req_h[h].operand_b;
+            assign head_act_a[h]  = ${drp}_r_dp_valid_h[h] & ~head_role_b[h];
+            assign head_act_b[h]  = ${drp}_r_dp_valid_h[h] &  head_role_b[h];
+            assign head_hold_a[h] = (head_q_usage != '0) & ~head_role_b[h];
+            assign head_hold_b[h] = (head_q_usage != '0) &  head_role_b[h];
+            assign head_sel[h]    = r_dp_valid_i &
+                (r_dp_req_i.src_protocol == idma_pkg::${database[drp]['protocol_enum']}) &
+                (r_dp_req_i.src_head == h) &
+                ~|((r_dp_req_i.operand_b ? head_hold_b : head_hold_a) &
+                   ~(${dual_num_heads}'d1 << h));
+
+            cc_stream_fifo #(
+                .FallThrough ( 1'b1       ),
+                .Depth       ( 32'd2      ),
+                .data_t      ( r_dp_req_t )
+            ) i_head_queue (
+                .clk_i,
+                .rst_ni,
+                .clr_i   ( 1'b0                    ),
+                .flush_i ( 1'b0                    ),
+                .usage_o ( head_q_usage            ),
+                .data_i  ( r_dp_req_i              ),
+                .valid_i ( head_sel[h]             ),
+                .ready_o ( head_q_ready[h]         ),
+                .data_o  ( ${drp}_r_dp_req_h[h]    ),
+                .valid_o ( ${drp}_r_dp_valid_h[h]  ),
+                .ready_i ( ${drp}_r_dp_ready[h]    )
+            );
+
+            assign ${drp}_r_dp_rsp_ready_h[h] = r_dp_ready_i;
+            assign ${drp}_buffer_in_ready_h[h] = head_role_b[h] ? buffer_b_in_ready
+                                                                : buffer_in_ready;
+        end
+
+        assign r_dp_ready_o = |(head_sel & head_q_ready);
+        assign r_dp_queued  = |${drp}_r_dp_valid_h;
+
+        // read responses are only consumed by the error handler, which compute excludes
+        always_comb begin : gen_read_response_multiplexer
+            r_dp_valid_o = 1'b0;
+            r_dp_rsp_o   = '0;
+            for (int unsigned h = 0; h < ${dual_num_heads}; h++) begin
+                if (${drp}_r_dp_valid[h]) begin
+                    r_dp_valid_o = 1'b1;
+                    r_dp_rsp_o   = ${drp}_r_dp_rsp[h];
+                end
+            end
+        end
+
+        // the a-role head feeds the first buffer, the b-role head the second
+        always_comb begin : gen_operand_multiplexer
+            buffer_in         = '0;
+            buffer_in_valid   = '0;
+            buffer_in_req     = '0;
+            buffer_b_in       = '0;
+            buffer_b_in_valid = '0;
+            buffer_b_in_req   = '0;
+            for (int unsigned h = 0; h < ${dual_num_heads}; h++) begin
+                if (head_act_a[h]) begin
+                    buffer_in       = ${drp}_buffer_in[h];
+                    buffer_in_valid = ${drp}_buffer_in_valid[h];
+                    buffer_in_req   = ${drp}_r_dp_req_h[h];
+                end
+                if (head_act_b[h]) begin
+                    buffer_b_in       = ${drp}_buffer_in[h];
+                    buffer_b_in_valid = ${drp}_buffer_in_valid[h];
+                    buffer_b_in_req   = ${drp}_r_dp_req_h[h];
+                end
+            end
+        end
+
+        assign buffer_b_in_tmp     = {buffer_b_in, buffer_b_in} >> (buffer_b_in_req.shift * 8);
+        assign buffer_b_in_shifted = buffer_b_in_tmp[$bits(buffer_b_in_shifted)/8-1:0];
+
+        idma_dataflow_element #(
+            .BufferDepth   ( BufferDepth   ),
+            .StrbWidth     ( StrbWidth     ),
+            .PrintFifoInfo ( PrintFifoInfo ),
+            .strb_t        ( strb_t        ),
+            .byte_t        ( byte_t        )
+        ) i_dataflow_element_b (
+            .clk_i       ( clk_i               ),
+            .rst_ni      ( rst_ni              ),
+            .data_i      ( buffer_b_in_shifted ),
+            .valid_i     ( buffer_b_in_valid   ),
+            .ready_o     ( buffer_b_in_ready   ),
+            .data_o      ( buffer_b_out        ),
+            .valid_o     ( buffer_b_out_valid  ),
+            .ready_i     ( buffer_b_ready      )
+        );
+
+        assign cmp_dual = idma_pkg::compute_operands(w_dp_req_i.compute) == 32'd2;
+    end else begin : gen_read_multiplexer
+        for (genvar h = 0; h < ${dual_num_heads}; h++) begin : gen_head_handle
+            assign ${drp}_r_dp_req_h[h]       = r_dp_req_i;
+            assign ${drp}_r_dp_valid_h[h]     =
+                (r_dp_req_i.src_protocol == idma_pkg::${database[drp]['protocol_enum']}) &
+                (r_dp_req_i.src_head == h) & r_dp_valid_i;
+            assign ${drp}_r_dp_rsp_ready_h[h] =
+                (r_dp_req_i.src_protocol == idma_pkg::${database[drp]['protocol_enum']}) &
+                (r_dp_req_i.src_head == h) & r_dp_ready_i;
+            assign ${drp}_buffer_in_ready_h[h] = buffer_in_ready;
+        end
+        assign r_dp_queued       = 1'b0;
+        assign buffer_in_req     = r_dp_req_i;
+        assign buffer_b_out      = '0;
+        assign buffer_b_out_valid = '0;
+        assign cmp_dual          = 1'b0;
+
+        always_comb begin
+            if (r_dp_valid_i) begin
+                case(r_dp_req_i.src_protocol)
+                idma_pkg::${database[drp]['protocol_enum']}: begin
+                    r_dp_ready_o    = ${drp}_r_dp_ready [r_dp_req_i.src_head];
+                    r_dp_rsp_o      = ${drp}_r_dp_rsp [r_dp_req_i.src_head];
+                    r_dp_valid_o    = ${drp}_r_dp_valid [r_dp_req_i.src_head];
+
+                    buffer_in       = ${drp}_buffer_in [r_dp_req_i.src_head];
+                    buffer_in_valid = ${drp}_buffer_in_valid [r_dp_req_i.src_head];
+                end
+                default: begin
+                    r_dp_ready_o    = 1'b0;
+                    r_dp_rsp_o      = '0;
+                    r_dp_valid_o    = 1'b0;
+
+                    buffer_in       = '0;
+                    buffer_in_valid = '0;
+                end
+                endcase
+            end else begin
+                r_dp_ready_o    = 1'b0;
+                r_dp_rsp_o      = '0;
+                r_dp_valid_o    = 1'b0;
+
+                buffer_in       = '0;
+                buffer_in_valid = '0;
+            end
+        end
+    end
+
+% elif not one_read_port:
     //--------------------------------------
     // Read Multiplexers
     //--------------------------------------
@@ -354,7 +548,11 @@ ${rendered_read_ports[read_port]}
     // Read Barrel shifter
     //--------------------------------------
 
+% if dual_operand_eligible:
+    assign buffer_in_tmp = {buffer_in, buffer_in} >> (buffer_in_req.shift * 8);
+% else:
     assign buffer_in_tmp = {buffer_in, buffer_in} >> (r_dp_req_i.shift * 8);
+% endif
     assign buffer_in_shifted = buffer_in_tmp[$bits(buffer_in_shifted)/8-1:0];
 
     //--------------------------------------
@@ -382,7 +580,58 @@ ${rendered_read_ports[read_port]}
     // On-the-fly compute
     //--------------------------------------
 
-% if compute_eligible:
+% if dual_operand_eligible:
+    if (EnableCompute) begin : gen_compute
+        logic                  cmp_active;
+        byte_t [StrbWidth-1:0] cmp_data_o;
+        strb_t                 cmp_strb_o, cmp_lane_valid, cmp_lane_ready, cmp_lane_valid_i;
+        byte_t [NumOperands*StrbWidth-1:0] cmp_data_i;
+
+        if (NumOperands == 32'd2) begin : gen_two_operands
+            assign cmp_data_i = {buffer_b_out, buffer_out};
+        end else begin : gen_one_operand
+            assign cmp_data_i = buffer_out;
+        end
+
+        idma_otf_compute #(
+            .StrbWidth           ( StrbWidth          ),
+            .ComputeEnable       ( ComputeOps         ),
+            .ComputeTuning       ( ComputeTuning      ),
+            .NumOperands         ( NumOperands        )
+        ) i_idma_otf_compute (
+            .clk_i,
+            .rst_ni,
+            .compute_i   ( w_dp_req_i.compute ),
+            .cfg_valid_i ( w_dp_valid_i        ),
+            .active_o    ( cmp_active          ),
+            .data_i       ( cmp_data_i          ),
+            .lane_valid_i ( cmp_lane_valid_i    ),
+            .lane_ready_o ( cmp_lane_ready      ),
+            .data_o       ( cmp_data_o          ),
+            .strb_o       ( cmp_strb_o          ),
+            .lane_valid_o ( cmp_lane_valid      ),
+            .ready_i      ( w_dp_req_ready      ),
+            .lane_ready_i ( buffer_out_ready_shifted )
+        );
+
+        // join: a two-operand op sees a lane once both buffers hold it and pops both
+        assign cmp_lane_valid_i  = cmp_dual ? buffer_out_valid & buffer_b_out_valid
+                                            : buffer_out_valid;
+        assign wr_data           = cmp_active ? cmp_data_o : buffer_out;
+        assign wr_valid          = cmp_active ? cmp_lane_valid : buffer_out_valid;
+        assign wr_strb           = cmp_active ? cmp_strb_o : '1;
+        assign dataflow_ready_in = cmp_active ? (cmp_dual ? cmp_lane_ready & buffer_b_out_valid
+                                                          : cmp_lane_ready)
+                                              : buffer_out_ready_shifted;
+        assign buffer_b_ready    = (cmp_active & cmp_dual) ? cmp_lane_ready & buffer_out_valid : '0;
+    end else begin : gen_no_compute
+        assign wr_data           = buffer_out;
+        assign wr_valid          = buffer_out_valid;
+        assign wr_strb           = '1;
+        assign dataflow_ready_in = buffer_out_ready_shifted;
+        assign buffer_b_ready    = '0;
+    end
+% elif compute_eligible:
     if (EnableCompute) begin : gen_compute
         logic                  cmp_active;
         byte_t [StrbWidth-1:0] cmp_data_o;
@@ -495,6 +744,40 @@ ${rendered_read_ports[read_port]}
 % endfor
         default:       aw_ready_o = 1'b0;
         endcase
+    end
+
+% endif
+% if dual_operand_eligible:
+    //--------------------------------------
+    // Operand-only write bypass
+    //--------------------------------------
+
+    if (NumOperands == 32'd2) begin : gen_operand_only_write
+        // an operand-only burst writes nothing; its response follows every pending B
+        logic [cc_pkg::cnt_width(MetaFifoDepth)-1:0] b_pending_d, b_pending_q;
+        logic ghost, ghost_fire;
+
+        assign ghost      = w_dp_valid_i & w_dp_req_i.operand_only;
+        assign ghost_fire = ghost & (b_pending_q == '0);
+
+        assign w_port_dp_valid  = w_dp_valid_i & ~ghost;
+        assign w_dp_req_ready   = ghost ? ghost_fire & w_dp_ready_i : w_port_dp_ready;
+        assign w_dp_valid_o     = ghost_fire | w_port_rsp_valid;
+        assign w_dp_rsp_o       = ghost_fire ? '0 : w_port_dp_rsp;
+        assign w_port_rsp_ready = w_dp_ready_i & ~ghost_fire;
+
+        always_comb begin
+            b_pending_d = b_pending_q;
+            if (w_port_dp_valid & w_port_dp_ready)   b_pending_d = b_pending_d + 1'b1;
+            if (w_port_rsp_valid & w_port_rsp_ready) b_pending_d = b_pending_d - 1'b1;
+        end
+        `FF(b_pending_q, b_pending_d, '0, clk_i, rst_ni)
+    end else begin : gen_no_operand_only_write
+        assign w_port_dp_valid  = w_dp_valid_i;
+        assign w_dp_req_ready   = w_port_dp_ready;
+        assign w_dp_valid_o     = w_port_rsp_valid;
+        assign w_dp_rsp_o       = w_port_dp_rsp;
+        assign w_port_rsp_ready = w_dp_ready_i;
     end
 
 % endif
@@ -622,8 +905,14 @@ ${rendered_write_ports[write_port]}
     //--------------------------------------
     // Module Control
     //--------------------------------------
+% if dual_operand_eligible:
+    assign r_dp_busy_o   = r_dp_valid_i | r_dp_queued;
+    assign w_dp_busy_o   = w_dp_valid_i | w_dp_ready_o;
+    assign buffer_busy_o = |buffer_out_valid | |buffer_b_out_valid;
+% else:
     assign r_dp_busy_o   = r_dp_valid_i;
     assign w_dp_busy_o   = w_dp_valid_i | w_dp_ready_o;
     assign buffer_busy_o = |buffer_out_valid;
+% endif
 
 endmodule

--- a/src/db/idma_axi.yml
+++ b/src/db/idma_axi.yml
@@ -68,7 +68,7 @@ legalizer_write_data_path: |
         shift: opt_tf_q.write_shift,
         num_beats: w_req_o.aw_req.axi.aw_chan.len,
         is_single: w_req_o.aw_req.axi.aw_chan.len == '0,
-        compute: opt_tf_q.compute
+        compute: opt_tf_q.compute${w_dp_req_extra}
     };
 read_template: |
     idma_axi_read #(
@@ -83,7 +83,7 @@ read_template: |
     ) i_idma_axi_read${mh} (
         .clk_i             ( clk_i      ),
         .rst_ni            ( rst_ni     ),
-        .r_dp_req_i        ( r_dp_req_i ),
+        .r_dp_req_i        ( ${r_dp_req_i} ),
         .r_dp_valid_i      ( ${r_dp_valid_i} ),
         .r_dp_ready_o      ( ${r_dp_ready_o} ),
         .r_dp_rsp_o        ( ${r_dp_rsp_o} ),
@@ -96,7 +96,7 @@ read_template: |
         .read_rsp_i        ( ${read_response} ),
         .buffer_in_o       ( ${buffer_in} ),
         .buffer_in_valid_o ( ${buffer_in_valid} ),
-        .buffer_in_ready_i ( buffer_in_ready )
+        .buffer_in_ready_i ( ${buffer_in_ready} )
     );
 write_template: |
     idma_axi_write #(

--- a/src/db/idma_axi_lite.yml
+++ b/src/db/idma_axi_lite.yml
@@ -66,7 +66,7 @@ read_template: |
         .read_req_t ( ${req_t}      ),
         .read_rsp_t ( ${rsp_t}      )
     ) i_idma_axil_read${mh} (
-        .r_dp_req_i        ( r_dp_req_i ),
+        .r_dp_req_i        ( ${r_dp_req_i} ),
         .r_dp_valid_i      ( ${r_dp_valid_i} ),
         .r_dp_ready_o      ( ${r_dp_ready_o} ),
         .r_dp_rsp_o        ( ${r_dp_rsp_o} ),
@@ -79,7 +79,7 @@ read_template: |
         .read_rsp_i        ( ${read_response}     ),
         .buffer_in_o       ( ${buffer_in}         ),
         .buffer_in_valid_o ( ${buffer_in_valid}   ),
-        .buffer_in_ready_i ( buffer_in_ready      )
+        .buffer_in_ready_i ( ${buffer_in_ready}      )
     );
 write_template: |
     idma_axil_write #(

--- a/src/db/idma_axi_stream.yml
+++ b/src/db/idma_axi_stream.yml
@@ -231,7 +231,7 @@ read_template: |
         .read_req_t       ( ${req_t} ),
         .read_rsp_t       ( ${rsp_t} )
     ) i_idma_axis_read${mh} (
-        .r_dp_req_i        ( r_dp_req_i ),
+        .r_dp_req_i        ( ${r_dp_req_i} ),
         .r_dp_req_valid_i  ( ${r_dp_valid_i} ),
         .r_dp_req_ready_o  ( ${r_dp_ready_o} ),
         .r_dp_rsp_o        ( ${r_dp_rsp_o} ),
@@ -244,7 +244,7 @@ read_template: |
         .read_rsp_o        ( ${read_response} ),
         .buffer_in_o       ( ${buffer_in} ),
         .buffer_in_valid_o ( ${buffer_in_valid} ),
-        .buffer_in_ready_i ( buffer_in_ready )
+        .buffer_in_ready_i ( ${buffer_in_ready} )
     );
 write_template: |
     idma_axis_write #(

--- a/src/db/idma_init.yml
+++ b/src/db/idma_init.yml
@@ -88,7 +88,7 @@ read_template: |
         .read_req_t       ( ${req_t}           ),
         .read_rsp_t       ( ${rsp_t}           )
     ) i_idma_init_read${mh} (
-        .r_dp_req_i        ( r_dp_req_i ),
+        .r_dp_req_i        ( ${r_dp_req_i} ),
         .r_dp_valid_i      ( ${r_dp_valid_i} ),
         .r_dp_ready_o      ( ${r_dp_ready_o} ),
         .r_dp_rsp_o        ( ${r_dp_rsp_o} ),
@@ -101,7 +101,7 @@ read_template: |
         .read_rsp_i        ( ${read_response} ),
         .buffer_in_o       ( ${buffer_in} ),
         .buffer_in_valid_o ( ${buffer_in_valid} ),
-        .buffer_in_ready_i ( buffer_in_ready )
+        .buffer_in_ready_i ( ${buffer_in_ready} )
     );
 write_template: |
     idma_init_write #(

--- a/src/db/idma_obi.yml
+++ b/src/db/idma_obi.yml
@@ -73,7 +73,7 @@ read_template: |
         .read_req_t       ( ${req_t}           ),
         .read_rsp_t       ( ${rsp_t}           )
     ) i_idma_obi_read${mh} (
-        .r_dp_req_i        ( r_dp_req_i ),
+        .r_dp_req_i        ( ${r_dp_req_i} ),
         .r_dp_valid_i      ( ${r_dp_valid_i} ),
         .r_dp_ready_o      ( ${r_dp_ready_o} ),
         .r_dp_rsp_o        ( ${r_dp_rsp_o} ),
@@ -86,7 +86,7 @@ read_template: |
         .read_rsp_i        ( ${read_response} ),
         .buffer_in_o       ( ${buffer_in} ),
         .buffer_in_valid_o ( ${buffer_in_valid} ),
-        .buffer_in_ready_i ( buffer_in_ready )
+        .buffer_in_ready_i ( ${buffer_in_ready} )
     );
 write_template: |
     idma_obi_write #(

--- a/src/db/idma_tilelink.yml
+++ b/src/db/idma_tilelink.yml
@@ -86,7 +86,7 @@ legalizer_write_data_path: |
         shift: opt_tf_q.write_shift,
         num_beats: 'd0,
         is_single: w_num_bytes <= StrbWidth,
-        compute: opt_tf_q.compute
+        compute: opt_tf_q.compute${w_dp_req_extra}
     };
 read_template: |
     idma_tilelink_read #(
@@ -102,7 +102,7 @@ read_template: |
     ) i_idma_tilelink_read${mh} (
         .clk_i             ( clk_i ),
         .rst_ni            ( rst_ni ),
-        .r_dp_req_i        ( r_dp_req_i ),
+        .r_dp_req_i        ( ${r_dp_req_i} ),
         .r_dp_valid_i      ( ${r_dp_valid_i} ),
         .r_dp_ready_o      ( ${r_dp_ready_o} ),
         .r_dp_rsp_o        ( ${r_dp_rsp_o} ),
@@ -115,7 +115,7 @@ read_template: |
         .read_rsp_i        ( ${read_response} ),
         .buffer_in_o       ( ${buffer_in} ),
         .buffer_in_valid_o ( ${buffer_in_valid} ),
-        .buffer_in_ready_i ( buffer_in_ready )
+        .buffer_in_ready_i ( ${buffer_in_ready} )
     );
 write_template: |
     idma_tilelink_write #(

--- a/src/frontend/reg/idma_reg.rdl
+++ b/src/frontend/reg/idma_reg.rdl
@@ -172,6 +172,13 @@ addrmap idma_reg #(
         andi = 4'd4 { desc = "y = x & imm"; };
         ori  = 4'd5 { desc = "y = x | imm"; };
         xori = 4'd6 { desc = "y = x ^ imm"; };
+        add  = 4'd8 { desc = "y = a + b (two operand streams)"; };
+        sub  = 4'd9 { desc = "y = a - b (two operand streams)"; };
+        mul  = 4'd10 { desc = "y = a * b (two operand streams, needs the alu_mul feature)"; };
+        and  = 4'd11 { desc = "y = a & b (two operand streams)"; };
+        or   = 4'd12 { desc = "y = a | b (two operand streams)"; };
+        xor  = 4'd13 { desc = "y = a ^ b (two operand streams)"; };
+        axpy = 4'd14 { desc = "y = imm * a + b (two operand streams, needs the alu_mul feature)"; };
     };
 
     reg compute_cfg {

--- a/src/idma_pkg.sv
+++ b/src/idma_pkg.sv
@@ -148,7 +148,7 @@ package idma_pkg;
         compute_params_t params;
     } compute_options_t;
 
-    /// Compile-time per-op compute feature enables; `mxfp16` and `alu_mul` are area opt-outs
+    /// Compile-time compute feature enables; `mxfp16`, `alu_mul` opt out of area, `dual` adds b
     typedef struct packed {
         logic transpose;
         logic mxquant;
@@ -156,6 +156,7 @@ package idma_pkg;
         logic mxfp16;
         logic alu;
         logic alu_mul;
+        logic dual;
     } compute_enable_t;
 
     /// Implementation tuning knobs for the compute engines
@@ -175,12 +176,23 @@ package idma_pkg;
 
     /// Single source of truth: does the ALU function use the multiplier?
     function automatic logic alu_func_uses_mul(alu_func_e func);
-        return func inside {ALU_MULI};
+        return func inside {ALU_MULI, ALU_MUL, ALU_AXPY};
+    endfunction
+
+    /// Single source of truth: does the ALU function take a second operand stream?
+    function automatic logic alu_func_dual(alu_func_e func);
+        return func inside {ALU_ADD, ALU_SUB, ALU_MUL, ALU_AND, ALU_OR, ALU_XOR, ALU_AXPY};
     endfunction
 
     /// Single source of truth: is the ALU function defined?
     function automatic logic alu_func_defined(alu_func_e func);
-        return func inside {ALU_NOT, ALU_ADDI, ALU_SUBI, ALU_MULI, ALU_ANDI, ALU_ORI, ALU_XORI};
+        return func inside {ALU_NOT, ALU_ADDI, ALU_SUBI, ALU_MULI, ALU_ANDI, ALU_ORI, ALU_XORI,
+                            ALU_ADD, ALU_SUB, ALU_MUL, ALU_AND, ALU_OR, ALU_XOR, ALU_AXPY};
+    endfunction
+
+    /// Single source of truth: number of operand streams the compute op consumes
+    function automatic int unsigned compute_operands(compute_options_t cmp);
+        return ((cmp.op == COMPUTE_ALU) && alu_func_dual(cmp.params.alu.func)) ? 32'd2 : 32'd1;
     endfunction
 
     /// Single source of truth: is the requested op elaborated under this feature mask?
@@ -192,7 +204,8 @@ package idma_pkg;
             COMPUTE_MXDEQUANT:      return ena.mxdequant;
             COMPUTE_MXDEQUANT_FP16: return ena.mxdequant & ena.mxfp16;
             COMPUTE_ALU:            return ena.alu & alu_func_defined(cmp.params.alu.func) &
-                                           (~alu_func_uses_mul(cmp.params.alu.func) | ena.alu_mul);
+                                           (~alu_func_uses_mul(cmp.params.alu.func) | ena.alu_mul) &
+                                           (~alu_func_dual(cmp.params.alu.func) | ena.dual);
             default:                return 1'b0;
         endcase
     endfunction

--- a/test/idma_alu_dpi.c
+++ b/test/idma_alu_dpi.c
@@ -5,7 +5,7 @@
 // Authors:
 // - Daniel Keller <dankeller@iis.ee.ethz.ch>
 
-// DPI-C golden for the byte-wise SIMD ALU: y[i] = f(x[i], imm) modulo 256. Written
+// DPI-C golden for the byte-wise SIMD ALU: y[i] = f(a[i], b[i], imm) modulo 256. Written
 // from the function definitions in idma_reg.rdl (alu_func), not from the RTL.
 
 #include <stdint.h>
@@ -13,10 +13,15 @@
 #define ALU_GM_MAX_BYTES (1 << 20)
 
 static uint8_t alu_gm_in[ALU_GM_MAX_BYTES];
+static uint8_t alu_gm_in_b[ALU_GM_MAX_BYTES];
 static uint8_t alu_gm_out[ALU_GM_MAX_BYTES];
 
 void alu_gm_load(int idx, int val) {
   if (idx >= 0 && idx < ALU_GM_MAX_BYTES) alu_gm_in[idx] = (uint8_t)val;
+}
+
+void alu_gm_load_b(int idx, int val) {
+  if (idx >= 0 && idx < ALU_GM_MAX_BYTES) alu_gm_in_b[idx] = (uint8_t)val;
 }
 
 int alu_gm_get(int idx) {
@@ -24,12 +29,12 @@ int alu_gm_get(int idx) {
   return -1;
 }
 
-// func encoding follows the alu_func enum: 0 not, 1 addi, 2 subi, 3 muli, 4 andi, 5 ori, 6 xori
+// func follows alu_func: 0-6 not/addi/subi/muli/andi/ori/xori, 8-14 add/sub/mul/and/or/xor/axpy
 void alu_gm_run(int func, int imm, int len) {
   uint8_t k = (uint8_t)imm;
   if (len > ALU_GM_MAX_BYTES) len = ALU_GM_MAX_BYTES;
   for (int i = 0; i < len; ++i) {
-    uint8_t x = alu_gm_in[i], y;
+    uint8_t x = alu_gm_in[i], b = alu_gm_in_b[i], y;
     switch (func) {
       case 0: y = (uint8_t)~x; break;
       case 1: y = (uint8_t)(x + k); break;
@@ -38,6 +43,13 @@ void alu_gm_run(int func, int imm, int len) {
       case 4: y = (uint8_t)(x & k); break;
       case 5: y = (uint8_t)(x | k); break;
       case 6: y = (uint8_t)(x ^ k); break;
+      case 8: y = (uint8_t)(x + b); break;
+      case 9: y = (uint8_t)(x - b); break;
+      case 10: y = (uint8_t)(x * b); break;
+      case 11: y = (uint8_t)(x & b); break;
+      case 12: y = (uint8_t)(x | b); break;
+      case 13: y = (uint8_t)(x ^ b); break;
+      case 14: y = (uint8_t)(k * x + b); break;
       default: y = x; break;
     }
     alu_gm_out[i] = y;

--- a/test/tb_idma_dual.sv
+++ b/test/tb_idma_dual.sv
@@ -1,0 +1,368 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// Dual-operand compute on the two-read-head backend (idma_backend_2r_axi_w_axi):
+// a two-operand ALU transfer reads operand a on one head, its operand-only partner
+// request reads operand b on the other head, and the joined stream is written once.
+// Every two-operand function runs over aligned, differently misaligned, page-crossing,
+// tail-beat and multi-burst geometries, on both head assignments, under random
+// per-channel AXI stalls on all three ports; single-operand ops and plain copies on
+// either head interleave with the pairs. Byte-exact against the DPI-C golden; the
+// destination is checked at the first operand's response, so it also proves that the
+// partner's response never overtakes it.
+
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+
+module tb_idma_dual
+  import idma_pkg::*;
+#(
+  parameter int unsigned DataWidth  = 64,
+  parameter int unsigned AddrWidth  = 32,
+  parameter int unsigned UserWidth  = 1,
+  parameter int unsigned AxiIdWidth = 12,
+  parameter int unsigned TFLenWidth = 32,
+  parameter int unsigned StallPct   = 30,
+  parameter bit          Verbose    = 1'b0
+);
+
+  import "DPI-C" function void alu_gm_load(input int idx, input int val);
+  import "DPI-C" function void alu_gm_load_b(input int idx, input int val);
+  import "DPI-C" function void alu_gm_run(input int func, input int imm, input int len);
+  import "DPI-C" function int  alu_gm_get(input int idx);
+
+  localparam time TA = 1ns, TT = 9ns, TCK = 10ns;
+  localparam int unsigned StrbWidth = DataWidth / 8;
+  localparam int unsigned NumHeads  = 2;
+  localparam int unsigned NumBuses  = NumHeads + 1;
+
+  typedef logic [AddrWidth-1:0]  addr_t;
+  typedef logic [DataWidth-1:0]  data_t;
+  typedef logic [StrbWidth-1:0]  strb_t;
+  typedef logic [AxiIdWidth-1:0] id_t;
+  typedef logic [UserWidth-1:0]  user_t;
+  typedef logic [TFLenWidth-1:0] tf_len_t;
+
+  `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_chan_t, axi_w_chan_t, axi_ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(axi_rsp_t, axi_b_chan_t, axi_r_chan_t)
+
+  `IDMA_TYPEDEF_FULL_REQ_T(idma_req_t, id_t, addr_t, tf_len_t)
+  `IDMA_TYPEDEF_FULL_RSP_T(idma_rsp_t, addr_t)
+
+  typedef struct packed { axi_ar_chan_t ar_chan; } axi_read_meta_channel_t;
+  typedef struct packed { axi_read_meta_channel_t axi; } read_meta_channel_t;
+  typedef struct packed { axi_aw_chan_t aw_chan; } axi_write_meta_channel_t;
+  typedef struct packed { axi_write_meta_channel_t axi; } write_meta_channel_t;
+
+  logic clk, rst_n;
+  idma_req_t    idma_req;    logic req_valid, req_ready;
+  idma_rsp_t    idma_rsp;    logic rsp_valid, rsp_ready;
+  idma_eh_req_t idma_eh_req; logic eh_req_valid, eh_req_ready;
+  idma_busy_t   busy;
+
+  // bus 0/1: read heads, bus 2: write port; each behind a random-stall shim
+  axi_req_t [NumBuses-1:0] axi_req, axi_req_mem;
+  axi_rsp_t [NumBuses-1:0] axi_rsp, axi_rsp_mem;
+
+  assign idma_eh_req  = '0;
+  assign eh_req_valid = 1'b0;
+
+  clk_rst_gen #(.ClkPeriod(TCK), .RstClkCycles(1)) i_clk_rst_gen (.clk_o(clk), .rst_no(rst_n));
+
+  // random-stall shim: a channel's go bit may rise any cycle but only falls after its handshake
+  logic [NumBuses-1:0] aw_go, w_go, ar_go, b_go, r_go;
+  function automatic logic go_next(input logic go, input logic vld, input logic rdy);
+    if (go && vld && !rdy) return 1'b1;
+    return ($urandom_range(99) >= StallPct);
+  endfunction
+  for (genvar i = 0; i < NumBuses; i++) begin : gen_bus
+    always_ff @(posedge clk or negedge rst_n) begin
+      if (!rst_n) {aw_go[i], w_go[i], ar_go[i], b_go[i], r_go[i]} <= '0;
+      else begin
+        aw_go[i] <= go_next(aw_go[i], axi_req[i].aw_valid,    axi_rsp_mem[i].aw_ready);
+        w_go[i]  <= go_next(w_go[i],  axi_req[i].w_valid,     axi_rsp_mem[i].w_ready);
+        ar_go[i] <= go_next(ar_go[i], axi_req[i].ar_valid,    axi_rsp_mem[i].ar_ready);
+        b_go[i]  <= go_next(b_go[i],  axi_rsp_mem[i].b_valid, axi_req[i].b_ready);
+        r_go[i]  <= go_next(r_go[i],  axi_rsp_mem[i].r_valid, axi_req[i].r_ready);
+      end
+    end
+    always_comb begin
+      axi_req_mem[i] = axi_req[i];
+      axi_rsp[i]     = axi_rsp_mem[i];
+      axi_req_mem[i].aw_valid = axi_req[i].aw_valid & aw_go[i];
+      axi_req_mem[i].w_valid  = axi_req[i].w_valid  & w_go[i];
+      axi_req_mem[i].ar_valid = axi_req[i].ar_valid & ar_go[i];
+      axi_req_mem[i].b_ready  = axi_req[i].b_ready  & b_go[i];
+      axi_req_mem[i].r_ready  = axi_req[i].r_ready  & r_go[i];
+      axi_rsp[i].aw_ready     = axi_rsp_mem[i].aw_ready & aw_go[i];
+      axi_rsp[i].w_ready      = axi_rsp_mem[i].w_ready  & w_go[i];
+      axi_rsp[i].ar_ready     = axi_rsp_mem[i].ar_ready & ar_go[i];
+      axi_rsp[i].b_valid      = axi_rsp_mem[i].b_valid  & b_go[i];
+      axi_rsp[i].r_valid      = axi_rsp_mem[i].r_valid  & r_go[i];
+    end
+
+    axi_sim_mem #(
+      .AddrWidth(AddrWidth), .DataWidth(DataWidth), .IdWidth(AxiIdWidth), .UserWidth(UserWidth),
+      .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+      .WarnUninitialized(1'b0), .ClearErrOnAccess(1'b1), .ApplDelay(TA), .AcqDelay(TT)
+    ) i_axi_sim_mem (
+      .clk_i(clk), .rst_ni(rst_n), .axi_req_i(axi_req_mem[i]), .axi_rsp_o(axi_rsp_mem[i]),
+      .mon_r_last_o(), .mon_r_beat_count_o(), .mon_r_user_o(), .mon_r_id_o(),
+      .mon_r_data_o(), .mon_r_addr_o(), .mon_r_valid_o(),
+      .mon_w_last_o(), .mon_w_beat_count_o(), .mon_w_user_o(), .mon_w_id_o(),
+      .mon_w_data_o(), .mon_w_addr_o(), .mon_w_valid_o()
+    );
+  end
+
+  idma_backend_2r_axi_w_axi #(
+    .CombinedShifter(1'b0), .DataWidth(DataWidth), .AddrWidth(AddrWidth), .AxiIdWidth(AxiIdWidth),
+    .UserWidth(UserWidth), .TFLenWidth(TFLenWidth), .MaskInvalidData(1'b1), .BufferDepth(3),
+    .EnableCompute(1'b1),
+    .ComputeOps(idma_pkg::compute_enable_t'{alu: 1'b1, alu_mul: 1'b1, dual: 1'b1, default: '0}),
+    .ComputeTuning('1),
+    .RAWCouplingAvail(1'b0), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
+    .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(3),
+    .MemSysDepth(0),
+    .idma_req_t(idma_req_t), .idma_rsp_t(idma_rsp_t), .idma_eh_req_t(idma_eh_req_t),
+    .idma_busy_t(idma_busy_t), .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .write_meta_channel_t(write_meta_channel_t), .read_meta_channel_t(read_meta_channel_t)
+  ) i_idma_backend (
+    .clk_i(clk), .rst_ni(rst_n),
+    .idma_req_i(idma_req), .req_valid_i(req_valid), .req_ready_o(req_ready),
+    .idma_rsp_o(idma_rsp), .rsp_valid_o(rsp_valid), .rsp_ready_i(rsp_ready),
+    .idma_eh_req_i(idma_eh_req), .eh_req_valid_i(eh_req_valid), .eh_req_ready_o(eh_req_ready),
+    .axi_read_req_o(axi_req[NumHeads-1:0]), .axi_read_rsp_i(axi_rsp[NumHeads-1:0]),
+    .axi_write_req_o(axi_req[NumHeads]), .axi_write_rsp_i(axi_rsp[NumHeads]), .busy_o(busy)
+  );
+
+  int unsigned rsp_cnt;
+  always @(posedge clk) if (rsp_valid && rsp_ready) rsp_cnt <= rsp_cnt + 1;
+
+  // memory accessors (generate instances cannot be indexed by a variable)
+  task automatic wr_mem(input int unsigned bus, input addr_t a, input logic [7:0] d);
+    case (bus)
+      0: gen_bus[0].i_axi_sim_mem.mem[a] = d;
+      1: gen_bus[1].i_axi_sim_mem.mem[a] = d;
+      default: gen_bus[2].i_axi_sim_mem.mem[a] = d;
+    endcase
+  endtask
+  function automatic logic [7:0] rd_wmem(input addr_t a);
+    return gen_bus[2].i_axi_sim_mem.mem.exists(a) ? gen_bus[2].i_axi_sim_mem.mem[a] : 8'hxx;
+  endfunction
+
+  localparam int unsigned NumFuncs = 7;
+  localparam idma_pkg::alu_func_e Funcs [NumFuncs] = '{
+    ALU_ADD, ALU_SUB, ALU_MUL, ALU_AND, ALU_OR, ALU_XOR, ALU_AXPY};
+  localparam int unsigned Margin = 32;
+  localparam logic [7:0] Canary = 8'hC5;
+
+  function automatic logic [7:0] src_gen(input int unsigned i, input int unsigned seed);
+    return 8'(((i + seed) * 32'd2654435761) >> 13);
+  endfunction
+
+  // launch one transfer without waiting for its response (drive at TA, sample at TT)
+  task automatic launch(input addr_t src, input addr_t dst, input int unsigned len,
+                        input logic en, input idma_pkg::alu_func_e func, input logic [7:0] imm,
+                        input int unsigned head);
+    automatic idma_req_t req = '0;
+    req.length   = tf_len_t'(len);
+    req.src_addr = src;
+    req.dst_addr = dst;
+    req.opt.src_protocol = idma_pkg::AXI;
+    req.opt.dst_protocol = idma_pkg::AXI;
+    req.opt.src_head     = multihead_t'(head);
+    req.opt.src.burst    = axi_pkg::BURST_INCR;
+    req.opt.dst.burst    = axi_pkg::BURST_INCR;
+    req.opt.beo.decouple_rw = 1'b1;
+    req.opt.beo.decouple_aw = 1'b1;
+    req.opt.compute.enable  = en;
+    req.opt.compute.op      = idma_pkg::COMPUTE_ALU;
+    req.opt.compute.params.alu.func = func;
+    req.opt.compute.params.alu.imm  = imm;
+    req.opt.last            = 1'b1;
+    @(posedge clk); #TA;
+    idma_req  = req;
+    req_valid = 1'b1;
+    #(TT - TA);
+    while (!req_ready) begin @(posedge clk); #TT; end
+    @(posedge clk); #TA;
+    req_valid = 1'b0;
+    idma_req  = '0;
+  endtask
+
+  task automatic wait_rsps(input int unsigned n);
+    while (rsp_cnt < n) @(posedge clk);
+  endtask
+
+  // fill operand a (head bus ha) and b (head bus hb) plus the goldens; canaries around dst
+  task automatic prepare(input int unsigned ha, input addr_t src_a, input int unsigned hb,
+                         input addr_t src_b, input addr_t dst, input int unsigned len,
+                         input int unsigned seed);
+    for (int unsigned i = 0; i < len; i++) begin
+      wr_mem(ha, src_a + i, src_gen(i, seed));
+      alu_gm_load(int'(i), int'(src_gen(i, seed)));
+      wr_mem(hb, src_b + i, src_gen(i, seed + 4096));
+      alu_gm_load_b(int'(i), int'(src_gen(i, seed + 4096)));
+    end
+    for (int unsigned i = 0; i < len + 2 * Margin; i++) wr_mem(2, dst - Margin + i, Canary);
+  endtask
+
+  // byte-exact destination check plus the canary margins; returns the error count
+  function automatic int unsigned check(input int unsigned geo, input idma_pkg::alu_func_e func,
+                                        input addr_t dst, input int unsigned len);
+    automatic int unsigned errs = 0;
+    for (int unsigned i = 0; i < len; i++)
+      if (rd_wmem(dst + i) !== 8'(alu_gm_get(int'(i)))) begin
+        errs++;
+        if (errs <= 8) $display("[DUAL] geo%0d func=%0d dst[%0d] = %02h exp %02h", geo, func, i,
+                                rd_wmem(dst + i), 8'(alu_gm_get(int'(i))));
+      end
+    for (int unsigned i = 0; i < Margin; i++) begin
+      if (rd_wmem(dst - Margin + i) !== Canary) begin
+        errs++;
+        if (errs <= 8) $display("[DUAL] geo%0d func=%0d canary before dst clobbered", geo, func);
+      end
+      if (rd_wmem(dst + len + i) !== Canary) begin
+        errs++;
+        if (errs <= 8) $display("[DUAL] geo%0d func=%0d canary after dst clobbered", geo, func);
+      end
+    end
+    return errs;
+  endfunction
+
+  // one pair over one geometry; dst is checked at the first response, the partner's must follow
+  task automatic run_pair(input int unsigned geo, input idma_pkg::alu_func_e func,
+                          input logic [7:0] imm, input int unsigned ha, input addr_t src_a,
+                          input int unsigned hb, input addr_t src_b, input addr_t dst,
+                          input int unsigned len, input int unsigned seed,
+                          inout int unsigned errs);
+    automatic int unsigned base = rsp_cnt;
+    if (Verbose)
+      $display("[DUAL] geo%0d func=%0d imm=%02h a=h%0d:%h b=h%0d:%h dst=%h len=%0d @%0t", geo,
+               func, imm, ha, src_a, hb, src_b, dst, len, $time);
+    prepare(ha, src_a, hb, src_b, dst, len, seed);
+    alu_gm_run(int'(func), int'(imm), int'(len));
+    launch(src_a, dst, len, 1'b1, func, imm, ha);
+    launch(src_b, dst, len, 1'b1, func, imm, hb);
+    wait_rsps(base + 1);
+    errs += check(geo, func, dst, len);
+    wait_rsps(base + 2);
+    repeat (5) @(posedge clk);
+  endtask
+
+  localparam addr_t SrcABase = 'h0001_0000, SrcBBase = 'h0003_0000, DstBase = 'h0009_0000;
+
+  // geometry list: operand a offset, operand b offset, destination offset, length
+  localparam int unsigned NumGeos = 8;
+  localparam int unsigned GeoAOff [NumGeos] = '{0, 1, 4096 - 7, 5, 7, 0, StrbWidth / 2, 3};
+  localparam int unsigned GeoBOff [NumGeos] = '{0, 3, 0, 6, 2, 0, StrbWidth / 2 + 1, 4096 - 2};
+  localparam int unsigned GeoDOff [NumGeos] = '{0, 2, 4096 - 3, 7, 6, 0, 1, 5};
+  localparam int unsigned GeoLen  [NumGeos] = '{
+    4 * StrbWidth,      // aligned, whole beats
+    3 * StrbWidth + 5,  // all three misaligned differently, tail beat
+    5 * StrbWidth + 2,  // a and dst cross a page, b aligned
+    9000,               // multi-burst: more bursts than any queue holds
+    1,                  // single byte
+    StrbWidth - 1,      // sub-beat, aligned
+    StrbWidth,          // half-beat offsets
+    2 * StrbWidth + 3   // b crosses a page
+  };
+
+  initial begin
+    automatic int unsigned errs = 0, seed = 0, base;
+    automatic addr_t src_a, src_b, dst;
+    automatic logic [7:0] imm;
+    req_valid = 1'b0; rsp_ready = 1'b1; idma_req = '0; rsp_cnt = 0;
+    @(posedge rst_n);
+    repeat (5) @(posedge clk);
+
+    // every two-operand function over every geometry, a on head 0 and b on head 1
+    for (int unsigned g = 0; g < NumGeos; g++) begin
+      for (int unsigned f = 0; f < NumFuncs; f++) begin
+        src_a = SrcABase + GeoAOff[g];
+        src_b = SrcBBase + GeoBOff[g];
+        dst   = DstBase + GeoDOff[g];
+        imm   = 8'(seed * 37 + 3);
+        run_pair(g, Funcs[f], imm, 0, src_a, 1, src_b, dst, GeoLen[g], seed, errs);
+        seed++;
+      end
+    end
+
+    // heads swapped: a on head 1, b on head 0
+    for (int unsigned g = 0; g < NumGeos; g += 2) begin
+      src_a = SrcABase + GeoAOff[g];
+      src_b = SrcBBase + GeoBOff[g];
+      dst   = DstBase + GeoDOff[g];
+      imm   = 8'(seed * 37 + 3);
+      run_pair(NumGeos + g, Funcs[g % NumFuncs], imm, 1, src_a, 0, src_b, dst, GeoLen[g], seed,
+               errs);
+      seed++;
+    end
+
+    // single-operand ops and plain copies keep working on either head, before and after pairs
+    for (int unsigned h = 0; h < NumHeads; h++) begin
+      base  = rsp_cnt;
+      src_a = SrcABase + 3;
+      dst   = DstBase + 5;
+      for (int unsigned i = 0; i < 3 * StrbWidth + 2; i++) begin
+        wr_mem(h, src_a + i, src_gen(i, 900 + h));
+        alu_gm_load(int'(i), int'(src_gen(i, 900 + h)));
+      end
+      for (int unsigned i = 0; i < 3 * StrbWidth + 2 + 2 * Margin; i++)
+        wr_mem(2, dst - Margin + i, Canary);
+      alu_gm_run(int'(ALU_XORI), 8'h5A, int'(3 * StrbWidth + 2));
+      launch(src_a, dst, 3 * StrbWidth + 2, 1'b1, ALU_XORI, 8'h5A, h);
+      wait_rsps(base + 1);
+      errs += check(2 * NumGeos + h, ALU_XORI, dst, 3 * StrbWidth + 2);
+
+      base = rsp_cnt;
+      for (int unsigned i = 0; i < 2 * StrbWidth + 1 + 2 * Margin; i++)
+        wr_mem(2, dst - Margin + i, Canary);
+      launch(src_a, dst, 2 * StrbWidth + 1, 1'b0, ALU_NOT, 8'h00, h);
+      wait_rsps(base + 1);
+      for (int unsigned i = 0; i < 2 * StrbWidth + 1; i++)
+        if (rd_wmem(dst + i) !== src_gen(i, 900 + h)) begin
+          errs++;
+          if (errs <= 8) $display("[DUAL] copy h%0d dst[%0d] = %02h", h, i, rd_wmem(dst + i));
+        end
+    end
+
+    // a pair immediately followed by a plain copy on head 1 (config change drains the pair)
+    base  = rsp_cnt;
+    src_a = SrcABase + 1;
+    src_b = SrcBBase + 2;
+    dst   = DstBase + 3;
+    prepare(0, src_a, 1, src_b, dst, 5 * StrbWidth + 1, 777);
+    alu_gm_run(int'(ALU_AXPY), 8'h07, int'(5 * StrbWidth + 1));
+    for (int unsigned i = 0; i < 2 * StrbWidth; i++) wr_mem(1, SrcBBase + 'h1000 + i, 8'(i));
+    for (int unsigned i = 0; i < 2 * StrbWidth + 2 * Margin; i++)
+      wr_mem(2, DstBase + 'h1000 - Margin + i, Canary);
+    launch(src_a, dst, 5 * StrbWidth + 1, 1'b1, ALU_AXPY, 8'h07, 0);
+    launch(src_b, dst, 5 * StrbWidth + 1, 1'b1, ALU_AXPY, 8'h07, 1);
+    launch(SrcBBase + 'h1000, DstBase + 'h1000, 2 * StrbWidth, 1'b0, ALU_NOT, 8'h00, 1);
+    wait_rsps(base + 3);
+    errs += check(2 * NumGeos + 2, ALU_AXPY, dst, 5 * StrbWidth + 1);
+    for (int unsigned i = 0; i < 2 * StrbWidth; i++)
+      if (rd_wmem(DstBase + 'h1000 + i) !== 8'(i)) begin
+        errs++;
+        if (errs <= 8) $display("[DUAL] copy after pair dst[%0d] = %02h", i,
+                                rd_wmem(DstBase + 'h1000 + i));
+      end
+
+    if (errs == 0) $display("[DUAL] ALL PASS (StrbWidth=%0d)", StrbWidth);
+    else $fatal(1, "[DUAL] %0d errors (StrbWidth=%0d)", errs, StrbWidth);
+    $finish;
+  end
+
+  initial begin #50ms; $fatal(1, "[DUAL] timeout"); end
+
+endmodule

--- a/test/tb_idma_dualneg.sv
+++ b/test/tb_idma_dualneg.sv
@@ -1,0 +1,166 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// Negative tests for the operand pair on the two-read-head backend: each NegCase issues
+// one illegal request sequence and expects the matching legalizer guard to report
+// (compile with +define+INC_ASSERT). Case 1: the partner carries another op; 2: another
+// length; 3: the same read head; 4: a two-operand op without the second stream elaborated.
+
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+
+module tb_idma_dualneg
+  import idma_pkg::*;
+#(
+  parameter int unsigned DataWidth  = 64,
+  parameter int unsigned AddrWidth  = 32,
+  parameter int unsigned UserWidth  = 1,
+  parameter int unsigned AxiIdWidth = 12,
+  parameter int unsigned TFLenWidth = 32,
+  parameter int unsigned NegCase    = 1,
+  parameter bit          EnDual     = 1'b1
+);
+
+  localparam time TA = 1ns, TT = 9ns, TCK = 10ns;
+  localparam int unsigned StrbWidth = DataWidth / 8;
+  localparam int unsigned NumHeads  = 2;
+  localparam int unsigned NumBuses  = NumHeads + 1;
+
+  typedef logic [AddrWidth-1:0]  addr_t;
+  typedef logic [DataWidth-1:0]  data_t;
+  typedef logic [StrbWidth-1:0]  strb_t;
+  typedef logic [AxiIdWidth-1:0] id_t;
+  typedef logic [UserWidth-1:0]  user_t;
+  typedef logic [TFLenWidth-1:0] tf_len_t;
+
+  `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, data_t, strb_t, user_t)
+  `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, data_t, id_t, user_t)
+  `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_chan_t, axi_w_chan_t, axi_ar_chan_t)
+  `AXI_TYPEDEF_RESP_T(axi_rsp_t, axi_b_chan_t, axi_r_chan_t)
+
+  `IDMA_TYPEDEF_FULL_REQ_T(idma_req_t, id_t, addr_t, tf_len_t)
+  `IDMA_TYPEDEF_FULL_RSP_T(idma_rsp_t, addr_t)
+
+  typedef struct packed { axi_ar_chan_t ar_chan; } axi_read_meta_channel_t;
+  typedef struct packed { axi_read_meta_channel_t axi; } read_meta_channel_t;
+  typedef struct packed { axi_aw_chan_t aw_chan; } axi_write_meta_channel_t;
+  typedef struct packed { axi_write_meta_channel_t axi; } write_meta_channel_t;
+
+  logic clk, rst_n;
+  idma_req_t    idma_req;    logic req_valid, req_ready;
+  idma_rsp_t    idma_rsp;    logic rsp_valid, rsp_ready;
+  idma_eh_req_t idma_eh_req; logic eh_req_valid, eh_req_ready;
+  idma_busy_t   busy;
+  axi_req_t [NumBuses-1:0] axi_req;
+  axi_rsp_t [NumBuses-1:0] axi_rsp;
+
+  assign idma_eh_req  = '0;
+  assign eh_req_valid = 1'b0;
+
+  clk_rst_gen #(.ClkPeriod(TCK), .RstClkCycles(1)) i_clk_rst_gen (.clk_o(clk), .rst_no(rst_n));
+
+  for (genvar i = 0; i < NumBuses; i++) begin : gen_bus
+    axi_sim_mem #(
+      .AddrWidth(AddrWidth), .DataWidth(DataWidth), .IdWidth(AxiIdWidth), .UserWidth(UserWidth),
+      .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+      .WarnUninitialized(1'b0), .ClearErrOnAccess(1'b1), .ApplDelay(TA), .AcqDelay(TT)
+    ) i_axi_sim_mem (
+      .clk_i(clk), .rst_ni(rst_n), .axi_req_i(axi_req[i]), .axi_rsp_o(axi_rsp[i]),
+      .mon_r_last_o(), .mon_r_beat_count_o(), .mon_r_user_o(), .mon_r_id_o(),
+      .mon_r_data_o(), .mon_r_addr_o(), .mon_r_valid_o(),
+      .mon_w_last_o(), .mon_w_beat_count_o(), .mon_w_user_o(), .mon_w_id_o(),
+      .mon_w_data_o(), .mon_w_addr_o(), .mon_w_valid_o()
+    );
+  end
+
+  idma_backend_2r_axi_w_axi #(
+    .CombinedShifter(1'b0), .DataWidth(DataWidth), .AddrWidth(AddrWidth), .AxiIdWidth(AxiIdWidth),
+    .UserWidth(UserWidth), .TFLenWidth(TFLenWidth), .MaskInvalidData(1'b1), .BufferDepth(3),
+    .EnableCompute(1'b1),
+    .ComputeOps(idma_pkg::compute_enable_t'{alu: 1'b1, alu_mul: 1'b1, dual: EnDual, default: '0}),
+    .ComputeTuning('1),
+    .RAWCouplingAvail(1'b0), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
+    .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(3),
+    .MemSysDepth(0),
+    .idma_req_t(idma_req_t), .idma_rsp_t(idma_rsp_t), .idma_eh_req_t(idma_eh_req_t),
+    .idma_busy_t(idma_busy_t), .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .write_meta_channel_t(write_meta_channel_t), .read_meta_channel_t(read_meta_channel_t)
+  ) i_idma_backend (
+    .clk_i(clk), .rst_ni(rst_n),
+    .idma_req_i(idma_req), .req_valid_i(req_valid), .req_ready_o(req_ready),
+    .idma_rsp_o(idma_rsp), .rsp_valid_o(rsp_valid), .rsp_ready_i(rsp_ready),
+    .idma_eh_req_i(idma_eh_req), .eh_req_valid_i(eh_req_valid), .eh_req_ready_o(eh_req_ready),
+    .axi_read_req_o(axi_req[NumHeads-1:0]), .axi_read_rsp_i(axi_rsp[NumHeads-1:0]),
+    .axi_write_req_o(axi_req[NumHeads]), .axi_write_rsp_i(axi_rsp[NumHeads]), .busy_o(busy)
+  );
+
+  task automatic issue(input addr_t src, input addr_t dst, input int unsigned len,
+                       input idma_pkg::alu_func_e func, input int unsigned head);
+    automatic idma_req_t req = '0;
+    req.length   = tf_len_t'(len);
+    req.src_addr = src;
+    req.dst_addr = dst;
+    req.opt.src_protocol = idma_pkg::AXI;
+    req.opt.dst_protocol = idma_pkg::AXI;
+    req.opt.src_head     = multihead_t'(head);
+    req.opt.src.burst    = axi_pkg::BURST_INCR;
+    req.opt.dst.burst    = axi_pkg::BURST_INCR;
+    req.opt.beo.decouple_rw = 1'b1;
+    req.opt.beo.decouple_aw = 1'b1;
+    req.opt.compute.enable  = 1'b1;
+    req.opt.compute.op      = idma_pkg::COMPUTE_ALU;
+    req.opt.compute.params.alu.func = func;
+    req.opt.last            = 1'b1;
+    @(posedge clk); #TA;
+    idma_req  = req;
+    req_valid = 1'b1;
+    #(TT - TA);
+    while (!req_ready) begin @(posedge clk); #TT; end
+    @(posedge clk); #TA;
+    req_valid = 1'b0;
+    idma_req  = '0;
+  endtask
+
+  localparam addr_t SrcA = 'h0001_0000, SrcB = 'h0003_0000, Dst = 'h0009_0000;
+
+  initial begin
+    req_valid = 1'b0; rsp_ready = 1'b1; idma_req = '0;
+    for (int unsigned i = 0; i < 4096; i++) begin
+      gen_bus[0].i_axi_sim_mem.mem[SrcA + i] = 8'(i);
+      gen_bus[1].i_axi_sim_mem.mem[SrcB + i] = 8'(i);
+    end
+    @(posedge rst_n);
+    repeat (5) @(posedge clk);
+
+    case (NegCase)
+      1: begin
+        issue(SrcA, Dst, 64, idma_pkg::ALU_ADD, 0);
+        issue(SrcB, Dst, 64, idma_pkg::ALU_SUB, 1);
+      end
+      2: begin
+        issue(SrcA, Dst, 64, idma_pkg::ALU_ADD, 0);
+        issue(SrcB, Dst, 96, idma_pkg::ALU_ADD, 1);
+      end
+      3: begin
+        issue(SrcA, Dst, 64, idma_pkg::ALU_ADD, 0);
+        issue(SrcB, Dst, 64, idma_pkg::ALU_ADD, 0);
+      end
+      4: issue(SrcA, Dst, 64, idma_pkg::ALU_ADD, 0);
+      default: $fatal(1, "[DUALNEG] unknown NegCase %0d", NegCase);
+    endcase
+
+    repeat (3000) @(posedge clk);
+    $display("[DUALNEG] case %0d done", NegCase);
+    $finish();
+  end
+
+  initial begin #10ms; $display("[DUALNEG] case %0d done (timeout)", NegCase); $finish(); end
+
+endmodule

--- a/test/tb_idma_mxneg.sv
+++ b/test/tb_idma_mxneg.sv
@@ -9,8 +9,8 @@
 // the matching legalizer guard assert to report (compile with +define+INC_ASSERT).
 // The runner greps the transcript for the assert name; case 9 provokes transfer
 // overlap and expects the mxquant sub-unit's clear-with-in-flight-state fatal.
-// Cases 14-16 cover the ALU: op compiled out, multiplier compiled out, undefined
-// function.
+// Cases 14-17 cover the ALU: op compiled out, multiplier compiled out, undefined
+// function, two-operand function on a single-read-head backend.
 
 `include "axi/typedef.svh"
 `include "idma/typedef.svh"
@@ -42,7 +42,7 @@ module tb_idma_mxneg
     .EnableCompute(1'b1),
     .ComputeOps(idma_pkg::compute_enable_t'{transpose: 1'b1, mxquant: 1'b1, mxfp16: EnFp16,
                                             mxdequant: EnDequant, alu: EnAlu, alu_mul: EnAluMul,
-                                            default: '0}),
+                                            dual: 1'b1, default: '0}),
     .ComputeTuning('1),
     .RAWCouplingAvail(1'b1), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
     .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(StrbWidth),
@@ -115,6 +115,8 @@ module tb_idma_mxneg
       15: issue(Src, Dst, 64, idma_pkg::COMPUTE_ALU, idma_pkg::AXI, idma_pkg::AXI, 1'b0,
                 4'(idma_pkg::ALU_MULI));
       16: issue(Src, Dst, 64, idma_pkg::COMPUTE_ALU, idma_pkg::AXI, idma_pkg::AXI, 1'b0, 4'hF);
+      17: issue(Src, Dst, 64, idma_pkg::COMPUTE_ALU, idma_pkg::AXI, idma_pkg::AXI, 1'b0,
+                4'(idma_pkg::ALU_ADD));
       default: $fatal(1, "[MXNEG] unknown NegCase %0d", NegCase);
     endcase
 

--- a/util/idma_params.py
+++ b/util/idma_params.py
@@ -180,8 +180,8 @@ def main():
             if not ops_fields or not tuning_fields:
                 raise SystemExit('error: cannot read compute_enable_t/compute_tuning_t; '
                                  'the compute sweep cannot be validated')
-            # MSB first; mxfp16 and alu_mul gate sub-paths only, so they enable no datapath alone
-            real_ops = [f for f in ops_fields if f not in ('mxfp16', 'alu_mul')]
+            # MSB first; mxfp16, alu_mul and dual gate sub-paths only and enable no datapath alone
+            real_ops = [f for f in ops_fields if f not in ('mxfp16', 'alu_mul', 'dual')]
             real_mask = 0
             for pos, name in enumerate(reversed(ops_fields)):
                 if name in real_ops:

--- a/util/mario/backend.py
+++ b/util/mario/backend.py
@@ -9,7 +9,7 @@
 
 """ MARIO backend interaction"""
 from mako.template import Template
-from mario.util import compute_eligible, eval_key, prot_key
+from mario.util import compute_eligible, dual_operand_eligible, eval_key, prot_key
 
 
 def render_backend(prot_ids: dict, db: dict, tpl_file: str) -> str:
@@ -56,6 +56,7 @@ def render_backend(prot_ids: dict, db: dict, tpl_file: str) -> str:
             'one_read_port': srp,
             'one_write_port': swp,
             'compute_eligible': is_compute_eligible,
+            'dual_operand_eligible': bool(dual_operand_eligible(prot_id, prot_ids, db)),
             'used_non_bursting_write_protocols':
                 prot_key(used_write_prots, 'bursts', 'not_supported', db),
             'combined_aw_and_w':

--- a/util/mario/legalizer.py
+++ b/util/mario/legalizer.py
@@ -9,7 +9,7 @@
 
 """ MARIO legalizer interaction"""
 from mako.template import Template
-from mario.util import indent_block, eval_key, prot_key, compute_eligible
+from mario.util import indent_block, eval_key, prot_key, compute_eligible, dual_operand_eligible
 
 
 def prot_force_decouple(used_prots: list, db: dict) -> list:
@@ -39,6 +39,10 @@ def render_legalizer(prot_ids: dict, db: dict, tpl_file: str) -> str:
         srp = len(used_read_prots) == 1
         swp = len(used_write_prots) == 1
 
+        # dual-operand backends tag operand-only bursts in the write data path request
+        dual = bool(dual_operand_eligible(prot_id, prot_ids, db))
+        w_dp_req_extra = ',\n    operand_only: w_ghost_q' if dual else ''
+
         # Indent read meta channel
         for rp in used_read_prots:
             # format DB entry
@@ -53,7 +57,9 @@ def render_legalizer(prot_ids: dict, db: dict, tpl_file: str) -> str:
             # if datapath exists
             if 'legalizer_write_data_path' in db[wp]:
                 # format DB entry
-                data_path = indent_block(db[wp]['legalizer_write_data_path'], 3 - swp, 4)
+                data_path = Template(db[wp]['legalizer_write_data_path']).render(
+                    w_dp_req_extra=w_dp_req_extra)
+                data_path = indent_block(data_path, 3 - swp, 4)
                 db[wp]['legalizer_write_data_path'] = data_path
 
         has_page_read_bursting = eval_key(used_read_prots, 'bursts', 'split_at_page_boundary', db)
@@ -67,6 +73,7 @@ def render_legalizer(prot_ids: dict, db: dict, tpl_file: str) -> str:
             'name_uniqueifier': prot_id,
             'database': db,
             'compute_eligible': compute_eligible(used_read_prots, used_write_prots, db),
+            'dual_operand_eligible': dual,
             'used_read_protocols': used_read_prots,
             'used_write_protocols': used_write_prots,
             'used_protocols': prot_ids[prot_id]['used'],

--- a/util/mario/transport_layer.py
+++ b/util/mario/transport_layer.py
@@ -10,7 +10,7 @@
 """ MARIO transport layer interaction"""
 from mako.template import Template
 
-from mario.util import compute_eligible
+from mario.util import compute_eligible, dual_operand_eligible
 
 
 def render_read_mgr_inst(prot_id: str, prot_ids: dict, db: dict) -> dict:
@@ -20,6 +20,9 @@ def render_read_mgr_inst(prot_id: str, prot_ids: dict, db: dict) -> dict:
 
     # single read port
     srp = len(prot_ids[prot_id]['ar']) == 1
+
+    # dual-operand backends drive every head from a per-head request handle
+    dual = dual_operand_eligible(prot_id, prot_ids, db)
 
     # Render read ports
     for rp in prot_ids[prot_id]['ar']:
@@ -113,10 +116,21 @@ ar_valid_i\
                 buffer_in = f'{rp}_buffer_in{mh_bus}'
                 buffer_in_valid = f'{rp}_buffer_in_valid{mh_bus}'
 
+            # dual-operand: request, valid, response ready and buffer ready are per head
+            read_dp_request = 'r_dp_req_i'
+            buffer_in_ready = 'buffer_in_ready'
+            if dual:
+                read_dp_request = f'{rp}_r_dp_req_h{mh_bus}'
+                read_dp_valid_in = f'{rp}_r_dp_valid_h{mh_bus}'
+                read_dp_ready_in = f'{rp}_r_dp_rsp_ready_h{mh_bus}'
+                buffer_in_ready = f'{rp}_buffer_in_ready_h{mh_bus}'
+
             read_port_context = {
                 'database': db,
                 'req_t': read_req_str,
                 'rsp_t': read_rsp_str,
+                'r_dp_req_i': read_dp_request,
+                'buffer_in_ready': buffer_in_ready,
                 'r_dp_valid_i': read_dp_valid_in,
                 'r_dp_ready_o': read_dp_ready_out,
                 'r_dp_rsp_o': read_dp_response,
@@ -148,6 +162,9 @@ def render_write_mgr_inst(prot_id: str, prot_ids: dict, db: dict) -> dict:
 
     # single read port
     swp = len(prot_ids[prot_id]['aw']) == 1
+
+    # dual-operand backends route the write port through the operand-only bypass
+    dual = dual_operand_eligible(prot_id, prot_ids, db)
 
     # Render read ports
     for wp in prot_ids[prot_id]['aw']:
@@ -181,7 +198,20 @@ def render_write_mgr_inst(prot_id: str, prot_ids: dict, db: dict) -> dict:
                 write_req_str = f'{wp}_req_t'
                 write_rsp_str = f'{wp}_rsp_t'
 
-            if swp:
+            if swp and dual:
+                write_dp_valid_in = 'w_port_dp_valid'
+                write_dp_ready_out = 'w_port_dp_ready'
+                write_dp_response = 'w_port_dp_rsp'
+                write_dp_valid_out = 'w_port_rsp_valid'
+                write_dp_ready_in = 'w_port_rsp_ready'
+                write_meta_request = 'aw_req_i'
+                write_meta_valid = 'aw_valid_i'
+                write_meta_ready = 'aw_ready_o'
+                w_chan_valid = 'w_chan_valid_o'
+                w_chan_ready = 'w_chan_ready_o'
+                w_chan_first = 'w_chan_first_o'
+                buffer_out_ready = 'buffer_out_ready'
+            elif swp:
                 write_dp_valid_in = 'w_dp_valid_i'
                 write_dp_ready_out = 'w_dp_req_ready'
                 write_dp_response = 'w_dp_rsp_o'
@@ -282,6 +312,7 @@ def render_transport_layer(prot_ids: dict, db: dict, tpl_file: str) -> str:
 
         # Render Transport Layer
         is_compute_eligible = compute_eligible(prot_ids[prot_id]['ar'], prot_ids[prot_id]['aw'], db)
+        dual = dual_operand_eligible(prot_id, prot_ids, db)
         context = {
             'name_uniqueifier': prot_id,
             'database': db,
@@ -293,6 +324,9 @@ def render_transport_layer(prot_ids: dict, db: dict, tpl_file: str) -> str:
             'mh_format': mh_format,
             'any_mh': any_mh,
             'compute_eligible': is_compute_eligible,
+            'dual_operand_eligible': bool(dual),
+            'dual_read_protocol': dual.get('protocol'),
+            'dual_num_heads': dual.get('num_heads'),
             'rendered_read_ports': render_read_mgr_inst(prot_id, prot_ids, db),
             'rendered_write_ports': render_write_mgr_inst(prot_id, prot_ids, db)
         }

--- a/util/mario/util.py
+++ b/util/mario/util.py
@@ -50,6 +50,22 @@ def compute_eligible(used_read_prots: list, used_write_prots: list, db: dict) ->
     return bool(read_protocols & compute_protocols) and bool(write_protocols & compute_protocols)
 
 
+def dual_operand_eligible(prot_id: str, prot_ids: dict, db: dict) -> dict:
+    """Return the read protocol and head count if this backend can host the second
+    operand stream: compute-eligible, one write port, one read protocol with >= 2 heads."""
+    ar_prots = prot_ids[prot_id]['ar']
+    aw_prots = prot_ids[prot_id]['aw']
+    heads_r = prot_ids[prot_id]['multihead']['r']
+    heads_w = prot_ids[prot_id]['multihead']['w']
+    if not compute_eligible(ar_prots, aw_prots, db):
+        return {}
+    if len(aw_prots) != 1 or heads_w[aw_prots[0]] != 1:
+        return {}
+    if len(ar_prots) != 1 or heads_r[ar_prots[0]] < 2:
+        return {}
+    return {'protocol': ar_prots[0], 'num_heads': heads_r[ar_prots[0]]}
+
+
 def prepare_ids(id_strs: list) -> dict:
     """Parses and validates the IDs """
 

--- a/verify.mk
+++ b/verify.mk
@@ -23,6 +23,8 @@ IDMA_TOP           ?=
 # Backend variant a leg covers
 IDMA_VERIFY_ID     ?= rw_axi
 IDMA_MULTIHEAD_PAT := 2r_axi_w_axi 2rw_axi
+# ComputeOps masks elaborated on the two-read-head variant: alu+alu_mul+dual, everything
+IDMA_MULTIHEAD_COMPUTE := 7 127
 IDMA_VERIFY_DB     := $(IDMA_ROOT)/$(IDMA_JOBS_JSON)
 IDMA_VERIFY_DIR    := $(IDMA_ROOT)/target/verify
 IDMA_SLANG_DIR     := $(IDMA_ROOT)/target/sim/slang
@@ -164,7 +166,17 @@ idma_verify_multihead: $(IDMA_VERIFY_DIR)/multihead_ids.list
 	  $(SLANG) -f $(IDMA_SLANG_DIR)/mh_synth.f --top idma_backend_synth_$$id \
 	    $(IDMA_SLANG_ARGS); \
 	done
-	set -e; for tb in tb_idma_backend_multihead tb_idma_backend_multihead_rw; do \
+	# the two-read-head variant with the second operand stream elaborated
+	set -e; for c in $(IDMA_MULTIHEAD_COMPUTE); do \
+	  echo "--- verilator idma_backend_synth_2r_axi_w_axi [$$c] ---"; \
+	  $(VERILATOR) $(IDMA_VLT_LINT_ARGS) -f $(IDMA_VLT_DIR)/idma_multihead.f \
+	    --top-module idma_backend_synth_2r_axi_w_axi -GEnableCompute=1 -GComputeOps=$$c; \
+	  echo "--- slang idma_backend_synth_2r_axi_w_axi [$$c] ---"; \
+	  $(SLANG) -f $(IDMA_SLANG_DIR)/mh_synth.f --top idma_backend_synth_2r_axi_w_axi \
+	    -GEnableCompute=1 -GComputeOps=$$c $(IDMA_SLANG_ARGS); \
+	done
+	set -e; for tb in tb_idma_backend_multihead tb_idma_backend_multihead_rw \
+	                  tb_idma_dual tb_idma_dualneg; do \
 	  echo "--- slang $$tb ---"; \
 	  $(SLANG) -f $(IDMA_SLANG_DIR)/mh_tb.f --top $$tb \
 	    $(IDMA_SLANG_ARGS) $(IDMA_SLANG_TB_ARGS); \


### PR DESCRIPTION
Second operand stream for the compute engine on two-read-head backends, adapted from the viDMA reference design's fused dual-head path. **Stacked on #205** (which is stacked on #204); review the last commit only. Retarget once #205 lands.

## Programming model

A two-operand ALU function (`ALU_ADD/SUB/MUL/AND/OR/XOR/AXPY`, `AXPY = imm*a + b`) is issued as an **operand pair**: the two-operand request (source `a`, destination, `src_head` of `a`) immediately followed by an **operand-only partner** (source `b`, same compute config and length, the other `src_head`). The partner writes nothing, its destination is ignored, and both requests get their response in order (the partner's never before the first's). Operands may be misaligned independently and span any number of bursts.

## What

- **Legalizer** (`idma_legalizer.sv.tpl`, `dual_operand_eligible` only): parks the partner (`pair_*`), holds the first operand's reads until the partner is accepted, then interleaves the read bursts of both by swapping the parked and active read tracker after every accepted burst (only the source-side option fields swap; the protocol snippets are untouched). After the first operand's last write, one operand-only completion burst issues for the partner (`w_dp_req.operand_only`). Guards: `ComputeOperandsUnsupported` (all compute-eligible backends), `ComputeOperandPair`, `ComputeOperandLength`, `ComputeOperandHead`. New `operand_pair_o` lets a mismatched partner through the backend's compute-config gate so the guard, not a hang, reports it.
- **Transport layer** (`idma_transport_layer.sv.tpl`): per-head fall-through request queues (`cc_stream_fifo`, depth 2; a role, `a`/`b`, may occupy one head at a time so each buffer keeps request order), a second barrel shifter + `idma_dataflow_element` for `b`, lane-wise join in front of `idma_otf_compute` (a lane is presented once both buffers hold it and popped from both when written: the mutual interlock, at byte granularity), and an operand-only write bypass whose fabricated response waits for every pending B (`b_pending` counter sized by `MetaFifoDepth`). Elaborated only with `EnableCompute && ComputeOps.dual` (`NumOperands == 2`); with `dual` off the multi-head read mux is the same as before, wired through the per-head handles.
- **Backend** (`idma_backend.sv.tpl`): `r_dp_req_t.operand_b`, `w_dp_req_t.operand_only` (dual-eligible only), AW skipped for operand-only bursts, `MetaFifoDepth` passed down.
- **`idma_otf_compute`**: `NumOperands` parameter widens `data_i`; the ALU gets `data_b_i`. Single-head instantiations are textually unchanged.
- **`idma_axi_read`**: `r_ready`/`in_valid` now require `r_dp_valid_i`. With the per-head queues a request can trail its R data; before, such beats were consumed against a stale request and lost. Behavioural change for existing designs: none observed (R never precedes its request there), otherwise it turns silent loss into backpressure.
- mario: `util.dual_operand_eligible()` (compute-eligible, one write port, one read protocol with >= 2 heads); the DB read templates take `${r_dp_req_i}`/`${buffer_in_ready}`, the AXI/TileLink write data path snippet `${w_dp_req_extra}` (rendered through mako in `legalizer.py`); all default IDs render identically.
- Docs: `architecture/compute.md` (Two-Operand Transfers), `frontend/register.md`, `guides/verification.mdx`.

## Byte identity

Regenerated all default IDs plus `2r_axi_w_axi 2rw_axi` and diffed against #205's output: transport layers, backends, synth wrappers, TBs identical; the eight single-head legalizers gain only the 3-line `ComputeOperandsUnsupported` guard; the reg packages gain the new enum values.

## Verification (Questa 2026.1)

- `make idma_sim_tb_idma_dual`: `[DUAL] ALL PASS` at DataWidth 32/64/128/256/512/1024. Every two-operand function over 8 geometries (aligned; a/b/dst misaligned differently with tail beat; a and dst page-crossing; 9000 B multi-burst, i.e. more bursts than the queues hold; single byte; sub-beat; half-beat offsets; b page-crossing) with a on head 0 / b on head 1, plus every other geometry with the heads swapped; single-operand ALU op and plain copy on either head before/after pairs; a pair immediately followed by a copy on head 1. Random per-channel stalls (30 %) on both read ports and the write port. Destination is checked at the **first** response, so the partner's response provably never overtakes it. Golden `test/idma_alu_dpi.c` (function definitions, not the RTL).
- `make idma_sim_tb_idma_dualneg`: 4/4 guards FIRED (`ComputeOperandPair`, `ComputeOperandLength`, `ComputeOperandHead`, `ComputeOperandsUnsupported` with `dual` off); `tb_idma_mxneg` case 17 (two-operand function on `rw_axi`) FIRED, 16/16 total.
- Regression unchanged: `tb_idma_alu` (32..1024), `tb_idma_mxquant`, `tb_idma_mxroundtrip`, `tb_idma_mxrand` (32..1024), `tb_idma_transpose_b2b`, `tb_idma_transpose_nd` (32/64), `tb_idma_reg_frontend`, `tb_idma_backend_multihead`, `tb_idma_backend_multihead_rw` (Questa, all pass).
- Public flow: `make idma_verify_multihead` now also elaborates `idma_backend_synth_2r_axi_w_axi` with `-GEnableCompute=1 -GComputeOps=7|127` (verilator + slang) and slang-elaborates `tb_idma_dual`/`tb_idma_dualneg`: OK. `idma_lint_params IDMA_TOP=idma_backend_synth_rw_axi` (re-encoded `elab_compute` masks) OK, `idma_verify_codegen` OK, verible/flake8/yamllint clean.

## Known scope / disclosures

- Only `2r_axi_w_axi`-shaped topologies (one write port, one read protocol, >= 2 heads) get the second stream; `2rw_axi` and mixed-protocol variants reject two-operand ops with `ComputeOperandsUnsupported`. Validated with AXI reads only.
- The register frontend cannot issue operand pairs (it sets no `src_head`); the path is reachable from the backend interface / inst64-style frontends. The two-operand functions are therefore only exercised by `tb_idma_dual`.
- The multi-head TBs are Questa-only (they need the out-of-tree ids in the RTL); the public verify flow elaborates them (verilator/slang) but does not simulate them. `guards_untested` in `jobs/jobs.json` names the three pair guards for that reason.
- The partner inherits the first operand's AXI ID (its own `axi_id` is unused); its `src` AXI options apply to its reads.
- Second buffer, second shifter, per-head queues and the ghost-response counter cost area on the dual variant only. No synthesis numbers here.
- Error handling (already excluded with compute) is not available; `r_dp_rsp_o` of the multi-head read side is an OR of the heads in dual mode.
- The compute-config gate lets a *mismatched* partner through so the guard fires; after a fired guard the state is undefined, as for every other compute guard.
- No accumulator/reduction/generator ops from the reference (see #205).
