### PR TITLE
build: Run the desc64 register generation once under make -j

### DIFF
--- a/idma.mk
+++ b/idma.mk
@@ -208,8 +208,6 @@ $(IDMA_RTL_DIR)/idma_reg%d_reg_pkg.sv $(IDMA_RTL_DIR)/idma_reg%d_reg_top.sv $(ID
 	  -P NumDims=$(call dimension,$*) \
 	  -P Log2NumDims=$(call log2dimension,$(call dimension,$*))
 
-# One recipe emits all three desc64 files; a plain multi-target rule would run
-# it once per target (racing under make -j), so the two siblings hang off reg_top.
 $(IDMA_RTL_DIR)/idma_desc64_reg_pkg.sv $(IDMA_RTL_DIR)/idma_desc64_addrmap_pkg.sv: $(IDMA_RTL_DIR)/idma_desc64_reg_top.sv
 $(IDMA_RTL_DIR)/idma_desc64_reg_top.sv: $(IDMA_FE_DIR)/desc64/idma_desc64_reg.rdl
 	# desc64 is APB-native with hand-written wrappers, outside the CPUIF selector

--- a/idma.mk
+++ b/idma.mk
@@ -208,7 +208,10 @@ $(IDMA_RTL_DIR)/idma_reg%d_reg_pkg.sv $(IDMA_RTL_DIR)/idma_reg%d_reg_top.sv $(ID
 	  -P NumDims=$(call dimension,$*) \
 	  -P Log2NumDims=$(call log2dimension,$(call dimension,$*))
 
-$(IDMA_RTL_DIR)/idma_desc64_reg_pkg.sv $(IDMA_RTL_DIR)/idma_desc64_reg_top.sv $(IDMA_RTL_DIR)/idma_desc64_addrmap_pkg.sv:
+# One recipe emits all three desc64 files; a plain multi-target rule would run
+# it once per target (racing under make -j), so the two siblings hang off reg_top.
+$(IDMA_RTL_DIR)/idma_desc64_reg_pkg.sv $(IDMA_RTL_DIR)/idma_desc64_addrmap_pkg.sv: $(IDMA_RTL_DIR)/idma_desc64_reg_top.sv
+$(IDMA_RTL_DIR)/idma_desc64_reg_top.sv: $(IDMA_FE_DIR)/desc64/idma_desc64_reg.rdl
 	# desc64 is APB-native with hand-written wrappers, outside the CPUIF selector
 	$(PEAKRDL) regblock $(IDMA_FE_DIR)/desc64/idma_desc64_reg.rdl -o $(IDMA_RTL_DIR) \
 	  --default-reset arst_n --cpuif apb4-flat \


### PR DESCRIPTION
The three desc64 register outputs were the targets of one plain multi-target rule, so GNU make ran the recipe once per target and, under `make -j`, three concurrent `peakrdl` invocations clobbered each other's outputs (seen in cheshire's CI after bumping to 0.7.0 — pulp-platform/cheshire#294 had to serialize iDMA generation behind a `flock`). Make the two siblings depend on `reg_top` so the recipe runs exactly once; grouped targets (`&:`) need make 4.3, this form is portable. Verified: `make -j8` runs `peakrdl regblock` once, a second invocation is a no-op, `idma_hw_all` unchanged.