### PR TITLE
ci: Install graphviz from apt instead of the setup action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,9 @@ jobs:
           target: riscv64-elf
       -
         name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v2
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
       -
         name: Install Bender
         uses: pulp-platform/pulp-actions/bender-install@v2.5.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,9 @@ jobs:
           target: riscv64-elf
       -
         name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v2
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
       -
         name: Install Bender
         uses: pulp-platform/pulp-actions/bender-install@v2.5.0


### PR DESCRIPTION
Replaces `ts-graphviz/setup-graphviz@v2` with a direct apt install in `build.yml` and `docs.yml`.

## This does not fix the hangs, contrary to the original description

The CI hangs seen on 2026-08-19 are **degraded apt fetching from the Azure-hosted runners**, not a fault in the action. `setup-graphviz@v2` internally runs exactly:

```
sudo apt-get update
sudo apt-get install -y graphviz libgraphviz-dev pkg-config
```

so this change substitutes the same two commands. This PR's own CI spent 1min 48s at 35.7 kB/s on the same degraded archive. Graphviz is not preinstalled on the `ubuntu-22.04` image, so apt is unavoidable either way.

## What it is actually worth

- Fetches 3858 kB instead of 6322 kB, by dropping `libgraphviz-dev` and `pkg-config`, which the documentation build does not use.
- Removes a third-party action from the supply chain of both `build` and `docs`.

Modest, but real. Land it on those merits.

## The hang needs a separate change

The effective fix is a timeout on the apt steps so a stalled fetch fails fast instead of holding the matrix for 35 minutes, plus apt socket timeouts, since retries alone do not break a stalled TCP connection:

```
sudo apt-get -o Acquire::http::Timeout=15 -o Acquire::Retries=5 update
```

That belongs in its own PR, alongside `.github/actions/verify-setup/action.yml`, which has the same unguarded apt step.
