### PR TITLE
compute: Add the element cast unit

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -48,6 +48,7 @@ sources:
       - src/backend/idma_otf_mxquant.sv
       - src/backend/idma_otf_mxdequant.sv
       - src/backend/idma_otf_alu.sv
+      - src/backend/idma_otf_fpcast.sv
       - src/backend/idma_otf_compute.sv
       - src/backend/idma_error_handler.sv
       - src/backend/idma_init_read.sv
@@ -147,6 +148,7 @@ sources:
       - test/tb_idma_mxperf.sv
       - test/tb_idma_mxclear.sv
       - test/tb_idma_alu.sv
+      - test/tb_idma_fpcast.sv
 
   # Tightly-coupled inst64 frontend testbenches (needs the snitch_cluster-gated RTL)
   - target: all(idma_test, snitch_cluster)

--- a/doc/site/src/content/docs/architecture/compute.md
+++ b/doc/site/src/content/docs/architecture/compute.md
@@ -1,17 +1,18 @@
 ---
 title: Compute
-description: On-the-fly transpose, OCP microscaling (MX) quant/dequant and a byte-wise SIMD ALU in the transport datapath.
+description: On-the-fly transpose, OCP microscaling (MX) quant/dequant, a byte-wise SIMD ALU and element casts in the transport datapath.
 ---
 
 ## On-the-Fly Compute Role
 
 iDMA can transform data *while it is in flight* instead of moving it verbatim. The compute engine sits in the transport layer on the write side, between the read dataflow buffer and the write barrel shifter, so the transform runs on the beats streaming from source to destination with no round trip to memory. It is optional and elaborated only when `EnableCompute` is set; otherwise the write path is a plain pass-through.
 
-Three op families are provided:
+Four op families are provided:
 
 - **Transpose** (`idma_otf_transpose`) - tiled matrix transpose, element size 1/2/4/8 B.
 - **MX quant / dequant** (`idma_otf_mxquant`, `idma_otf_mxdequant`) - OCP microscaling conversion between FP32/FP16 and MXFP8, with the FP cast math in `src/idma_float_pkg.sv`.
 - **ALU** (`idma_otf_alu`) - byte-wise SIMD arithmetic and logic against an immediate, one independent 8-bit lane per byte.
+- **Element casts** (`idma_otf_fpcast`) - FP32/BF16 -> INT8/INT16 (round to nearest even, saturating), FP32 -> BF16, BF16/FP16 -> FP32, with the arithmetic in `src/idma_float_pkg.sv`.
 
 A single dispatcher, `idma_otf_compute`, routes one op per transfer to the selected sub-unit. Changing the compute config drains the engine before the next transfer starts. The transpose and MX units consume whole beats; the ALU handshakes per byte lane, so it accepts any alignment and length like a plain copy.
 
@@ -28,7 +29,7 @@ Compute is configured at two levels:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `EnableCompute` | `bit` | Elaborate the compute engine at all |
-| `ComputeOps` | `idma_pkg::compute_enable_t` | Per-op enable mask: `transpose`, `mxquant`, `mxdequant`, `mxfp16`, `alu`, `alu_mul`, `dual` |
+| `ComputeOps` | `idma_pkg::compute_enable_t` | Per-op enable mask: `transpose`, `mxquant`, `mxdequant`, `mxfp16`, `alu`, `alu_mul`, `dual`, `fpcast` |
 | `ComputeTuning` | `idma_pkg::compute_tuning_t` | Implementation knobs (`transpose_full_duplex`) |
 
 `mxfp16` gates the FP16 source/destination paths of the MX ops and `alu_mul` the ALU multiplier; leaving them off drops that area. `dual` elaborates the second operand stream for the two-operand ALU functions (see [Two-Operand Transfers](#two-operand-transfers)) and only takes effect on backends with a single write port and one read protocol with at least two heads (`2r_axi_w_axi`). An op (or ALU function) requested at run time but not elaborated is caught by the legalizer (`ComputeOpUnsupported`, `ComputeOperandsUnsupported`) and a simulation assertion in the dispatcher.
@@ -53,6 +54,13 @@ Compute is configured at two levels:
 | `COMPUTE_MXDEQUANT` | Dequantize, FP32 destination | 33 B / block | 128 B / block |
 | `COMPUTE_MXDEQUANT_FP16` | Dequantize, FP16 destination | 33 B / block | 64 B / block |
 | `COMPUTE_ALU` | Byte-wise ALU, function in `params.alu` | 1 B | 1 B |
+| `COMPUTE_CAST_FP32_I8` | FP32 -> INT8, RNE, saturating | 4 B | 1 B |
+| `COMPUTE_CAST_FP32_I16` | FP32 -> INT16, RNE, saturating | 4 B | 2 B |
+| `COMPUTE_CAST_FP32_BF16` | FP32 -> BF16, RNE | 4 B | 2 B |
+| `COMPUTE_CAST_BF16_I8` | BF16 -> INT8, RNE, saturating | 2 B | 1 B |
+| `COMPUTE_CAST_BF16_I16` | BF16 -> INT16, RNE, saturating | 2 B | 2 B |
+| `COMPUTE_CAST_BF16_FP32` | BF16 -> FP32, exact | 2 B | 4 B |
+| `COMPUTE_CAST_FP16_FP32` | FP16 -> FP32, exact | 2 B | 4 B |
 
 ## Transpose
 
@@ -108,6 +116,12 @@ On a backend with two read heads and `ComputeOps.dual` set, a two-operand ALU fu
 
 Constraints (legalizer assertions): the request after a two-operand request must be its partner with the same compute configuration (`ComputeOperandPair`), the same length (`ComputeOperandLength`) and another read head (`ComputeOperandHead`); a two-operand function on a backend without the second stream is rejected (`ComputeOperandsUnsupported`). The two operands may be misaligned independently. Both requests use the AXI ID and options of the first for the write side; the partner's `src` AXI options apply to its reads. Error handling is not available with compute in general.
 
+## Element Casts
+
+`idma_otf_fpcast` converts every element of an input beat and packs the converted bytes contiguously into a two-beat buffer that drains through the write side (`lane_valid_o` marks the filled bytes, the write pops what it consumes). NaN casts to integer as 0, +-Inf and out-of-range values saturate, integer rounding is round-to-nearest-even; FP32 -> BF16 rounds to nearest even and quiets NaN; BF16/FP16 -> FP32 are exact (NaN quieted). Casts consume whole beats: the legalizer requires beat-aligned source and destination and a beat-multiple length (`ComputeCastBeatAligned`), sizes the write length by the element ratio and requires the expanded length to fit the length field (`ComputeCastLengthFits`). `tb_idma_fpcast` checks every cast byte-exact against a host-FPU DPI-C golden over exponent sweeps and the corner cases (zeros, infinities, NaNs, subnormals, rounding ties, saturation edges).
+
+There is no integer -> float cast; the reference design has none either.
+
 ## Size-Changing Transfers
 
 MX ops change the byte count between read and write. The legalizer computes the write length from the per-op ratio:
@@ -127,6 +141,8 @@ and forces `decouple_rw` / `decouple_aw` on for any compute transfer. Constraint
 | `ComputeMxSrcProtocol` / `ComputeMxDstProtocol` | size-changing ops are AXI-only on src and dst (OBI is a TODO) |
 | `ComputeDstTilelink` | compute retires per beat, so a TileLink destination is not supported |
 | `ComputeMxdequantLengthFits` | dequant output length must fit the `length` field width |
+| `ComputeCastBeatAligned` | element casts: beat-aligned src/dst and a beat-multiple `length` |
+| `ComputeCastLengthFits` | expanding casts: output length must fit the `length` field width |
 | `ComputeOperandsUnsupported` | two-operand functions need `dual` on a two-read-head backend |
 | `ComputeOperandPair` / `ComputeOperandLength` / `ComputeOperandHead` | the operand-only partner follows immediately with the same config and length on another head |
 
@@ -136,7 +152,8 @@ and forces `decouple_rw` / `decouple_aw` on for any compute transfer. Constraint
 - `src/backend/idma_otf_transpose.sv` - tiled transpose engine
 - `src/backend/idma_otf_mxquant.sv`, `src/backend/idma_otf_mxdequant.sv` - MX pack/expand
 - `src/backend/idma_otf_alu.sv` - byte-wise SIMD ALU
-- `src/idma_float_pkg.sv` - FP32/FP16 <-> MXFP8 cast math and block scale
+- `src/backend/idma_otf_fpcast.sv` - element casts
+- `src/idma_float_pkg.sv` - FP32/FP16 <-> MXFP8 cast math, block scale, FP32/BF16 -> INT and FP32 <-> BF16 casts
 - `src/idma_pkg.sv` - `compute_options_t`, `compute_op_e`, `alu_func_e`, `compute_enable_t`, MX block geometry
 - `src/backend/tpl/idma_legalizer.sv.tpl` - size-changing length calc and compute constraints
 - `src/backend/tpl/idma_transport_layer.sv.tpl` - engine instantiation (`gen_compute`), operand streams (`gen_operand_streams`) and the operand-only write bypass

--- a/doc/site/src/content/docs/architecture/frontend/register.md
+++ b/doc/site/src/content/docs/architecture/frontend/register.md
@@ -95,7 +95,7 @@ Present when on-the-fly [compute](../compute/) is elaborated (`EnableCompute`). 
 | Bits | Field | Description |
 |------|-------|-------------|
 | 0 | `compute_enable` | Enable on-the-fly compute for the launched transfer |
-| 4:1 | `compute_op` | Op selector (`idma_pkg::compute_op_e`): `transpose`, `mxquant`, `mxquant_fp16`, `mxdequant`, `mxdequant_fp16`, `alu` |
+| 4:1 | `compute_op` | Op selector (`idma_pkg::compute_op_e`): `transpose`, `mxquant`, `mxquant_fp16`, `mxdequant`, `mxdequant_fp16`, `alu`, `cast_*` |
 | 6:5 | `transpose_mode` | Transpose element size: `1 << transpose_mode` bytes (8/16/32/64 bit) |
 | 18:7 | `transpose_tensor_m` | Transpose M dimension in elements (non-zero when transpose enabled) |
 | 30:19 | `transpose_tensor_n` | Transpose N dimension in elements (non-zero when transpose enabled) |

--- a/doc/site/src/content/docs/architecture/interfaces.md
+++ b/doc/site/src/content/docs/architecture/interfaces.md
@@ -56,7 +56,7 @@ typedef struct packed {
 } compute_options_t;
 ```
 
-`compute_op_e` encodes `COMPUTE_NONE`, `COMPUTE_TRANSPOSE`, `COMPUTE_MXQUANT`, `COMPUTE_MXQUANT_FP16`, `COMPUTE_MXDEQUANT`, `COMPUTE_MXDEQUANT_FP16`, and `COMPUTE_ALU`. It and the ALU function enum `alu_func_e` are generated from `idma_reg.rdl` so RTL and the SW headers share one encoding.
+`compute_op_e` encodes `COMPUTE_NONE`, `COMPUTE_TRANSPOSE`, `COMPUTE_MXQUANT`, `COMPUTE_MXQUANT_FP16`, `COMPUTE_MXDEQUANT`, `COMPUTE_MXDEQUANT_FP16`, `COMPUTE_ALU`, and the seven `COMPUTE_CAST_*` element casts. It and the ALU function enum `alu_func_e` are generated from `idma_reg.rdl` so RTL and the SW headers share one encoding.
 
 ## Transfer Response (`idma_rsp_t`)
 

--- a/doc/site/src/content/docs/guides/verification.mdx
+++ b/doc/site/src/content/docs/guides/verification.mdx
@@ -169,7 +169,8 @@ The on-the-fly compute engines have dedicated self-checking testbenches, checked
 | `idma_sim_tb_idma_transpose_b2b` | ND midend -> `rw_axi` | Two back-to-back transposes to distinct destinations |
 | `idma_sim_tb_idma_mxquant` | `rw_axi` backend, `COMPUTE_MXQUANT{,_FP16}` | FP32/FP16 -> MXFP8 33 B blocks, golden `idma_mxquant_dpi.c`; one run crosses a 4K page |
 | `idma_sim_tb_idma_alu` | `rw_axi` backend, `COMPUTE_ALU` | Every ALU function over misaligned, tail-beat, page-crossing and multi-burst geometries at `DataWidth` 32..1024 under random AXI stalls, golden `idma_alu_dpi.c` |
-| `idma_sim_tb_idma_mxneg` | `rw_axi` backend | One illegal compute request per case; each legalizer guard must fire (cases 14-17 cover the ALU) |
+| `idma_sim_tb_idma_fpcast` | `rw_axi` backend, `COMPUTE_CAST_*` | Every element cast over short, page-crossing and multi-burst whole-beat lengths with corner-case element vectors under random AXI stalls at `DataWidth` 32..1024, host-FPU golden `idma_fpcast_dpi.c` |
+| `idma_sim_tb_idma_mxneg` | `rw_axi` backend | One illegal compute request per case; each legalizer guard must fire (cases 14-19 cover the ALU and the casts) |
 | `idma_sim_tb_idma_dual` | `2r_axi_w_axi` backend, two-operand `COMPUTE_ALU` | Operand pairs over independently misaligned, page-crossing and multi-burst geometries on both head assignments, single-operand ops and copies on either head, random stalls on all three AXI ports, golden `idma_alu_dpi.c`; builds the multi-head RTL in and restores the default set afterwards |
 | `idma_sim_tb_idma_dualneg` | `2r_axi_w_axi` backend | Operand-pair guards: mismatched partner, length, head, missing second stream |
 

--- a/idma.mk
+++ b/idma.mk
@@ -482,7 +482,7 @@ idma_sim_tb_idma_mxclear: $(IDMA_VSIM_DIR)/compile.tcl
 	  else echo "[MXCLR] $$2 clear-guard DID NOT FIRE (see mxclear_$$2.log)"; exit 1; fi; \
 	done
 
-# each case must print its guard assert; cases 6/14/15 need a feature compiled out, case 4 a 1024-bit bus
+# each case must print its guard assert; cases 6/14/15/19 need a feature compiled out, case 4 a 1024-bit bus
 .PHONY: idma_sim_tb_idma_mxneg
 idma_sim_tb_idma_mxneg: $(IDMA_VSIM_DIR)/compile.tcl
 	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
@@ -494,10 +494,11 @@ idma_sim_tb_idma_mxneg: $(IDMA_VSIM_DIR)/compile.tcl
 	         "10 ComputeTransposeSingleBeat 64 1 1 1 1" "11 ComputeMxdequantLengthFits 64 1 1 1 1" \
 	         "12 ComputeMxFp16Width 1024 1 1 1 1" "13 not.elaborated 64 1 0 1 1" \
 	         "14 ComputeOpUnsupported 64 1 1 0 1" "15 ComputeOpUnsupported 64 1 1 1 0" \
-	         "16 ComputeOpUnsupported 64 1 1 1 1" "17 ComputeOperandsUnsupported 64 1 1 1 1"; do \
+	         "16 ComputeOpUnsupported 64 1 1 1 1" "17 ComputeOperandsUnsupported 64 1 1 1 1" \
+	         "18 ComputeCastBeatAligned 64 1 1 1 1" "19 ComputeOpUnsupported 64 1 1 1 1 0"; do \
 	  set -- $$c; \
 	  $(VSIM) -c -t 1ps -voptargs=+acc -gNegCase=$$1 -gDataWidth=$$3 -gEnDequant=$$4 -gEnFp16=$$5 \
-	    -gEnAlu=$$6 -gEnAluMul=$$7 \
+	    -gEnAlu=$$6 -gEnAluMul=$$7 -gEnCast=$${8:-1} \
 	    tb_idma_mxneg -do "run -all; quit" > mxneg_$$1.log 2>&1 || true; \
 	  if grep -qE "(ASSERT FAILED.*$$2|$$2)" mxneg_$$1.log; then echo "[MXNEG] case $$1 $$2 FIRED"; \
 	  else echo "[MXNEG] case $$1 $$2 DID NOT FIRE (see mxneg_$$1.log)"; exit 1; fi; \
@@ -541,6 +542,12 @@ idma_sim_tb_idma_dualneg: $(IDMA_VSIM_DIR)/compile_multihead.tcl
 	  else echo "[DUALNEG] case $$1 $$2 DID NOT FIRE (see dualneg_$$1.log)"; exit 1; fi; \
 	done
 	$(call idma_restore_default_rtl)
+
+.PHONY: idma_sim_tb_idma_fpcast
+idma_sim_tb_idma_fpcast: $(IDMA_VSIM_DIR)/compile.tcl
+	cd $(IDMA_VSIM_DIR); $(VSIM) -c -do "source compile.tcl; quit"
+	cd $(IDMA_VSIM_DIR); $(VLOG) -sv $(abspath $(IDMA_ROOT)/test/idma_fpcast_dpi.c)
+	$(call idma_run_mx_sim,tb_idma_fpcast,32 64 128 256 512 1024)
 
 .PHONY: idma_sim_tb_idma_transpose_midend
 idma_sim_tb_idma_transpose_midend: $(IDMA_VSIM_DIR)/compile.tcl

--- a/jobs/jobs.json
+++ b/jobs/jobs.json
@@ -456,7 +456,9 @@
                 { "tag" : "mxneg_14", "params" : { "NegCase" : 14, "DataWidth" : 64, "EnAlu" : 0 }, "token" : "ComputeOpUnsupported" },
                 { "tag" : "mxneg_15", "params" : { "NegCase" : 15, "DataWidth" : 64, "EnAluMul" : 0 }, "token" : "ComputeOpUnsupported" },
                 { "tag" : "mxneg_16", "params" : { "NegCase" : 16, "DataWidth" : 64 }, "token" : "ComputeOpUnsupported" },
-                { "tag" : "mxneg_17", "params" : { "NegCase" : 17, "DataWidth" : 64 }, "token" : "ComputeOperandsUnsupported" }
+                { "tag" : "mxneg_17", "params" : { "NegCase" : 17, "DataWidth" : 64 }, "token" : "ComputeOperandsUnsupported" },
+                { "tag" : "mxneg_18", "params" : { "NegCase" : 18, "DataWidth" : 64 }, "token" : "ComputeCastBeatAligned" },
+                { "tag" : "mxneg_19", "params" : { "NegCase" : 19, "DataWidth" : 64, "EnCast" : 0 }, "token" : "ComputeOpUnsupported" }
             ],
             "exclude" : [
                 { "case" : 4,  "why" : "DataWidth 1024 SIGSEGVs on verilator 5.020; passes on 5.046" },
@@ -488,14 +490,38 @@
             ]
         }
     },
+    "fpcast" : {
+        "jobs" : {
+        },
+        "params" : {
+            "AddrWidth"   : 32,
+            "UserWidth"   : 1,
+            "AxiIdWidth"  : 12,
+            "TFLenWidth"  : 32
+        },
+        "testbench" : "tb_idma_fpcast",
+        "verify" : {
+            "dpi" : "idma_fpcast_dpi",
+            "token" : "[CAST] ALL PASS",
+            "legs" : [
+                { "tag" : "fpcast_32", "params" : { "DataWidth" : 32 } },
+                { "tag" : "fpcast_64", "params" : { "DataWidth" : 64 } },
+                { "tag" : "fpcast_128", "params" : { "DataWidth" : 128 } },
+                { "tag" : "fpcast_256", "params" : { "DataWidth" : 256 } },
+                { "tag" : "fpcast_512", "params" : { "DataWidth" : 512 } },
+                { "tag" : "fpcast_1024", "params" : { "DataWidth" : 1024 } }
+            ]
+        }
+    },
     "_verify" : {
         "elab_widths" : [32, 64, 512, 1024],
         "elab_compute" : [
-            { "width" : 64, "ops" : 127, "tuning" : 1 },
-            { "width" : 512, "ops" : 127, "tuning" : 1 },
-            { "width" : 64, "ops" : 64, "tuning" : 0 },
-            { "width" : 64, "ops" : 48, "tuning" : 1 },
-            { "width" : 64, "ops" : 4, "tuning" : 1 }
+            { "width" : 64, "ops" : 255, "tuning" : 1 },
+            { "width" : 512, "ops" : 255, "tuning" : 1 },
+            { "width" : 64, "ops" : 128, "tuning" : 0 },
+            { "width" : 64, "ops" : 96, "tuning" : 1 },
+            { "width" : 64, "ops" : 8, "tuning" : 1 },
+            { "width" : 64, "ops" : 1, "tuning" : 1 }
         ],
         "elab_shared_tops" : [
             "idma_desc64_synth", "idma_nd_midend_synth",
@@ -511,6 +537,7 @@
         "guards_untested" : [
             { "guard" : "ComputeMxFp16Width", "why" : "only reachable from the excluded 1024 cases" },
             { "guard" : "ComputeMxdequantLengthFits", "why" : "case 11 is never accepted" },
+            { "guard" : "ComputeCastLengthFits", "why" : "same shape as MxdequantLengthFits: the request is never accepted" },
             { "guard" : "ComputeDstTilelink", "why" : "no TileLink backend variant exists" },
             { "guard" : "ComputeOperandPair", "why" : "multi-head only; fired by idma_sim_tb_idma_dualneg (Questa)" },
             { "guard" : "ComputeOperandLength", "why" : "multi-head only; fired by idma_sim_tb_idma_dualneg (Questa)" },

--- a/src/backend/idma_otf_compute.sv
+++ b/src/backend/idma_otf_compute.sv
@@ -49,7 +49,7 @@ module idma_otf_compute #(
   assign eff_compute = cfg_valid_i ? compute_i : latched_q;
 
   // per-op select: one legality predicate, then route by op
-  logic op_legal, sel_transpose, sel_mxquant, sel_mxdequant, sel_alu;
+  logic op_legal, sel_transpose, sel_mxquant, sel_mxdequant, sel_alu, sel_cast;
   idma_pkg::mx_fmt_e mx_fmt;
   assign op_legal      = eff_compute.enable &
                          idma_pkg::compute_op_supported(ComputeEnable, eff_compute);
@@ -59,6 +59,7 @@ module idma_otf_compute #(
   assign sel_mxdequant = op_legal & (eff_compute.op inside {idma_pkg::COMPUTE_MXDEQUANT,
                                                             idma_pkg::COMPUTE_MXDEQUANT_FP16});
   assign sel_alu       = op_legal & (eff_compute.op == idma_pkg::COMPUTE_ALU);
+  assign sel_cast      = op_legal & idma_pkg::compute_op_is_cast(eff_compute.op);
   assign mx_fmt        = idma_pkg::compute_op_fmt(eff_compute.op);
 
   assign active_o = op_legal;
@@ -182,6 +183,32 @@ module idma_otf_compute #(
     assign alu_data = '0; assign alu_lane_valid = '0; assign alu_lane_ready = '0;
   end
 
+  // element-cast sub-unit
+  logic [StrbWidth-1:0][7:0] fc_data;
+  logic [StrbWidth-1:0]      fc_lane_valid;
+  logic                      fc_in_ready, fc_busy;
+
+  if (ComputeEnable.fpcast) begin : gen_fpcast
+    idma_otf_fpcast #(
+      .StrbWidth ( StrbWidth )
+    ) i_idma_otf_fpcast (
+      .clk_i,
+      .rst_ni,
+      .clear_i      ( ~sel_cast              ),
+      .op_i         ( eff_compute.op         ),
+      .data_i       ( data_a                 ),
+      .valid_i      ( beat_valid & sel_cast  ),
+      .ready_o      ( fc_in_ready            ),
+      .data_o       ( fc_data                ),
+      .lane_valid_o ( fc_lane_valid          ),
+      .lane_ready_i ( lane_ready_i & {StrbWidth{sel_cast}} ),
+      .busy_o       ( fc_busy                )
+    );
+  end else begin : gen_no_fpcast
+    assign fc_data = '0; assign fc_lane_valid = '0; assign fc_in_ready = 1'b0;
+    assign fc_busy = 1'b0;
+  end
+
   // output dispatch, routed per opcode
   always_comb begin
     data_o       = '0;
@@ -216,6 +243,18 @@ module idma_otf_compute #(
           lane_valid_o = alu_lane_valid;
           lane_ready_o = alu_lane_ready;
         end
+        idma_pkg::COMPUTE_CAST_FP32_I8,
+        idma_pkg::COMPUTE_CAST_FP32_I16,
+        idma_pkg::COMPUTE_CAST_FP32_BF16,
+        idma_pkg::COMPUTE_CAST_BF16_I8,
+        idma_pkg::COMPUTE_CAST_BF16_I16,
+        idma_pkg::COMPUTE_CAST_BF16_FP32,
+        idma_pkg::COMPUTE_CAST_FP16_FP32: begin
+          data_o       = fc_data;
+          strb_o       = '1;
+          lane_valid_o = fc_lane_valid;
+          lane_ready_o = {StrbWidth{beat_valid & fc_in_ready}};
+        end
         default: ;
       endcase
     end
@@ -233,8 +272,8 @@ module idma_otf_compute #(
       else $fatal(1, "idma_otf_compute: two-operand op without a second operand stream");
   // backstop: the backend request interlock must never let a differing config in while busy
   always @(posedge clk_i) if (rst_ni && cfg_valid_i && (compute_i != latched_q))
-    assert (!(mx_busy || dq_busy))
-      else $fatal(1, "idma_otf_compute: compute config changed while an MX unit is busy");
+    assert (!(mx_busy || dq_busy || fc_busy))
+      else $fatal(1, "idma_otf_compute: compute config changed while a unit is busy");
   // pragma translate_on
 
 endmodule : idma_otf_compute

--- a/src/backend/idma_otf_fpcast.sv
+++ b/src/backend/idma_otf_fpcast.sv
@@ -1,0 +1,158 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+/// On-the-fly element cast: every input beat converts its FP32/BF16/FP16 elements to
+/// INT8/INT16/BF16/FP32 and the converted bytes are packed contiguously into a
+/// two-beat buffer that drains through StrbWidth-wide output beats. Beats are whole
+/// (beat-aligned addresses, beat-multiple length), so no element straddles a beat.
+module idma_otf_fpcast
+  import idma_float_pkg::*;
+#(
+  parameter int unsigned StrbWidth = 32'd8
+) (
+  input  logic clk_i,
+  input  logic rst_ni,
+  input  logic clear_i,
+  /// Cast op, stable for the transfer
+  input  idma_pkg::compute_op_e op_i,
+
+  input  logic [StrbWidth-1:0][7:0] data_i,
+  input  logic                      valid_i,
+  output logic                      ready_o,
+
+  output logic [StrbWidth-1:0][7:0] data_o,
+  output logic [StrbWidth-1:0]      lane_valid_o,
+  /// Byte lanes the write accepted this cycle; the pack pops exactly these
+  input  logic [StrbWidth-1:0]      lane_ready_i,
+  output logic                      busy_o
+);
+
+  initial assert (StrbWidth >= 4 && (StrbWidth & (StrbWidth-1)) == 0) else
+      $fatal(1, "idma_otf_fpcast: StrbWidth (%0d) must be a power of two >= 4", StrbWidth);
+
+  // an expanding beat yields two beats, so the pack holds two and accepts when it fits
+  localparam int unsigned BufSize     = 2 * StrbWidth;
+  localparam int unsigned OffsetWidth = $clog2(BufSize) + 1;
+  localparam int unsigned PopW        = $clog2(StrbWidth + 1);
+  localparam int unsigned Elems32     = StrbWidth / 4;
+  localparam int unsigned Elems16     = StrbWidth / 2;
+
+  logic [            7:0] pack_q [BufSize];
+  logic [OffsetWidth-1:0] pack_off_q;
+  logic [            7:0] pack_d [BufSize];
+  logic [OffsetWidth-1:0] pack_off_d;
+
+  // per op: element sizes and the converted bytes of this beat, packed from lane 0
+  logic [OffsetWidth-1:0] out_bytes;
+  logic [BufSize-1:0][7:0] conv;
+  always_comb begin
+    conv      = '0;
+    out_bytes = '0;
+    unique case (op_i)
+      idma_pkg::COMPUTE_CAST_FP32_I8: begin
+        out_bytes = OffsetWidth'(Elems32);
+        for (int e = 0; e < Elems32; e++)
+          conv[e] = 8'(fp32_to_int_rne_sat(data_i[e*4 +: 4], 32'd8));
+      end
+      idma_pkg::COMPUTE_CAST_FP32_I16: begin
+        out_bytes = OffsetWidth'(2 * Elems32);
+        for (int e = 0; e < Elems32; e++)
+          conv[e*2 +: 2] = 16'(fp32_to_int_rne_sat(data_i[e*4 +: 4], 32'd16));
+      end
+      idma_pkg::COMPUTE_CAST_FP32_BF16: begin
+        out_bytes = OffsetWidth'(2 * Elems32);
+        for (int e = 0; e < Elems32; e++)
+          conv[e*2 +: 2] = fp32_bits_to_bf16(data_i[e*4 +: 4]);
+      end
+      idma_pkg::COMPUTE_CAST_BF16_I8: begin
+        out_bytes = OffsetWidth'(Elems16);
+        for (int e = 0; e < Elems16; e++)
+          conv[e] = 8'(fp32_to_int_rne_sat(bf16_bits_to_fp32(data_i[e*2 +: 2]), 32'd8));
+      end
+      idma_pkg::COMPUTE_CAST_BF16_I16: begin
+        out_bytes = OffsetWidth'(2 * Elems16);
+        for (int e = 0; e < Elems16; e++)
+          conv[e*2 +: 2] = 16'(fp32_to_int_rne_sat(bf16_bits_to_fp32(data_i[e*2 +: 2]), 32'd16));
+      end
+      idma_pkg::COMPUTE_CAST_BF16_FP32: begin
+        out_bytes = OffsetWidth'(4 * Elems16);
+        for (int e = 0; e < Elems16; e++)
+          conv[e*4 +: 4] = bf16_bits_to_fp32(data_i[e*2 +: 2]);
+      end
+      idma_pkg::COMPUTE_CAST_FP16_FP32: begin
+        out_bytes = OffsetWidth'(4 * Elems16);
+        for (int e = 0; e < Elems16; e++)
+          conv[e*4 +: 4] = fp16_bits_to_fp32(data_i[e*2 +: 2]);
+      end
+      default: ;
+    endcase
+  end
+
+  // lane-exact pop: a tail beat pops only its own bytes
+  logic [PopW-1:0] pop_cnt;
+  always_comb begin
+    pop_cnt = '0;
+    for (int i = 0; i < StrbWidth; i++)
+      if (lane_ready_i[i] && lane_valid_o[i]) pop_cnt += PopW'(1);
+  end
+
+  assign busy_o = (pack_off_q != '0);
+
+  logic                 accept;
+  logic [BufSize*8-1:0] ins_vec;
+  logic [BufSize-1:0]   ins_mask;
+  always_comb begin
+    for (int i = 0; i < BufSize; i++) pack_d[i] = pack_q[i];
+    pack_off_d = pack_off_q;
+
+    if (pop_cnt != '0) begin
+      for (int i = 0; i < BufSize; i++)
+        pack_d[i] = ((i + 32'(pop_cnt)) < BufSize) ? pack_q[i + 32'(pop_cnt)] : 8'd0;
+      pack_off_d = (pack_off_d > OffsetWidth'(pop_cnt)) ? OffsetWidth'(pack_off_d - pop_cnt) : '0;
+    end
+
+    ready_o = (32'(pack_off_d) + 32'(out_bytes)) <= BufSize;
+    accept  = valid_i && ready_o;
+
+    // insert this beat's converted bytes at the post-pop write offset
+    ins_vec  = (BufSize*8)'(conv) << {pack_off_d, 3'b000};
+    ins_mask = ~({BufSize{1'b1}} << out_bytes) << pack_off_d;
+    if (accept) begin
+      for (int i = 0; i < BufSize; i++)
+        if (ins_mask[i]) pack_d[i] = ins_vec[i*8 +: 8];
+      pack_off_d = pack_off_d + out_bytes;
+    end
+  end
+
+  for (genvar i = 0; i < StrbWidth; i++) begin : gen_out
+    assign lane_valid_o[i] = (OffsetWidth'(i) < pack_off_q);
+    assign data_o[i]       = lane_valid_o[i] ? pack_q[i] : 8'd0;
+  end
+
+  // pragma translate_off
+  always @(posedge clk_i) if (rst_ni)
+    assert (32'(pop_cnt) <= 32'(pack_off_q))
+      else $fatal(1, "idma_otf_fpcast: pop exceeds pack occupancy");
+  // NOT IMPLEMENTED: overlapping compute transfers (a clear must never drop in-flight state)
+  always @(posedge clk_i) if (rst_ni && clear_i)
+    assert (pack_off_q == '0)
+      else $fatal(1, "idma_otf_fpcast: clear with in-flight state (overlapping transfers)");
+  // pragma translate_on
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      pack_off_q <= '0;
+      for (int i = 0; i < BufSize; i++) pack_q[i] <= 8'd0;
+    end else if (clear_i) begin
+      pack_off_q <= '0;
+    end else begin
+      pack_off_q <= pack_off_d;
+      for (int i = 0; i < BufSize; i++) pack_q[i] <= pack_d[i];
+    end
+  end
+
+endmodule : idma_otf_fpcast

--- a/src/backend/tpl/idma_legalizer.sv.tpl
+++ b/src/backend/tpl/idma_legalizer.sv.tpl
@@ -563,7 +563,7 @@ w_num_bytes_to_pb = w_page_num_bytes_to_pb;
             // size-changing compute: write length follows the per-op byte ratio
             if (EnableCompute && req_i.opt.compute.enable) begin
                 unique case (req_i.opt.compute.op)
-% for op in ['COMPUTE_MXQUANT', 'COMPUTE_MXQUANT_FP16', 'COMPUTE_MXDEQUANT', 'COMPUTE_MXDEQUANT_FP16']:
+% for op in ['COMPUTE_MXQUANT', 'COMPUTE_MXQUANT_FP16', 'COMPUTE_MXDEQUANT', 'COMPUTE_MXDEQUANT_FP16', 'COMPUTE_CAST_FP32_I8', 'COMPUTE_CAST_FP32_I16', 'COMPUTE_CAST_FP32_BF16', 'COMPUTE_CAST_BF16_I8', 'COMPUTE_CAST_BF16_FP32', 'COMPUTE_CAST_FP16_FP32']:
                     idma_pkg::${op}:
                         w_tf_d.length =
                             (req_i.length / idma_pkg::compute_in_bytes(idma_pkg::${op}))
@@ -877,6 +877,18 @@ ${database[protocol]['legalizer_write_data_path']}
                   (idma_pkg::compute_in_bytes(req_i.opt.compute.op) !=
                    idma_pkg::compute_out_bytes(req_i.opt.compute.op)) &
                   (req_i.opt.dst_protocol != idma_pkg::AXI)), clk_i, !rst_ni)
+    // element casts convert whole beats: beat-aligned addresses and a beat-multiple length
+    `ASSERT_NEVER(ComputeCastBeatAligned, (ready_o & valid_i & req_i.opt.compute.enable &
+                  idma_pkg::compute_op_is_cast(req_i.opt.compute.op) &
+                  ((req_i.length % StrbWidth != 0) | (req_i.src_addr[OffsetWidth-1:0] != '0) |
+                   (req_i.dst_addr[OffsetWidth-1:0] != '0))), clk_i, !rst_ni)
+    // NOT IMPLEMENTED: expanding cast output length that overflows the length field
+    `ASSERT_NEVER(ComputeCastLengthFits, (ready_o & valid_i & req_i.opt.compute.enable &
+                  idma_pkg::compute_op_is_cast(req_i.opt.compute.op) &
+                  ($bits(req_i.length) < 64) &
+                  (((64'(req_i.length) / 64'(idma_pkg::compute_in_bytes(req_i.opt.compute.op))) *
+                    64'(idma_pkg::compute_out_bytes(req_i.opt.compute.op))) >=
+                   (65'd1 << $bits(req_i.length)))), clk_i, !rst_ni)
 % if compute_eligible:
     // the requested op must be elaborated in this configuration
     `ASSERT_NEVER(ComputeOpUnsupported, (ready_o & valid_i & req_i.opt.compute.enable &

--- a/src/frontend/reg/idma_reg.rdl
+++ b/src/frontend/reg/idma_reg.rdl
@@ -161,6 +161,13 @@ addrmap idma_reg #(
         mxdequant      = 4'd4 { desc = "MX dequant, FP32 destination (33B -> 128B per 32-element block)."; };
         mxdequant_fp16 = 4'd5 { desc = "MX dequant, FP16 destination (33B -> 64B per 32-element block)."; };
         alu            = 4'd6 { desc = "Byte-wise SIMD ALU; the function is selected in compute_alu."; };
+        cast_fp32_i8   = 4'd7 { desc = "Element cast FP32 -> INT8, round to nearest even, saturating (4B -> 1B)."; };
+        cast_fp32_i16  = 4'd8 { desc = "Element cast FP32 -> INT16, round to nearest even, saturating (4B -> 2B)."; };
+        cast_fp32_bf16 = 4'd9 { desc = "Element cast FP32 -> BF16, round to nearest even (4B -> 2B)."; };
+        cast_bf16_i8   = 4'd10 { desc = "Element cast BF16 -> INT8, round to nearest even, saturating (2B -> 1B)."; };
+        cast_bf16_i16  = 4'd11 { desc = "Element cast BF16 -> INT16, round to nearest even, saturating (2B -> 2B)."; };
+        cast_bf16_fp32 = 4'd12 { desc = "Element cast BF16 -> FP32, exact (2B -> 4B)."; };
+        cast_fp16_fp32 = 4'd13 { desc = "Element cast FP16 -> FP32, exact (2B -> 4B)."; };
     };
 
     // Byte-wise ALU function (idma_pkg::alu_func_e): 8-bit lanes, wrapping arithmetic

--- a/src/idma_float_pkg.sv
+++ b/src/idma_float_pkg.sv
@@ -5,7 +5,8 @@
 // Authors:
 // - Daniel Keller <dankeller@iis.ee.ethz.ch>
 
-/// FP-cast core for MX compute: FP16/FP32 <-> MXFP8 (E5M2) with E8M0 block scale.
+/// FP-cast core for MX compute (FP16/FP32 <-> MXFP8 with E8M0 block scale) and the
+/// element casts FP32/BF16 -> INT8/INT16, FP32 <-> BF16.
 package idma_float_pkg;
 
   // block geometry is single-homed in idma_pkg
@@ -240,6 +241,60 @@ package idma_float_pkg;
     if (fp32_exp <= 0) return sign_bit;
     else if (fp32_exp >= 255) return sign_bit | {1'b0, 8'hFE, 23'h7FFFFF};
     else return sign_bit | (32'(fp32_exp[7:0]) << 23) | 32'(out_mant);
+  endfunction
+
+  // FP32 -> two's complement integer of IntBits: RNE, saturating, NaN -> 0
+  function automatic logic [31:0] fp32_to_int_rne_sat(input logic [31:0] fp32_bits,
+                                                      input int unsigned int_bits);
+    logic        sign;
+    logic [7:0]  exp32;
+    logic [22:0] man32;
+    int          unb, sh;
+    logic [23:0] full_mant;
+    logic [55:0] shifted;
+    logic [31:0] mag, sat_pos, sat_neg;
+    logic        guard, sticky;
+
+    sign    = fp32_bits[31];
+    exp32   = fp32_bits[30:23];
+    man32   = fp32_bits[22:0];
+    sat_pos = (32'd1 << (int_bits - 1)) - 32'd1;
+    sat_neg = 32'd0 - (32'd1 << (int_bits - 1));
+    if (exp32 == 8'hFF && man32 != 23'd0) return 32'd0;
+    if (exp32 == 8'hFF)                   return sign ? sat_neg : sat_pos;
+    if (exp32 == 8'd0)                    return 32'd0;
+    unb = int'(exp32) - Fp32Bias;
+    if (unb < -1)                  return 32'd0;
+    if (unb >= int'(int_bits))     return sign ? sat_neg : sat_pos;
+    // integer part in [23+unb+1 : 23], guard just below, sticky the rest
+    full_mant = {1'b1, man32};
+    shifted   = {32'd0, full_mant} << (unb + 1);
+    mag       = shifted[55:24];
+    guard     = shifted[23];
+    sticky    = |shifted[22:0];
+    if (guard && (sticky || mag[0])) mag = mag + 32'd1;
+    if (sign) begin
+      if (mag > (32'd1 << (int_bits - 1))) return sat_neg;
+      return 32'd0 - mag;
+    end
+    if (mag > sat_pos) return sat_pos;
+    return mag;
+  endfunction
+
+  // FP32 -> BF16: RNE, NaN quieted
+  function automatic logic [15:0] fp32_bits_to_bf16(input logic [31:0] fp32_bits);
+    logic [31:0] rounded;
+    if (fp32_bits[30:23] == 8'hFF && fp32_bits[22:0] != 23'd0)
+      return {fp32_bits[31], 8'hFF, 1'b1, 6'd0};
+    rounded = fp32_bits + 32'h7FFF + 32'(fp32_bits[16]);
+    return rounded[31:16];
+  endfunction
+
+  // BF16 -> FP32: exact, NaN quieted
+  function automatic logic [31:0] bf16_bits_to_fp32(input logic [15:0] bf16_bits);
+    if (bf16_bits[14:7] == 8'hFF && bf16_bits[6:0] != 7'd0)
+      return {bf16_bits, 16'd0} | 32'h0040_0000;
+    return {bf16_bits, 16'd0};
   endfunction
 
 endpackage

--- a/src/idma_pkg.sv
+++ b/src/idma_pkg.sv
@@ -98,6 +98,13 @@ package idma_pkg;
             COMPUTE_MXQUANT_FP16:   return MxFp16BlockBytes;
             COMPUTE_MXDEQUANT:      return MxBlockBytes;
             COMPUTE_MXDEQUANT_FP16: return MxBlockBytes;
+            COMPUTE_CAST_FP32_I8,
+            COMPUTE_CAST_FP32_I16,
+            COMPUTE_CAST_FP32_BF16: return 32'd4;
+            COMPUTE_CAST_BF16_I8,
+            COMPUTE_CAST_BF16_I16,
+            COMPUTE_CAST_BF16_FP32,
+            COMPUTE_CAST_FP16_FP32: return 32'd2;
             default:                return 32'd1;
         endcase
     endfunction
@@ -108,8 +115,22 @@ package idma_pkg;
             COMPUTE_MXQUANT_FP16:   return MxBlockBytes;
             COMPUTE_MXDEQUANT:      return MxFp32BlockBytes;
             COMPUTE_MXDEQUANT_FP16: return MxFp16BlockBytes;
+            COMPUTE_CAST_FP32_I8,
+            COMPUTE_CAST_BF16_I8:   return 32'd1;
+            COMPUTE_CAST_FP32_I16,
+            COMPUTE_CAST_FP32_BF16,
+            COMPUTE_CAST_BF16_I16:  return 32'd2;
+            COMPUTE_CAST_BF16_FP32,
+            COMPUTE_CAST_FP16_FP32: return 32'd4;
             default:                return 32'd1;
         endcase
+    endfunction
+
+    /// Single source of truth: is `op` an element cast (beat-aligned, whole-beat unit)?
+    function automatic logic compute_op_is_cast(compute_op_e op);
+        return op inside {COMPUTE_CAST_FP32_I8, COMPUTE_CAST_FP32_I16, COMPUTE_CAST_FP32_BF16,
+                          COMPUTE_CAST_BF16_I8, COMPUTE_CAST_BF16_I16, COMPUTE_CAST_BF16_FP32,
+                          COMPUTE_CAST_FP16_FP32};
     endfunction
 
     /// Transpose tensor dimension width (elements)
@@ -157,6 +178,7 @@ package idma_pkg;
         logic alu;
         logic alu_mul;
         logic dual;
+        logic fpcast;
     } compute_enable_t;
 
     /// Implementation tuning knobs for the compute engines
@@ -206,7 +228,7 @@ package idma_pkg;
             COMPUTE_ALU:            return ena.alu & alu_func_defined(cmp.params.alu.func) &
                                            (~alu_func_uses_mul(cmp.params.alu.func) | ena.alu_mul) &
                                            (~alu_func_dual(cmp.params.alu.func) | ena.dual);
-            default:                return 1'b0;
+            default:                return compute_op_is_cast(cmp.op) & ena.fpcast;
         endcase
     endfunction
 

--- a/test/idma_fpcast_dpi.c
+++ b/test/idma_fpcast_dpi.c
@@ -1,0 +1,104 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// DPI-C golden for the element casts, from the IEEE definitions on the host FPU: RNE and
+// saturation for the integer casts (NaN -> 0), RNE for BF16, exact widening (NaN quieted).
+
+#include <fenv.h>
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+#define CAST_GM_MAX_BYTES (1 << 20)
+
+static uint8_t cast_gm_in[CAST_GM_MAX_BYTES];
+static uint8_t cast_gm_out[CAST_GM_MAX_BYTES];
+
+void cast_gm_load(int idx, int val) {
+  if (idx >= 0 && idx < CAST_GM_MAX_BYTES) cast_gm_in[idx] = (uint8_t)val;
+}
+
+int cast_gm_get(int idx) {
+  if (idx >= 0 && idx < CAST_GM_MAX_BYTES) return (int)cast_gm_out[idx];
+  return -1;
+}
+
+static uint32_t rd32(const uint8_t *p) {
+  return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+static uint16_t rd16(const uint8_t *p) { return (uint16_t)(p[0] | (p[1] << 8)); }
+static void wr32(uint8_t *p, uint32_t v) {
+  p[0] = (uint8_t)v; p[1] = (uint8_t)(v >> 8); p[2] = (uint8_t)(v >> 16); p[3] = (uint8_t)(v >> 24);
+}
+static void wr16(uint8_t *p, uint16_t v) { p[0] = (uint8_t)v; p[1] = (uint8_t)(v >> 8); }
+
+static int64_t f32_to_int_sat(uint32_t bits, int int_bits) {
+  float f;
+  double r;
+  int64_t lo = -((int64_t)1 << (int_bits - 1)), hi = ((int64_t)1 << (int_bits - 1)) - 1;
+  memcpy(&f, &bits, 4);
+  if (isnan(f)) return 0;
+  if (isinf(f)) return signbit(f) ? lo : hi;
+  fesetround(FE_TONEAREST);
+  r = nearbyint((double)f);
+  if (r < (double)lo) return lo;
+  if (r > (double)hi) return hi;
+  return (int64_t)r;
+}
+
+static uint16_t f32_to_bf16(uint32_t bits) {
+  if (((bits >> 23) & 0xFFu) == 0xFFu && (bits & 0x7FFFFFu) != 0)
+    return (uint16_t)(((bits >> 16) & 0x8000u) | 0x7FC0u);
+  return (uint16_t)((bits + 0x7FFFu + ((bits >> 16) & 1u)) >> 16);
+}
+
+static uint32_t bf16_to_f32(uint16_t h) {
+  uint32_t bits = (uint32_t)h << 16;
+  if (((h >> 7) & 0xFFu) == 0xFFu && (h & 0x7Fu) != 0) bits |= 0x00400000u;
+  return bits;
+}
+
+static uint32_t fp16_to_f32(uint16_t h) {
+  uint32_t sign = (uint32_t)(h >> 15) & 0x1u;
+  uint32_t exp  = (uint32_t)(h >> 10) & 0x1Fu;
+  uint32_t mant = (uint32_t)h & 0x3FFu;
+  if (exp == 0) {
+    if (mant == 0) return sign << 31;
+    int e = -1;
+    uint32_t m = mant;
+    do { m <<= 1; e++; } while ((m & 0x400u) == 0);
+    m &= 0x3FFu;
+    return (sign << 31) | ((uint32_t)(127 - 15 - e) << 23) | (m << 13);
+  }
+  if (exp == 0x1Fu) {
+    if (mant == 0) return (sign << 31) | (0xFFu << 23);
+    return (sign << 31) | (0xFFu << 23) | (1u << 22) | (mant << 12);
+  }
+  return (sign << 31) | ((exp + (127 - 15)) << 23) | (mant << 13);
+}
+
+// op follows compute_op (7 fp32->i8 .. 13 fp16->fp32); returns the output byte count
+int cast_gm_run(int op, int in_bytes) {
+  int in_sz = (op <= 9) ? 4 : 2, out = 0;
+  if (in_bytes > CAST_GM_MAX_BYTES) in_bytes = CAST_GM_MAX_BYTES;
+  for (int i = 0; i + in_sz <= in_bytes; i += in_sz) {
+    uint32_t x = (in_sz == 4) ? rd32(&cast_gm_in[i]) : (uint32_t)rd16(&cast_gm_in[i]);
+    switch (op) {
+      case 7:  cast_gm_out[out] = (uint8_t)f32_to_int_sat(x, 8); out += 1; break;
+      case 8:  wr16(&cast_gm_out[out], (uint16_t)f32_to_int_sat(x, 16)); out += 2; break;
+      case 9:  wr16(&cast_gm_out[out], f32_to_bf16(x)); out += 2; break;
+      case 10: cast_gm_out[out] = (uint8_t)f32_to_int_sat(bf16_to_f32((uint16_t)x), 8); out += 1;
+               break;
+      case 11: wr16(&cast_gm_out[out], (uint16_t)f32_to_int_sat(bf16_to_f32((uint16_t)x), 16));
+               out += 2; break;
+      case 12: wr32(&cast_gm_out[out], bf16_to_f32((uint16_t)x)); out += 4; break;
+      case 13: wr32(&cast_gm_out[out], fp16_to_f32((uint16_t)x)); out += 4; break;
+      default: break;
+    }
+  }
+  return out;
+}

--- a/test/tb_idma_fpcast.sv
+++ b/test/tb_idma_fpcast.sv
@@ -1,0 +1,301 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+// Element-cast campaign on the rw_axi backend: every cast op over whole-beat lengths
+// (short, page-crossing, multi-burst) with element vectors that sweep the exponent range
+// and hit the corner cases (+-0, +-Inf, quiet and signalling NaN, subnormals, exact
+// rounding ties, saturation boundaries), plus back-to-back casts that switch the op.
+// Byte-exact against the DPI-C golden (host FPU); canary bytes around each destination;
+// an AXI shim injects random per-channel stalls.
+
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+
+module tb_idma_fpcast
+  import idma_pkg::*;
+#(
+  parameter int unsigned DataWidth  = 64,
+  parameter int unsigned AddrWidth  = 32,
+  parameter int unsigned UserWidth  = 1,
+  parameter int unsigned AxiIdWidth = 12,
+  parameter int unsigned TFLenWidth = 32,
+  parameter int unsigned StallPct   = 30,
+  parameter bit          Verbose    = 1'b0
+);
+
+  import "DPI-C" function void cast_gm_load(input int idx, input int val);
+  import "DPI-C" function int  cast_gm_run(input int op, input int in_bytes);
+  import "DPI-C" function int  cast_gm_get(input int idx);
+
+  `include "include/tb_idma_mx_common.svh"
+
+  // random-stall shim: a channel's go bit may rise any cycle but only falls after its handshake
+  logic aw_go, w_go, ar_go, b_go, r_go;
+  function automatic logic go_next(input logic go, input logic vld, input logic rdy);
+    if (go && vld && !rdy) return 1'b1;
+    return ($urandom_range(99) >= StallPct);
+  endfunction
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) {aw_go, w_go, ar_go, b_go, r_go} <= '0;
+    else begin
+      aw_go <= go_next(aw_go, axi_req.aw_valid,    axi_rsp_mem.aw_ready);
+      w_go  <= go_next(w_go,  axi_req.w_valid,     axi_rsp_mem.w_ready);
+      ar_go <= go_next(ar_go, axi_req.ar_valid,    axi_rsp_mem.ar_ready);
+      b_go  <= go_next(b_go,  axi_rsp_mem.b_valid, axi_req.b_ready);
+      r_go  <= go_next(r_go,  axi_rsp_mem.r_valid, axi_req.r_ready);
+    end
+  end
+  always_comb begin
+    axi_req_mem = axi_req;
+    axi_rsp     = axi_rsp_mem;
+    axi_req_mem.aw_valid = axi_req.aw_valid & aw_go;
+    axi_req_mem.w_valid  = axi_req.w_valid  & w_go;
+    axi_req_mem.ar_valid = axi_req.ar_valid & ar_go;
+    axi_req_mem.b_ready  = axi_req.b_ready  & b_go;
+    axi_req_mem.r_ready  = axi_req.r_ready  & r_go;
+    axi_rsp.aw_ready     = axi_rsp_mem.aw_ready & aw_go;
+    axi_rsp.w_ready      = axi_rsp_mem.w_ready  & w_go;
+    axi_rsp.ar_ready     = axi_rsp_mem.ar_ready & ar_go;
+    axi_rsp.b_valid      = axi_rsp_mem.b_valid  & b_go;
+    axi_rsp.r_valid      = axi_rsp_mem.r_valid  & r_go;
+  end
+
+  idma_backend_rw_axi #(
+    .CombinedShifter(1'b0), .DataWidth(DataWidth), .AddrWidth(AddrWidth), .AxiIdWidth(AxiIdWidth),
+    .UserWidth(UserWidth), .TFLenWidth(TFLenWidth), .MaskInvalidData(1'b1), .BufferDepth(3),
+    .EnableCompute(1'b1),
+    .ComputeOps(idma_pkg::compute_enable_t'{fpcast: 1'b1, default: '0}),
+    .ComputeTuning('1),
+    .RAWCouplingAvail(1'b1), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
+    .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(3),
+    .MemSysDepth(0),
+    .idma_req_t(idma_req_t), .idma_rsp_t(idma_rsp_t), .idma_eh_req_t(idma_eh_req_t),
+    .idma_busy_t(idma_busy_t), .axi_req_t(axi_req_t), .axi_rsp_t(axi_rsp_t),
+    .write_meta_channel_t(write_meta_channel_t), .read_meta_channel_t(read_meta_channel_t)
+  ) i_idma_backend (
+    .clk_i(clk), .rst_ni(rst_n),
+    .idma_req_i(idma_req), .req_valid_i(req_valid), .req_ready_o(req_ready),
+    .idma_rsp_o(idma_rsp), .rsp_valid_o(rsp_valid), .rsp_ready_i(rsp_ready),
+    .idma_eh_req_i(idma_eh_req), .eh_req_valid_i(eh_req_valid), .eh_req_ready_o(eh_req_ready),
+    .axi_read_req_o(axi_read_req), .axi_read_rsp_i(axi_read_rsp),
+    .axi_write_req_o(axi_write_req), .axi_write_rsp_i(axi_write_rsp), .busy_o(busy)
+  );
+
+  int unsigned rsp_cnt;
+  always @(posedge clk) if (rsp_valid && rsp_ready) rsp_cnt <= rsp_cnt + 1;
+
+  localparam int unsigned NumOps = 7;
+  localparam idma_pkg::compute_op_e Ops [NumOps] = '{
+    COMPUTE_CAST_FP32_I8, COMPUTE_CAST_FP32_I16, COMPUTE_CAST_FP32_BF16, COMPUTE_CAST_BF16_I8,
+    COMPUTE_CAST_BF16_I16, COMPUTE_CAST_BF16_FP32, COMPUTE_CAST_FP16_FP32};
+  localparam int unsigned Margin = 32;
+  localparam logic [7:0] Canary = 8'hC5;
+
+  function automatic logic [31:0] hash32(input int unsigned i);
+    automatic logic [31:0] h = 32'(i) * 32'd2654435761;
+    return h ^ (h >> 15) ^ (32'(i) * 32'd40503);
+  endfunction
+
+  // FP32 element: corner cases every 16th, otherwise sign/exponent/mantissa swept independently
+  function automatic logic [31:0] fp32_gen(input int unsigned i);
+    automatic logic [31:0] h = hash32(i);
+    case (i % 16)
+      0:  return 32'h0000_0000;                       // +0
+      1:  return 32'h8000_0000;                       // -0
+      2:  return 32'h7F80_0000;                       // +Inf
+      3:  return 32'hFF80_0000;                       // -Inf
+      4:  return 32'h7FC0_0000 | (h & 32'h003F_FFFF); // qNaN
+      5:  return 32'h7F80_0001 | (h & 32'h001F_FFFF); // sNaN
+      6:  return {h[31], 8'd0, 23'd1 | h[22:0]};      // subnormal
+      7:  return {h[31], 8'd126, 23'd0};              // +-0.5 (tie to even 0)
+      8:  return {h[31], 8'd127, 23'h400000};         // +-1.5 (tie to even 2)
+      9:  return {h[31], 8'd133, 23'h7F0000};         // +-127.5 (int8 saturation edge)
+      10: return {h[31], 8'd141, 23'h7FFF00};         // +-32767.5 (int16 saturation edge)
+      11: return {h[31], 8'd134, 23'h008000};         // +-128.5 (int8 negative edge)
+      12: return {h[31], h[30:23], 15'd0, h[15], 16'h8000} ^ (32'(h[16]) << 16); // bf16 tie
+      13: return {h[31], 8'(120 + (i % 20)), h[22:0]}; // small magnitudes around 1
+      14: return {h[31], 8'(127 + (i % 18)), h[22:0]}; // magnitudes up to 2^17
+      default: return h;
+    endcase
+  endfunction
+
+  // 16-bit element (BF16 or FP16 bit pattern): specials every 8th, else swept
+  function automatic logic [15:0] h16_gen(input int unsigned i);
+    automatic logic [31:0] h = hash32(i + 4096);
+    case (i % 8)
+      0: return 16'h0000;                 // +0
+      1: return 16'h8000;                 // -0
+      2: return {h[15], 8'hFF, 7'd0};     // Inf (bf16) / NaN (fp16)
+      3: return {h[15], 8'hFF, 7'h40};    // NaN (bf16) / NaN (fp16)
+      4: return {h[15], 5'd0, 10'd1 | h[9:0]}; // subnormal (fp16) / tiny normal (bf16)
+      5: return {h[15], 5'd31, 10'd0};    // fp16 Inf / bf16 large
+      6: return {h[15], 8'(120 + (i % 16)), h[6:0]}; // bf16 near 1
+      default: return h[15:0];
+    endcase
+  endfunction
+
+  // launch one cast (drive at TA, sample at TT)
+  task automatic launch(input addr_t src, input addr_t dst, input int unsigned len,
+                        input idma_pkg::compute_op_e op);
+    automatic idma_req_t req = '0;
+    req.length   = tf_len_t'(len);
+    req.src_addr = src;
+    req.dst_addr = dst;
+    req.opt.src_protocol = idma_pkg::AXI;
+    req.opt.dst_protocol = idma_pkg::AXI;
+    req.opt.src.burst    = axi_pkg::BURST_INCR;
+    req.opt.dst.burst    = axi_pkg::BURST_INCR;
+    req.opt.beo.decouple_rw = 1'b1;
+    req.opt.beo.decouple_aw = 1'b1;
+    req.opt.compute.enable  = 1'b1;
+    req.opt.compute.op      = op;
+    req.opt.last            = 1'b1;
+    @(posedge clk); #TA;
+    idma_req  = req;
+    req_valid = 1'b1;
+    #(TT - TA);
+    while (!req_ready) begin @(posedge clk); #TT; end
+    @(posedge clk); #TA;
+    req_valid = 1'b0;
+    idma_req  = '0;
+  endtask
+
+  task automatic wait_rsps(input int unsigned n);
+    while (rsp_cnt < n) @(posedge clk);
+    repeat (10) @(posedge clk);
+  endtask
+
+  // fill src (and the golden input) with elements of the op's source format
+  task automatic prepare(input idma_pkg::compute_op_e op, input addr_t src, input addr_t dst,
+                         input int unsigned len, input int unsigned out_len,
+                         input int unsigned seed, input bit canaries = 1'b1);
+    automatic logic [31:0] w;
+    automatic logic [15:0] h;
+    if (idma_pkg::compute_in_bytes(op) == 4) begin
+      for (int unsigned e = 0; e < len / 4; e++) begin
+        w = fp32_gen(e + seed);
+        for (int unsigned b = 0; b < 4; b++) begin
+          wr_mem(src + e*4 + b, w[b*8 +: 8]);
+          cast_gm_load(int'(e*4 + b), int'(w[b*8 +: 8]));
+        end
+      end
+    end else begin
+      for (int unsigned e = 0; e < len / 2; e++) begin
+        h = h16_gen(e + seed);
+        for (int unsigned b = 0; b < 2; b++) begin
+          wr_mem(src + e*2 + b, h[b*8 +: 8]);
+          cast_gm_load(int'(e*2 + b), int'(h[b*8 +: 8]));
+        end
+      end
+    end
+    if (canaries)
+      for (int unsigned i = 0; i < out_len + 2 * Margin; i++) wr_mem(dst - Margin + i, Canary);
+  endtask
+
+  // byte-exact destination check plus the canary margins; returns the error count
+  function automatic int unsigned check(input int unsigned geo, input idma_pkg::compute_op_e op,
+                                        input addr_t dst, input int unsigned out_len);
+    automatic int unsigned errs = 0;
+    for (int unsigned i = 0; i < out_len; i++)
+      if (rd_mem(dst + i) !== 8'(cast_gm_get(int'(i)))) begin
+        errs++;
+        if (errs <= 8) $display("[CAST] geo%0d op=%0d dst[%0d] = %02h exp %02h", geo, op, i,
+                                rd_mem(dst + i), 8'(cast_gm_get(int'(i))));
+      end
+    for (int unsigned i = 0; i < Margin; i++) begin
+      if (rd_mem(dst - Margin + i) !== Canary) begin
+        errs++;
+        if (errs <= 8) $display("[CAST] geo%0d op=%0d canary before dst clobbered", geo, op);
+      end
+      if (rd_mem(dst + out_len + i) !== Canary) begin
+        errs++;
+        if (errs <= 8) $display("[CAST] geo%0d op=%0d canary after dst clobbered", geo, op);
+      end
+    end
+    return errs;
+  endfunction
+
+  function automatic int unsigned out_bytes(input idma_pkg::compute_op_e op,
+                                            input int unsigned len);
+    return (len / idma_pkg::compute_in_bytes(op)) * idma_pkg::compute_out_bytes(op);
+  endfunction
+
+  // one op over one geometry, waited
+  task automatic run_case(input int unsigned geo, input idma_pkg::compute_op_e op,
+                          input addr_t src, input addr_t dst, input int unsigned len,
+                          input int unsigned seed, inout int unsigned errs);
+    automatic int unsigned base = rsp_cnt, olen = out_bytes(op, len), golen;
+    if (Verbose)
+      $display("[CAST] geo%0d op=%0d src=%h dst=%h len=%0d @%0t", geo, op, src, dst, len, $time);
+    prepare(op, src, dst, len, olen, seed);
+    golen = cast_gm_run(int'(op), int'(len));
+    if (golen != olen) begin
+      errs++; $display("[CAST] geo%0d op=%0d golden length %0d != %0d", geo, op, golen, olen);
+    end
+    launch(src, dst, len, op);
+    wait_rsps(base + 1);
+    errs += check(geo, op, dst, olen);
+  endtask
+
+  localparam addr_t SrcBase = 'h0001_0000, DstBase = 'h0009_0000;
+  // beat-aligned pitch between back-to-back destinations (largest output plus canaries)
+  localparam int unsigned B2bPitch = ((16 * StrbWidth + 2 * Margin + StrbWidth - 1) / StrbWidth)
+                                     * StrbWidth;
+
+  // geometry list: source offset, destination offset, length (all whole beats)
+  localparam int unsigned NumGeos = 5;
+  localparam int unsigned GeoSrcOff [NumGeos] = '{0, 4096 - 2 * StrbWidth, 0, StrbWidth, 0};
+  localparam int unsigned GeoDstOff [NumGeos] = '{0, 0, 4096 - StrbWidth, 2 * StrbWidth, 0};
+  localparam int unsigned GeoLen    [NumGeos] = '{
+    4 * StrbWidth,        // short
+    5 * StrbWidth,        // read crosses a page
+    6 * StrbWidth,        // write crosses a page (for expanding casts also the read)
+    StrbWidth,            // single beat
+    4096 + 3 * StrbWidth  // multi-burst
+  };
+
+  initial begin
+    automatic int unsigned errs = 0, seed = 0, base;
+    automatic addr_t src, dst;
+    req_valid = 1'b0; rsp_ready = 1'b1; idma_req = '0; rsp_cnt = 0;
+    @(posedge rst_n);
+    repeat (5) @(posedge clk);
+
+    for (int unsigned g = 0; g < NumGeos; g++) begin
+      for (int unsigned o = 0; o < NumOps; o++) begin
+        src = SrcBase + GeoSrcOff[g];
+        dst = DstBase + GeoDstOff[g];
+        run_case(g, Ops[o], src, dst, GeoLen[g], seed, errs);
+        seed += 64;
+      end
+    end
+
+    // back-to-back: switch the op per transfer without waiting, disjoint destinations
+    base = rsp_cnt;
+    for (int unsigned o = 0; o < NumOps; o++) begin
+      src = SrcBase + 8 * StrbWidth * o;
+      dst = DstBase + B2bPitch * o;
+      prepare(Ops[o], src, dst, 4 * StrbWidth, out_bytes(Ops[o], 4 * StrbWidth), 700 + 64 * o);
+      launch(src, dst, 4 * StrbWidth, Ops[o]);
+    end
+    wait_rsps(base + NumOps);
+    for (int unsigned o = 0; o < NumOps; o++) begin
+      src = SrcBase + 8 * StrbWidth * o;
+      dst = DstBase + B2bPitch * o;
+      prepare(Ops[o], src, dst, 4 * StrbWidth, 0, 700 + 64 * o, 1'b0);
+      void'(cast_gm_run(int'(Ops[o]), int'(4 * StrbWidth)));
+      errs += check(NumGeos, Ops[o], dst, out_bytes(Ops[o], 4 * StrbWidth));
+    end
+
+    if (errs == 0) $display("[CAST] ALL PASS (StrbWidth=%0d)", StrbWidth);
+    else $fatal(1, "[CAST] %0d errors (StrbWidth=%0d)", errs, StrbWidth);
+    $finish;
+  end
+
+  initial begin #50ms; $fatal(1, "[CAST] timeout"); end
+
+endmodule

--- a/test/tb_idma_mxneg.sv
+++ b/test/tb_idma_mxneg.sv
@@ -9,8 +9,8 @@
 // the matching legalizer guard assert to report (compile with +define+INC_ASSERT).
 // The runner greps the transcript for the assert name; case 9 provokes transfer
 // overlap and expects the mxquant sub-unit's clear-with-in-flight-state fatal.
-// Cases 14-17 cover the ALU: op compiled out, multiplier compiled out, undefined
-// function, two-operand function on a single-read-head backend.
+// Cases 14-17 cover the ALU (op or multiplier compiled out, undefined function, two-operand
+// function without a second read head), 18-19 the casts (odd length, unit compiled out).
 
 `include "axi/typedef.svh"
 `include "idma/typedef.svh"
@@ -27,7 +27,8 @@ module tb_idma_mxneg
   parameter bit          EnDequant  = 1'b1,
   parameter bit          EnFp16     = 1'b1,
   parameter bit          EnAlu      = 1'b1,
-  parameter bit          EnAluMul   = 1'b1
+  parameter bit          EnAluMul   = 1'b1,
+  parameter bit          EnCast     = 1'b1
 );
 
   `include "include/tb_idma_mx_common.svh"
@@ -42,7 +43,7 @@ module tb_idma_mxneg
     .EnableCompute(1'b1),
     .ComputeOps(idma_pkg::compute_enable_t'{transpose: 1'b1, mxquant: 1'b1, mxfp16: EnFp16,
                                             mxdequant: EnDequant, alu: EnAlu, alu_mul: EnAluMul,
-                                            dual: 1'b1, default: '0}),
+                                            dual: 1'b1, fpcast: EnCast, default: '0}),
     .ComputeTuning('1),
     .RAWCouplingAvail(1'b1), .HardwareLegalizer(1'b1), .RejectZeroTransfers(1'b1),
     .ErrorCap(idma_pkg::NO_ERROR_HANDLING), .PrintFifoInfo(1'b0), .NumAxInFlight(StrbWidth),
@@ -117,6 +118,10 @@ module tb_idma_mxneg
       16: issue(Src, Dst, 64, idma_pkg::COMPUTE_ALU, idma_pkg::AXI, idma_pkg::AXI, 1'b0, 4'hF);
       17: issue(Src, Dst, 64, idma_pkg::COMPUTE_ALU, idma_pkg::AXI, idma_pkg::AXI, 1'b0,
                 4'(idma_pkg::ALU_ADD));
+      18: issue(Src, Dst, StrbWidth + 4, idma_pkg::COMPUTE_CAST_FP32_I8,
+                idma_pkg::AXI, idma_pkg::AXI, 1'b0);
+      19: issue(Src, Dst, 4 * StrbWidth, idma_pkg::COMPUTE_CAST_BF16_FP32,
+                idma_pkg::AXI, idma_pkg::AXI, 1'b0);
       default: $fatal(1, "[MXNEG] unknown NegCase %0d", NegCase);
     endcase
 

--- a/verify.mk
+++ b/verify.mk
@@ -24,7 +24,7 @@ IDMA_TOP           ?=
 IDMA_VERIFY_ID     ?= rw_axi
 IDMA_MULTIHEAD_PAT := 2r_axi_w_axi 2rw_axi
 # ComputeOps masks elaborated on the two-read-head variant: alu+alu_mul+dual, everything
-IDMA_MULTIHEAD_COMPUTE := 7 127
+IDMA_MULTIHEAD_COMPUTE := 14 255
 IDMA_VERIFY_DB     := $(IDMA_ROOT)/$(IDMA_JOBS_JSON)
 IDMA_VERIFY_DIR    := $(IDMA_ROOT)/target/verify
 IDMA_SLANG_DIR     := $(IDMA_ROOT)/target/sim/slang


### PR DESCRIPTION
Element cast unit as a fourth compute op family, adapted from the viDMA reference design's scalar FP cast engine. **Stacked on #206** (-> #205 -> #204); review the last commit only.

## What

- `src/backend/idma_otf_fpcast.sv`: whole-beat streaming cast. Each input beat converts its FP32/BF16/FP16 elements and appends the converted bytes to a two-beat pack buffer that drains through `lane_valid_o`/`lane_ready_i` exactly like the MX units (lane-exact pop, tail beat partially filled). Compression, identity and expansion are one structure: an input beat is accepted when its converted bytes fit; an expanding beat (2 B -> 4 B) needs the buffer empty, so expansion runs at half input rate (output-bound anyway).
- Seven flat ops `COMPUTE_CAST_{FP32_I8,FP32_I16,FP32_BF16,BF16_I8,BF16_I16,BF16_FP32,FP16_FP32}` (values 7..13 in `idma_reg.rdl`, so they are reg-frontend reachable); `compute_in_bytes/out_bytes` carry the ratios and the legalizer sizes the write length as for MX. Numerics: FP -> INT is round-to-nearest-even with saturation, NaN -> 0; FP32 -> BF16 RNE with NaN quieted; BF16/FP16 -> FP32 exact (NaN quieted). Same rules as the reference design.
- `idma_float_pkg`: `fp32_to_int_rne_sat(bits, int_bits)` (one shifter, both widths), `fp32_bits_to_bf16`, `bf16_bits_to_fp32`.
- Guards: `ComputeCastBeatAligned` (beat-aligned src/dst, beat-multiple length: casts consume whole beats and no element straddles a beat), `ComputeCastLengthFits` (expanding casts). `ComputeOps.fpcast`, `ComputeOpUnsupported` covers the compiled-out case.
- Docs: `architecture/compute.md` (Element Casts), `frontend/register.md`, `interfaces.md`, `guides/verification.mdx`.

## Verification (Questa 2026.1)

- `make idma_sim_tb_idma_fpcast`: `[CAST] ALL PASS` at DataWidth 32/64/128/256/512/1024. Every cast over short, read-page-crossing, write-page-crossing, single-beat and multi-burst (4096+3 beats) lengths plus a back-to-back run switching the op per transfer; canaries; random per-channel AXI stalls (30 %). Element vectors sweep sign/exponent/mantissa and hit +-0, +-Inf, quiet/signalling NaN, subnormals, exact ties (0.5, 1.5, 127.5, 128.5, 32767.5, BF16 mantissa ties), and saturation edges. Golden `test/idma_fpcast_dpi.c` is written from the IEEE definitions on the host FPU (`nearbyint` under `FE_TONEAREST`, `isnan/isinf`, bit-level BF16 rounding), i.e. independent of the RTL. Mutation check: replacing `nearbyint` by `trunc` in the golden makes the TB fail.
- `tb_idma_mxneg`: cases 18 (`ComputeCastBeatAligned`) and 19 (cast with `fpcast` compiled out -> `ComputeOpUnsupported`) FIRED; 18/18 total.
- Regression unchanged: `tb_idma_alu`, `tb_idma_dual` (32..1024), `tb_idma_mxquant`, `tb_idma_mxroundtrip` (32..1024), `tb_idma_transpose_b2b`, `tb_idma_transpose_nd` (32/64).
- Public flow: `idma_verify_sim_fpcast` under Verilator 5.046: 6/6 legs PASS; `idma_lint_params IDMA_TOP=idma_backend_synth_rw_axi` (re-encoded `elab_compute` masks, 8 bits now) OK; `idma_verify_multihead` (masks 14/255) OK; `idma_verify_codegen` OK; verible/flake8/yamllint clean.

## Known scope / disclosures

- Casts consume whole beats: `length % StrbWidth == 0` and beat-aligned addresses. A tail beat cannot be supported without knowing where the transfer ends inside the beat stream (the next transfer's beats can already sit behind it in the buffer), the same limitation MX has. At StrbWidth 128 that means 128 B granularity.
- No integer -> float cast; the reference design has none either.
- Only the FP32/BF16/FP16 sources of the reference are ported. The 4-bit `compute_op` field now has 14 of 16 values taken (0..13); further op families should go hierarchical (params) like the ALU.
- Expansion runs at one input beat per two cycles by construction (output-bound).
- Generated RTL for the default IDs changes only by the two new legalizer guards and the ratio case entries; the transport layers are textually unchanged.
