### PR TITLE
ci: Poll the internal pipeline every 60s instead of every 10

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -30,4 +30,5 @@ jobs:
           domain: iis-git.ee.ethz.ch
           repo: github-mirror/idma
           token: ${{ secrets.GITLAB_TOKEN }}
-          poll-count: 10800 # (10800/60=180min=3hours)
+          poll-period: 60
+          poll-count: 180


### PR DESCRIPTION
`poll-period` was never set, so `pulp-actions/gitlab-ci` used its default of 10 seconds:

```yaml
poll-count: 10800 # (10800/60=180min=3hours)
```

The comment divides by 60 as if the period were one second. The real budget is `10800 x 10s` = **30 hours**; only `timeout-minutes: 200` bounded the job. The internal pipeline runs for tens of minutes, so polling that often costs roughly 1200 API calls per run against iis-git for no benefit.

`60s x 180` is the 3 hours the comment always intended, and matches what gwaihir already uses.

## What other pulp repos do

| repo | poll-period | poll-count | effective |
|---|---|---|---|
| gwaihir | 60 | 180 | 3 h |
| snitch_cluster | 20 | 1000 | 5.5 h |
| axi | *(default 10)* | 1800 | 5 h |
| carfield | *(default 10)* | 2160 | 6 h |
| cheshire | *(default 10)* | 10800 | 30 h, same wrong comment |

cheshire carries the identical comment and the same unset period, so it has the same 30 hour budget.

## Whether the polling can be removed

Holding a GitHub runner for up to 200 minutes purely to wait is the real cost, so the push-based options were checked:

- **GitLab's GitHub integration is unavailable.** `iis-git.ee.ethz.ch` runs GitLab 19.2.4 Community Edition (`enterprise=false`) and the API rejects the `github` integration slug outright; it is [Premium/Ultimate only](https://gitlab.com/gitlab-org/gitlab/-/issues/5401).
- **A `.gitlab-ci.yml` job POSTing to `/repos/pulp-platform/iDMA/statuses/<sha>`** is feasible and needs no extra infrastructure: the internal runners already reach github.com, since `bender checkout` fetches dependencies from there on every job. It needs a PAT with commit-status write stored as a masked CI variable, which is a credential decision rather than a code change. This is the [commonly recommended approach](https://forum.gitlab.com/t/how-to-set-commit-status-on-github-repo-after-pipeline-finishes/79677) for CE.
- **A webhook receiver** such as [gitlab-ci-github-status-checks](https://github.com/flotwig/gitlab-ci-github-status-checks) reproduces the EE integration for CE, but requires hosting a service.
- Mirror-and-wait actions such as [gitlab-mirror-and-ci-action](https://github.com/Gallium70/gitlab-mirror-and-ci-action) all poll too, so they are no improvement.

Nothing native to CE removes the wait, so this PR fixes the interval and leaves the push-based change to a follow-up.
