### PR TITLE
Fix final `spyglas` violations in `snitch` cluster

### DIFF
--- a/src/idma_float_pkg.sv
+++ b/src/idma_float_pkg.sv
@@ -67,7 +67,7 @@ package idma_float_pkg;
     logic exp_is_zero, exp_is_max, mant_is_zero;
     logic [ 3:0] rounded;
     logic guard, sticky, roundup;
-    int   out_exp;
+    logic [4:0] out_exp;
     logic carry;
     logic [ 5:0] sh_amt;
     logic [ 3:0] sub_kept;
@@ -213,7 +213,7 @@ package idma_float_pkg;
     logic [ 4:0] exp_e5;
     logic [ 1:0] mant;
     logic [31:0] sign_bit;
-    int          fp32_exp;
+    logic [ 7:0] fp32_exp;
     logic [22:0] out_mant;
     logic exp_is_zero, exp_is_max;
 


### PR DESCRIPTION
## Description
This PR introduces a minor fix for `spyglass` violations into the `snitch` cluster. Refer to [PR #330](https://github.com/pulp-platform/snitch_cluster/pull/330) for more details.

## Type of change

- [x] Bug fix

## Checklist

- [x] This PR targets `fix/inst64-init-write-rsp`.
- [x] Commits follow [Chris Beams style](https://chris.beams.io/posts/git-commit/) (≤100-char imperative subject, optional `area:` prefix).
- [x] `make idma_hw_all` and the relevant lints pass locally.
- [x] No AI-attribution lines on commits (e.g. `Co-authored-by:` for AI tools).
- [x] Related issues are referenced.
- [ ] Test this PR commit into the `snitch` CI before merge.