### PR TITLE
ci: Point the matrix check at the renamed elaboration workflow

### DIFF
--- a/util/check_jobs.py
+++ b/util/check_jobs.py
@@ -19,7 +19,7 @@ still describe the same design:
      case or named as untested. Without (e) a new case or a new guard is added to
      the design and silently exercised by nothing.
 
-The simulation matrix is not checked: CI fans it out over src/db/verify.yml, the
+The simulation matrix is not checked: CI fans it out over jobs/jobs.json, the
 same file that drives the local runs. The backend-id matrix is a literal list in
 the workflow, so (e) still compares it against the ids.
 

--- a/verify.mk
+++ b/verify.mk
@@ -247,7 +247,7 @@ idma_verify_codegen:
 	$(PYTHON) $(IDMA_UTIL_DIR)/check_jobs.py --ids "$(IDMA_BACKEND_IDS)" \
 	  --jobs $(IDMA_ROOT)/$(IDMA_JOBS_JSON) --jobs-dir $(IDMA_ROOT)/jobs \
 	  --verify-db $(IDMA_VERIFY_DB) \
-	  --matrix-file $(IDMA_ROOT)/.github/workflows/verify.yml \
+	  --matrix-file $(IDMA_ROOT)/.github/workflows/elaborate.yml \
 	  --mxneg-tb $(IDMA_ROOT)/test/tb_idma_mxneg.sv \
 	  --mxneg-guard-src $(IDMA_ROOT)/src/backend/tpl/idma_legalizer.sv.tpl \
 	  $(IDMA_SOURCE_GLOBS)


### PR DESCRIPTION
`elaborate / codegen-consistency` fails on master:

```
FileNotFoundError: './.github/workflows/verify.yml'
  util/check_jobs.py:133
make: *** [verify.mk:247: idma_verify_codegen] Error 1
```

#215 renamed `verify.yml` to `elaborate.yml`, but `verify.mk` passes that path to `check_jobs.py` as `--matrix-file`; the check reads the workflow to compare the literal backend-id matrix against `IDMA_BACKEND_IDS`. I grepped `.github/` for references to the old name and missed the one in `verify.mk`.

The check that exists to catch matrix drift caught its own input moving, which is the right outcome.

Also corrects the module docstring, which said the simulation matrix is driven by `src/db/verify.yml`. That file does not exist; the run list comes from `jobs/jobs.json`.

Verified locally: `make idma_verify_codegen` returns 0, including the codegen determinism diff.