### PR TITLE
ci: Never prune a deploy branch whose tip is tagged

### DIFF
--- a/.github/workflows/prune-deploy-branches.yml
+++ b/.github/workflows/prune-deploy-branches.yml
@@ -66,6 +66,10 @@ jobs:
 
           gh api --paginate "/repos/${repo}/branches?per_page=100" --jq '.[].name' > branches.txt
 
+          # A deploy branch tipped by a tag is a published release artefact.
+          gh api --paginate "/repos/${repo}/tags?per_page=100" \
+            --jq '.[].commit.sha' | sort -u > tagged.txt
+
           while IFS= read -r br; do
             # Hard allow-list: only __deploy__ refs are ever touchable.
             case "$br" in __deploy__*) : ;; *) continue ;; esac
@@ -85,6 +89,11 @@ jobs:
             cepoch="$(date -u -d "$cdate" +%s)" \
               || { echo "SKIP  (bad date)         $br"; continue; }
             age=$(( (now - cepoch) / 86400 ))
+
+            # Never prune a branch whose tip is tagged, whatever its age or target.
+            if grep -qx "$sha" tagged.txt; then
+              echo "KEEP  (release tag)     $br"; kept=$((kept+1)); continue
+            fi
 
             # Feature-branch deploys are pure CI cruft: always prune. Mainline deploys
             # follow the retention window.


### PR DESCRIPTION
The prune job protects exactly one deploy branch, derived from the highest `vX.Y.Z` tag:

```bash
src7="$(git rev-parse "${latest_tag}^" | cut -c1-7)"
keep_branch="__deploy__${src7}__master"
```

So tagging a new release un-protects the previous release's deploy branch, which then falls to `RETENTION_DAYS=60` on the next scheduled run.

Concretely: tagging `v0.7.0` makes `__deploy__b248755__master` eligible, and that branch carries **`v0.6.5`** and is 399 days old. The cron runs Mondays, so it would go on the next pass.

The tag keeps the commit reachable, so nothing is garbage-collected and Bender resolution by tag keeps working. What breaks is anyone pinning the branch.

Keep any deploy branch whose tip carries a tag, regardless of age or target. Verified against the live repo: `__deploy__b248755__master` tips at `28a36e5e`, which is in the tag set, so it is now kept.

No new lint findings (long lines 2 -> 2, yamllint warnings 4 -> 4, both pre-existing).