### PR TITLE
ci: Warm the verilator packages once per run

### DIFF
--- a/.github/actions/verify-setup/action.yml
+++ b/.github/actions/verify-setup/action.yml
@@ -48,12 +48,23 @@ runs:
         fi
         bender --version
 
+    - if: inputs.verilator == 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.cache/apt-debs
+        key: apt-debs-ubuntu-24.04-${{ runner.arch }}-v1
+
     # ubuntu's verilator ships OBJCACHE empty, so the sims pass OBJCACHE=ccache
     - if: inputs.verilator == 'true'
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y verilator ccache
+        if ls "$HOME/.cache/apt-debs"/*.deb >/dev/null 2>&1; then
+          sudo dpkg -i "$HOME/.cache/apt-debs"/*.deb || sudo apt-get -f install -y
+        else
+          echo "apt-debs cache miss; installing from the archive"
+          sudo apt-get update
+          sudo apt-get install -y verilator ccache
+        fi
         echo "CCACHE_DIR=$HOME/.cache/ccache" >> "$GITHUB_ENV"
         echo "CCACHE_MAXSIZE=2G" >> "$GITHUB_ENV"
     - if: inputs.verilator == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
+  warm-toolchain:
+    uses: ./.github/workflows/warm-toolchain.yml
+    secrets: inherit
+
   build:
     needs: lint
     uses: ./.github/workflows/build.yml
@@ -38,7 +42,7 @@ jobs:
     secrets: inherit
 
   verify:
-    needs: lint
+    needs: [lint, warm-toolchain]
     uses: ./.github/workflows/verify.yml
     secrets: inherit
 

--- a/.github/workflows/warm-toolchain.yml
+++ b/.github/workflows/warm-toolchain.yml
@@ -1,0 +1,35 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Authors:
+# - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+name: warm-toolchain
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+
+  warm:
+    runs-on: ubuntu-24.04
+    steps:
+      -
+        name: Restore package cache
+        id: debs
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/apt-debs
+          key: apt-debs-ubuntu-24.04-${{ runner.arch }}-v1
+      -
+        name: Download packages
+        if: steps.debs.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$HOME/.cache/apt-debs"
+          sudo apt-get update
+          sudo apt-get install -y -d \
+            -o Dir::Cache::archives="$HOME/.cache/apt-debs" \
+            verilator ccache
+          ls -1 "$HOME/.cache/apt-debs"/*.deb | wc -l


### PR DESCRIPTION
Every `verify` job installs verilator and ccache from the ubuntu archive independently. Measured in an ubuntu 24.04 container:

```
verilator + ccache  ->  33 packages, 29.9 MB to download, 132 MB installed
```

With 13 verify jobs that is roughly 390 MB per run and 13 independent chances to hit a stalled mirror. Today one of them stalled and held a run for 48 minutes.

## Change

A `warm-toolchain` job runs alongside `lint`, with no `needs:`, so the fetch overlaps work the run performs anyway rather than adding to the critical path:

```
lint ─┬ lint-license / lint-sv / lint-python / ...
      └ warm-toolchain          (parallel sibling)
   │
   └─► verify                   restore ~/.cache/apt-debs, dpkg -i
                                fall back to apt on a miss
```

`dpkg -i` is followed by `apt-get -f install -y`, because dpkg does not resolve dependency order on its own.

## Scope

Deliberately limited to `verify`:

- `verify` runs on **ubuntu-24.04**, `build` and `docs` on **ubuntu-22.04**. Packages are built against the image, so a single cache cannot serve both; the key names the image to make that explicit and prevent a jammy job restoring noble debs.
- `build` and `docs` fetch only graphviz, 3.9 MB across 2 jobs. They keep installing it directly.
- The slang wheel is not warmed. It comes from PyPI, which has not been the failing source, and `setup-uv` already caches uv's own cache. Warming it would be speculative.

## Degradation

A cache miss installs from the archive exactly as before, so a cold cache behaves like today rather than breaking the matrix. `warm-toolchain` is a separate visible job rather than a step hidden inside a lint job, so if it stops working that is apparent instead of silently reverting to per-job fetches.

## Testing

The package count and size were measured with `apt-get --simulate` in an ubuntu 24.04 container. The install path itself needs CI to confirm: this PR's own run exercises the cold path, and a re-run afterwards exercises the warm path.
