### PR TITLE
docs: Publish the site from master only

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.output.page_url }}
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     steps:
       -
         name: Deploy to Github Pages


### PR DESCRIPTION
The published documentation site has been tracking `devel`, not the last release. Every recent deployment came from devel:

```
2026-08-19T07:47  ref=devel  sha=aa0dce5e
2026-08-18T22:02  ref=devel  sha=497c1f23
2026-08-17T12:37  ref=devel  sha=4342a1b8
```

With devel 84 commits ahead of master, readers have been seeing unreleased material. Worse, once a release is tagged the next devel push would silently overwrite the released docs.

Two independent things allowed this, and both are addressed.

## 1. Workflow guard (this diff)

`deploy-pages` was guarded on the event being a push, but the workflow triggers on `master` and `devel` alike:

```yaml
if: ${{ github.event_name == 'push' }}
```

It now also checks the branch. The `doc` job still runs on both branches, so a broken documentation build keeps failing early on devel; only publishing is restricted.

## 2. Environment deployment branch policy (repo setting, already applied)

The workflow guard alone is the weaker half: the `github-pages` environment is where GitHub actually enforces who may deploy, and it permitted devel regardless of what the workflow says. Any other workflow, a `workflow_dispatch`, or simply reverting this diff could have published from devel again.

The allow-list was:

```
dev-tbenz, devel, master
```

and is now `master` only.

## 3. Stale branch removed from the allow-list

`dev-tbenz` was a personal branch holding permission to publish the project's documentation. Removed as part of the above.

Settings changes are not expressible in a diff, so they are recorded here for review. The previous policy is kept locally should it need restoring.
