### PR TITLE
ci: Split the verification matrix into elaborate and simulate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,19 @@ jobs:
     uses: ./.github/workflows/analyze.yml
     secrets: inherit
 
-  verify:
+  elaborate:
     needs: [lint, warm-toolchain]
-    uses: ./.github/workflows/verify.yml
+    uses: ./.github/workflows/elaborate.yml
+    secrets: inherit
+
+  simulate:
+    needs: elaborate
+    uses: ./.github/workflows/simulate.yml
     secrets: inherit
 
   # The licensed EDA pipeline runs only once the license-free matrix is green
   gitlab-ci:
-    needs: [build, verify]
+    needs: [build, elaborate, simulate]
     uses: ./.github/workflows/gitlab-ci.yml
     secrets: inherit
 

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -5,17 +5,15 @@
 # Author:
 # - Daniel Keller <dankeller@iis.ee.ethz.ch>
 
-# License-free verification matrix; the run set is src/db/verify.yml
+# License-free elaboration matrix; the run set is jobs/jobs.json
 
-name: verify
+name: elaborate
 
 on:
   workflow_call:
   workflow_dispatch:
 
 jobs:
-
-  # jobs.json and the generated tree must still describe the same design
   codegen-consistency:
     runs-on: ubuntu-24.04
     steps:
@@ -29,7 +27,6 @@ jobs:
         name: Check jobs.json, the CI matrix and codegen determinism
         run: uv run --locked make idma_verify_codegen
 
-  # One backend variant: its jobs.json parameters, a width sweep, its testbench
   elab-backend:
     strategy:
       fail-fast: false
@@ -61,7 +58,6 @@ jobs:
         name: Elaborate ${{ matrix.id }}
         run: uv run --locked make idma_verify_backend IDMA_VERIFY_ID=${{ matrix.id }}
 
-  # The non-backend synthesis tops, plus the inst64 testbench
   elab-shared-tops:
     runs-on: ubuntu-24.04
     steps:
@@ -80,7 +76,6 @@ jobs:
         name: Elaborate the shared synthesis tops
         run: uv run --locked make idma_verify_shared
 
-  # Testbench tops; verilator cannot parse the verification stack, so slang only
   elab-tb-shared:
     runs-on: ubuntu-24.04
     steps:
@@ -97,7 +92,6 @@ jobs:
         name: Elaborate the shared testbenches
         run: uv run --locked make idma_verify_tb_shared
 
-  # Out-of-tree multi-head build; license-free but generated only on request
   elab-multihead:
     runs-on: ubuntu-24.04
     steps:
@@ -112,53 +106,3 @@ jobs:
       -
         name: Elaborate the multi-head variants and testbenches
         run: uv run --locked make idma_verify_multihead
-
-  # The suite list comes from the database, so a new suite needs no edit here
-  sim-matrix:
-    needs: [elab-backend, elab-shared-tops, elab-tb-shared]
-    runs-on: ubuntu-24.04
-    outputs:
-      suites: ${{ steps.legs.outputs.suites }}
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up toolchain
-        uses: ./.github/actions/verify-setup
-      -
-        name: Read the suites from the verification database
-        id: legs
-        run: |
-          suites=$(uv run --locked python util/run_verify.py --emit-matrix suites)
-          echo "suites=$suites" >> "$GITHUB_OUTPUT"
-
-  # Real simulation; run_verify.py knows which suites are negative tests
-  simulate:
-    needs: sim-matrix
-    if: needs.sim-matrix.outputs.suites != ''
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.sim-matrix.outputs.suites) }}
-    runs-on: ubuntu-24.04
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up toolchain
-        uses: ./.github/actions/verify-setup
-        with:
-          verilator: 'true'
-          ccache-key: sim-${{ matrix.suite }}
-      -
-        name: Generate RTL
-        run: uv run --locked make idma_hw_all
-      -
-        name: Simulate ${{ matrix.suite }}
-        run: uv run --locked make idma_verify_sim_${{ matrix.suite }} \
-          IDMA_VLT_MAKEFLAGS="-j4 OBJCACHE=ccache"
-      -
-        name: ccache statistics
-        if: always()
-        run: ccache --show-stats

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -1,0 +1,62 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author:
+# - Daniel Keller <dankeller@iis.ee.ethz.ch>
+
+# License-free simulation matrix; the run set is jobs/jobs.json
+
+name: simulate
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  sim-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      suites: ${{ steps.legs.outputs.suites }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up toolchain
+        uses: ./.github/actions/verify-setup
+      -
+        name: Read the suites from the verification database
+        id: legs
+        run: |
+          suites=$(uv run --locked python util/run_verify.py --emit-matrix suites)
+          echo "suites=$suites" >> "$GITHUB_OUTPUT"
+
+  simulate:
+    needs: sim-matrix
+    if: needs.sim-matrix.outputs.suites != ''
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.sim-matrix.outputs.suites) }}
+    runs-on: ubuntu-24.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up toolchain
+        uses: ./.github/actions/verify-setup
+        with:
+          verilator: 'true'
+          ccache-key: sim-${{ matrix.suite }}
+      -
+        name: Generate RTL
+        run: uv run --locked make idma_hw_all
+      -
+        name: Simulate ${{ matrix.suite }}
+        run: uv run --locked make idma_verify_sim_${{ matrix.suite }} \
+          IDMA_VLT_MAKEFLAGS="-j4 OBJCACHE=ccache"
+      -
+        name: ccache statistics
+        if: always()
+        run: ccache --show-stats


### PR DESCRIPTION
`verify` held both the elaboration jobs and the simulation jobs, so a run reported a single status for two kinds of work and a red `verify` did not say which had failed.

The split follows a dependency that already existed inside the workflow: `sim-matrix` needed `[elab-backend, elab-shared-tops, elab-tb-shared]`. That intra-workflow dependency becomes `simulate: needs: elaborate` at the `ci.yml` level.

```
lint ─► elaborate  codegen-consistency, elab-backend [matrix],
        │          elab-shared-tops, elab-tb-shared, elab-multihead
        └► simulate  sim-matrix, simulate [matrix]
```

`gitlab-ci` now needs `[build, elaborate, simulate]` in place of `[build, verify]`.

The job set is identical, verified by parsing both trees: no job lost, none added. Nothing outside `ci.yml` referenced `verify.yml`, and the nonfree side depends on the make targets (`idma_verify_backend` and friends), not on workflow or job names, so it is unaffected.

One behavioural change worth noting: `simulate` now waits for all of `elaborate`, including `codegen-consistency` and `elab-multihead`, which `sim-matrix` did not previously depend on. Those are among the faster jobs, so the cost is small and the graph is easier to read.