### PR TITLE
Backend: Add Fixed burst support

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -145,6 +145,7 @@ sources:
       - test/tb_idma_mxneg.sv
       - test/tb_idma_mxperf.sv
       - test/tb_idma_mxclear.sv
+      - test/tb_idma_backend_fixed_burst.sv
 
   # Tightly-coupled inst64 frontend testbenches (needs the snitch_cluster-gated RTL)
   - target: all(idma_test, snitch_cluster)

--- a/jobs/jobs.json
+++ b/jobs/jobs.json
@@ -553,6 +553,20 @@
             ]
         }
     },
+    "fixed_burst" : {
+        "jobs" : {
+        },
+        "params" : {
+        },
+        "testbench" : "tb_idma_backend_fixed_burst",
+        "verify" : {
+            "token" : "ALL CHECKS PASSED",
+            "legs" : [
+                { "tag" : "fixed_burst_32", "params" : { "DataWidth" : 32 } },
+                { "tag" : "fixed_burst_64", "params" : { "DataWidth" : 64 } }
+            ]
+        }
+    },
     "_verify" : {
         "elab_widths" : [32, 64, 512, 1024],
         "elab_compute" : [

--- a/src/backend/tpl/idma_legalizer.sv.tpl
+++ b/src/backend/tpl/idma_legalizer.sv.tpl
@@ -159,6 +159,9 @@ ${database[p]['max_beats_per_burst']} * StrbWidth > ${database[p]['page_size']}\
     % if database[read_protocol]['bursts'] == 'only_pow2':
     page_len_t r_${database[read_protocol]['prefix']}_num_bytes_to_pb;
     % endif
+    % if database[read_protocol].get('supports_fixed_bursts', 'false') == 'true':
+    page_len_t r_${database[read_protocol]['prefix']}_fixed_max_bytes;
+    % endif
 % endfor
     page_len_t r_num_bytes_to_pb;
 % if no_write_bursting or has_page_write_bursting:
@@ -167,6 +170,9 @@ ${database[p]['max_beats_per_burst']} * StrbWidth > ${database[p]['page_size']}\
 % for write_protocol in used_write_protocols:
     % if database[write_protocol]['bursts'] == 'only_pow2':
     page_len_t w_${database[write_protocol]['prefix']}_num_bytes_to_pb;
+    % endif
+    % if database[write_protocol].get('supports_fixed_bursts', 'false') == 'true':
+    page_len_t w_${database[write_protocol]['prefix']}_fixed_max_bytes;
     % endif
 % endfor
     page_len_t w_num_bytes_to_pb;
@@ -208,7 +214,7 @@ ${database[p]['max_beats_per_burst']} * StrbWidth > ${database[p]['page_size']}\
             % if index != len(used_non_bursting_read_protocols)-1:
 ,\
             % endif
-        % endfor       
+        % endfor
 } ),
     % endif
 
@@ -227,7 +233,7 @@ ${database[p]['max_beats_per_burst']} * StrbWidth > ${database[p]['page_size']}\
         .OffsetWidth   ( OffsetWidth ),
         .addr_t        ( addr_t      ),
         .len_t         ( page_len_t  )
-    ) i_read_pow2_splitter ( 
+    ) i_read_pow2_splitter (
         .addr_i              ( r_tf_q.addr ),
         .length_i            ( \
         % if database[read_protocol]['tltoaxi4_compatibility_mode'] == "true":
@@ -241,9 +247,26 @@ r_tf_q.length[PageAddrWidth:0] ),
     );
 
     % endif
+    % if database[read_protocol].get('supports_fixed_bursts', 'false') == 'true':
+    /// Protocol '${read_protocol}' caps a FIXED burst at ${database[read_protocol]['max_beats_per_fixed_burst']} beats.
+    localparam int unsigned R${read_protocol.capitalize()}FixedBurstAddrWidth = $clog2(32'd${database[read_protocol]['max_beats_per_fixed_burst']});
+
+    assign r_${database[read_protocol]['prefix']}_fixed_max_bytes = page_len_t'(1 << (OffsetWidth +
+        ((opt_tf_q.src_reduce_len && (opt_tf_q.src_max_llen < 3'(R${read_protocol.capitalize()}FixedBurstAddrWidth)))
+            ? opt_tf_q.src_max_llen : R${read_protocol.capitalize()}FixedBurstAddrWidth)));
+
+    % endif
 % endfor
 % if one_read_port:
-    % if has_pow2_read_bursting:
+    % if has_fixed_read_bursting:
+    assign r_num_bytes_to_pb = (opt_tf_q.src_axi_opt.burst == axi_pkg::BURST_FIXED) ?
+                               r_${database[used_read_protocols[0]]['prefix']}_fixed_max_bytes : \
+        % if has_pow2_read_bursting:
+r_${database[used_read_protocols[0]]['prefix']}_num_bytes_to_pb;
+        % else:
+r_page_num_bytes_to_pb;
+        % endif
+    % elif has_pow2_read_bursting:
     assign r_num_bytes_to_pb = r_${database[used_read_protocols[0]]['prefix']}_num_bytes_to_pb;
     % else:
     assign r_num_bytes_to_pb = r_page_num_bytes_to_pb;
@@ -253,7 +276,15 @@ r_tf_q.length[PageAddrWidth:0] ),
         case (opt_tf_q.src_protocol)
     % for read_protocol in used_read_protocols:
         idma_pkg::${database[read_protocol]['protocol_enum']}: \
-        % if database[read_protocol]['bursts'] == 'only_pow2':
+        % if database[read_protocol].get('supports_fixed_bursts', 'false') == 'true':
+r_num_bytes_to_pb = (opt_tf_q.src_axi_opt.burst == axi_pkg::BURST_FIXED) ?
+                    r_${database[read_protocol]['prefix']}_fixed_max_bytes : \
+            % if database[read_protocol]['bursts'] == 'only_pow2':
+r_${database[read_protocol]['prefix']}_num_bytes_to_pb;
+            % else:
+r_page_num_bytes_to_pb;
+            % endif
+        % elif database[read_protocol]['bursts'] == 'only_pow2':
 r_num_bytes_to_pb = r_${database[read_protocol]['prefix']}_num_bytes_to_pb;
         % else:
 r_num_bytes_to_pb = r_page_num_bytes_to_pb;
@@ -287,7 +318,7 @@ r_num_bytes_to_pb = r_page_num_bytes_to_pb;
             % if index != len(used_non_bursting_write_protocols)-1:
 ,\
             % endif
-        % endfor       
+        % endfor
 } ),
     % endif
 
@@ -311,7 +342,7 @@ $clog2(${database[write_protocol]['page_size']}) ),
         .OffsetWidth   ( OffsetWidth ),
         .addr_t        ( addr_t      ),
         .len_t         ( page_len_t  )
-    ) i_write_pow2_splitter ( 
+    ) i_write_pow2_splitter (
         .addr_i              ( w_tf_q.addr ),
         .length_i            ( \
         % if database[write_protocol]['tltoaxi4_compatibility_mode'] == "true":
@@ -325,9 +356,26 @@ w_tf_q.length[PageAddrWidth:0] ),
     );
 
     % endif
+    % if database[write_protocol].get('supports_fixed_bursts', 'false') == 'true':
+    /// Protocol '${write_protocol}' caps a FIXED burst at ${database[write_protocol]['max_beats_per_fixed_burst']} beats.
+    localparam int unsigned W${write_protocol.capitalize()}FixedBurstAddrWidth = $clog2(32'd${database[write_protocol]['max_beats_per_fixed_burst']});
+
+    assign w_${database[write_protocol]['prefix']}_fixed_max_bytes = page_len_t'(1 << (OffsetWidth +
+        ((opt_tf_q.dst_reduce_len && (opt_tf_q.dst_max_llen < 3'(W${write_protocol.capitalize()}FixedBurstAddrWidth)))
+            ? opt_tf_q.dst_max_llen : W${write_protocol.capitalize()}FixedBurstAddrWidth)));
+
+    % endif
 % endfor
 % if one_write_port:
-    % if has_pow2_write_bursting:
+    % if has_fixed_write_bursting:
+    assign w_num_bytes_to_pb = (opt_tf_q.dst_axi_opt.burst == axi_pkg::BURST_FIXED) ?
+                               w_${database[used_write_protocols[0]]['prefix']}_fixed_max_bytes : \
+        % if has_pow2_write_bursting:
+w_${database[used_write_protocols[0]]['prefix']}_num_bytes_to_pb;
+        % else:
+w_page_num_bytes_to_pb;
+        % endif
+    % elif has_pow2_write_bursting:
     assign w_num_bytes_to_pb = w_${database[used_write_protocols[0]]['prefix']}_num_bytes_to_pb;
     % else:
     assign w_num_bytes_to_pb = w_page_num_bytes_to_pb;
@@ -337,7 +385,15 @@ w_tf_q.length[PageAddrWidth:0] ),
         case (opt_tf_q.dst_protocol)
     % for write_protocol in used_write_protocols:
         idma_pkg::${database[write_protocol]['protocol_enum']}: \
-        % if database[write_protocol]['bursts'] == 'only_pow2':
+        % if database[write_protocol].get('supports_fixed_bursts', 'false') == 'true':
+w_num_bytes_to_pb = (opt_tf_q.dst_axi_opt.burst == axi_pkg::BURST_FIXED) ?
+                    w_${database[write_protocol]['prefix']}_fixed_max_bytes : \
+            % if database[write_protocol]['bursts'] == 'only_pow2':
+w_${database[write_protocol]['prefix']}_num_bytes_to_pb;
+            % else:
+w_page_num_bytes_to_pb;
+            % endif
+        % elif database[write_protocol]['bursts'] == 'only_pow2':
 w_num_bytes_to_pb = w_${database[write_protocol]['prefix']}_num_bytes_to_pb;
         % else:
 w_num_bytes_to_pb = w_page_num_bytes_to_pb;
@@ -374,7 +430,7 @@ w_num_bytes_to_pb = w_page_num_bytes_to_pb;
             % if index != len(used_non_bursting_or_force_decouple_read_protocols)-1:
 ,\
             % endif
-        % endfor 
+        % endfor
  })\
     % endif
     % if len(used_non_bursting_or_force_decouple_write_protocols) != 0:
@@ -385,7 +441,7 @@ w_num_bytes_to_pb = w_page_num_bytes_to_pb;
             % if index != len(used_non_bursting_or_force_decouple_write_protocols)-1:
 ,\
             % endif
-        % endfor 
+        % endfor
  })\
     % endif
 ) begin
@@ -417,8 +473,14 @@ w_num_bytes_to_pb = w_page_num_bytes_to_pb;
             r_num_bytes = r_num_bytes_possible;
             // calculate remainder
             r_tf_d.length = r_tf_q.length - r_num_bytes_possible;
+    % if has_fixed_read_bursting:
+            // next address
+            r_tf_d.addr = (opt_tf_q.src_axi_opt.burst == axi_pkg::BURST_FIXED) ?
+                          r_tf_q.addr : r_tf_q.addr + r_num_bytes;
+    % else:
             // next address
             r_tf_d.addr = r_tf_q.addr + r_num_bytes;
+    % endif
 
         // remaining bytes fit in one burst
         end else begin
@@ -436,8 +498,14 @@ w_num_bytes_to_pb = w_page_num_bytes_to_pb;
             w_num_bytes = w_num_bytes_possible;
             // calculate remainder
             w_tf_d.length = w_tf_q.length - w_num_bytes_possible;
+    % if has_fixed_write_bursting:
+            // next address
+            w_tf_d.addr = (opt_tf_q.dst_axi_opt.burst == axi_pkg::BURST_FIXED) ?
+                          w_tf_q.addr : w_tf_q.addr + w_num_bytes;
+    % else:
             // next address
             w_tf_d.addr = w_tf_q.addr + w_num_bytes;
+    % endif
 
         // remaining bytes fit in one burst
         end else begin
@@ -653,7 +721,7 @@ ${database[protocol]['legalizer_write_data_path']}
                 % if index != len(used_non_bursting_or_force_decouple_read_protocols)-1:
 ,\
                 % endif
-            % endfor 
+            % endfor
  })\
         % endif
         % if len(used_non_bursting_or_force_decouple_write_protocols) != 0:
@@ -664,9 +732,9 @@ ${database[protocol]['legalizer_write_data_path']}
                 % if index != len(used_non_bursting_or_force_decouple_write_protocols)-1:
 ,\
                 % endif
-            % endfor 
+            % endfor
  })\
-        % endif       
+        % endif
 ) begin
             r_tf_ena  = (r_ready_i & !flush_i) | kill_i;
             w_tf_ena  = (w_ready_i & !flush_i) | kill_i;
@@ -697,11 +765,26 @@ ${database[protocol]['legalizer_write_data_path']}
     //--------------------------------------
     // Assertions
     //--------------------------------------
-    // only support the decomposition of incremental bursts
+    // only support the decomposition of incremental bursts, and fixed bursts where the
+    // active read/write protocol(s) actually support them
+% if has_fixed_read_bursting:
+    `ASSERT_NEVER(OnlySupportedBurstsSRC, (ready_o & valid_i &
+                  (req_i.opt.src.burst != axi_pkg::BURST_INCR) &
+                  (req_i.opt.src.burst != axi_pkg::BURST_FIXED)),
+                  clk_i, !rst_ni)
+% else:
     `ASSERT_NEVER(OnlyIncrementalBurstsSRC, (ready_o & valid_i &
                   req_i.opt.src.burst != axi_pkg::BURST_INCR), clk_i, !rst_ni)
+% endif
+% if has_fixed_write_bursting:
+    `ASSERT_NEVER(OnlySupportedBurstsDST, (ready_o & valid_i &
+                  (req_i.opt.dst.burst != axi_pkg::BURST_INCR) &
+                  (req_i.opt.dst.burst != axi_pkg::BURST_FIXED)),
+                  clk_i, !rst_ni)
+% else:
     `ASSERT_NEVER(OnlyIncrementalBurstsDST, (ready_o & valid_i &
                   req_i.opt.dst.burst != axi_pkg::BURST_INCR), clk_i, !rst_ni)
+% endif
 
     // size-changing compute: length must be a whole multiple of the op's input granule
     `ASSERT_NEVER(ComputeSizeAligned, (ready_o & valid_i & req_i.opt.compute.enable &

--- a/src/db/idma_axi.yml
+++ b/src/db/idma_axi.yml
@@ -12,6 +12,8 @@ tb_define: "PROT_AXI4"
 bursts: "split_at_page_boundary"
 page_size: 4096
 max_beats_per_burst: 256
+supports_fixed_bursts: "true"
+max_beats_per_fixed_burst: 16
 legalizer_force_decouple: "false"
 read_meta_channel: "ar_chan"
 write_meta_channel: "aw_chan"

--- a/src/db/idma_tilelink.yml
+++ b/src/db/idma_tilelink.yml
@@ -12,6 +12,7 @@ tb_define: "PROT_TILELINK"
 bursts: "only_pow2"
 page_size: 2048                # limited by TLToAXI4 Bridge -> To be AXI compliant -> Less than 256 beats
 tltoaxi4_compatibility_mode: "true" # If this is true burst will never cross a page boundary and only 32 beat write bursts -> Needed for TLToAXI4 Bridge
+supports_fixed_bursts: "false"
 legalizer_force_decouple: "true" # Forces the legalizer to decouple
 read_meta_channel: "a_chan"
 write_meta_channel: "a_chan"

--- a/test/idma_test.sv
+++ b/test/idma_test.sv
@@ -684,7 +684,9 @@ package idma_test;
             input logic       transpose_en = 1'b0,
             input logic [1:0] transp_mode  = '0,
             input logic [11:0] tensor_m    = '0,
-            input logic [11:0] tensor_n    = '0
+            input logic [11:0] tensor_n    = '0,
+            input axi_pkg::burst_t src_burst = axi_pkg::BURST_INCR,
+            input axi_pkg::burst_t dst_burst = axi_pkg::BURST_INCR
         );
             idma.req.length                 <= #TA length;
             idma.req.src_addr               <= #TA src_addr;
@@ -693,6 +695,8 @@ package idma_test;
             idma.req.opt.dst_protocol       <= #TA dst_protocol;
             idma.req.opt.src_head           <= #TA src_head;
             idma.req.opt.dst_head           <= #TA dst_head;
+            idma.req.opt.src.burst          <= #TA src_burst;
+            idma.req.opt.dst.burst          <= #TA dst_burst;
             idma.req.opt.axi_id             <= #TA id;
             idma.req.opt.beo.decouple_aw    <= #TA decouple_aw;
             idma.req.opt.beo.decouple_rw    <= #TA decouple_rw;
@@ -718,6 +722,8 @@ package idma_test;
             idma.req.opt.dst_protocol       <= #TA idma_pkg::AXI;
             idma.req.opt.src_head           <= #TA '0;
             idma.req.opt.dst_head           <= #TA '0;
+            idma.req.opt.src.burst          <= #TA axi_pkg::BURST_INCR;
+            idma.req.opt.dst.burst          <= #TA axi_pkg::BURST_INCR;
             idma.req.opt.axi_id             <= #TA '0;
             idma.req.opt.beo.decouple_aw    <= #TA '0;
             idma.req.opt.beo.decouple_rw    <= #TA '0;

--- a/test/tb_idma_backend_fixed_burst.sv
+++ b/test/tb_idma_backend_fixed_burst.sv
@@ -1,0 +1,586 @@
+// Copyright 2026 Mosaic SoC.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Luca Rufer <luca@mosaic-soc.com>
+
+// Testbench for AXI FIXED-burst support on the single-port AXI backend (idma_backend_rw_axi).
+// Three burst-type scenarios are checked:
+// - FIXED src -> INCR dst: every read beat targets the same source
+//   word, so the one word is copied out to `num_beats` sequential
+//   destination copies.
+// - INCR src -> FIXED dst: every write beat targets the same
+//   destination word, so the sequential source words are gathered down to
+//   whichever one is written *last*, which is the only one that survives.
+// - FIXED src -> FIXED dst: every beat is from the same to the same address.
+// On these scenarios, the following kind of tests are performed:
+// - Simple single-burst tests: transfers below the 16-beat FIXED-burst limit
+// - Multi-burst tests: transfers above the 16-beat FIXED-burst limit, checking
+//   that the burst is correctly split into multiple bursts.
+// - Page-boundary split tests: transfers that cross a 4K page boundary on the
+//   non-FIXED side, checking that the FIXED burst is also correctly split into
+//   multiple bursts.
+// - user-constrained llen tests: transfers that are split due to the
+//   user-specified max_llen, checking that the llen reduction is correctly
+//   applied to the FIXED bursts.
+// - Narrow tests: transfers that are narrower than the bus width
+// - Partial tests: transfers that are not a multiple of the bus width, so the
+//   last beat is partial and the second-to-last beat is the last full beat.
+
+`timescale 1ns/1ns
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+
+module tb_idma_backend_fixed_burst import idma_pkg::*; #(
+    parameter int unsigned BufferDepth      = 3,
+    parameter int unsigned NumAxInFlight    = 3,
+    parameter int unsigned DataWidth        = 32,
+    parameter int unsigned AddrWidth        = 32,
+    parameter int unsigned UserWidth        = 1,
+    parameter int unsigned AxiIdWidth       = 3,
+    parameter int unsigned TFLenWidth       = 32,
+    parameter int unsigned MemSysDepth      = 0,
+    parameter bit          CombinedShifter  = 1'b0,
+    parameter int unsigned WatchDogNumCycles = 2000
+);
+
+    localparam time TA  = 1ns;
+    localparam time TT  = 9ns;
+    localparam time TCK = 10ns;
+
+    localparam int unsigned StrbWidth   = DataWidth / 8;
+    localparam idma_pkg::error_cap_e ErrorCap = idma_pkg::NO_ERROR_HANDLING;
+
+    typedef logic [7:0]             byte_t;
+    typedef logic [AddrWidth-1:0]   addr_t;
+    typedef logic [DataWidth-1:0]   data_t;
+    typedef logic [StrbWidth-1:0]   strb_t;
+    typedef logic [UserWidth-1:0]   user_t;
+    typedef logic [AxiIdWidth-1:0]  id_t;
+    typedef logic [TFLenWidth-1:0]  tf_len_t;
+
+    `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, addr_t, id_t, user_t)
+    `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, data_t, strb_t, user_t)
+    `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, id_t, user_t)
+    `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, addr_t, id_t, user_t)
+    `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, data_t, id_t, user_t)
+    `AXI_TYPEDEF_REQ_T(axi_req_t, axi_aw_chan_t, axi_w_chan_t, axi_ar_chan_t)
+    `AXI_TYPEDEF_RESP_T(axi_rsp_t, axi_b_chan_t, axi_r_chan_t)
+
+    `IDMA_TYPEDEF_FULL_REQ_T(idma_req_t, id_t, addr_t, tf_len_t)
+    `IDMA_TYPEDEF_FULL_RSP_T(idma_rsp_t, addr_t)
+
+    typedef struct packed { axi_ar_chan_t ar_chan; } axi_read_meta_channel_t;
+    typedef struct packed { axi_read_meta_channel_t axi; } read_meta_channel_t;
+    typedef struct packed { axi_aw_chan_t aw_chan; } axi_write_meta_channel_t;
+    typedef struct packed { axi_write_meta_channel_t axi; } write_meta_channel_t;
+
+    // Clock / reset
+    logic clk;
+    logic rst_n;
+
+    // DMA request / response
+    idma_req_t idma_req;
+    logic req_valid, req_ready;
+    idma_rsp_t idma_rsp;
+    logic rsp_valid, rsp_ready;
+    idma_eh_req_t idma_eh_req;
+    logic eh_req_valid, eh_req_ready;
+    idma_busy_t busy;
+
+    // Single read master bus, single write master bus
+    axi_req_t axi_read_req, axi_write_req;
+    axi_rsp_t axi_read_rsp, axi_write_rsp;
+
+    // Driver
+    IDMA_DV #(
+        .DataWidth  (DataWidth),
+        .AddrWidth  (AddrWidth),
+        .UserWidth  (UserWidth),
+        .AxiIdWidth (AxiIdWidth),
+        .TFLenWidth (TFLenWidth)
+    ) idma_dv (clk);
+
+    typedef idma_test::idma_driver #(
+        .DataWidth  (DataWidth),
+        .AddrWidth  (AddrWidth),
+        .UserWidth  (UserWidth),
+        .AxiIdWidth (AxiIdWidth),
+        .TFLenWidth (TFLenWidth),
+        .TA         (TA),
+        .TT         (TT)
+    ) drv_t;
+    drv_t drv = new(idma_dv);
+
+    assign idma_req         = idma_dv.req;
+    assign req_valid        = idma_dv.req_valid;
+    // TB only inspects the written memory; keep rsp_ready asserted so the read
+    // datapath can drain R into the buffer.
+    assign rsp_ready        = 1'b1;
+    assign idma_eh_req      = idma_dv.eh_req;
+    assign eh_req_valid     = idma_dv.eh_req_valid;
+    assign idma_dv.req_ready    = req_ready;
+    assign idma_dv.rsp          = idma_rsp;
+    assign idma_dv.rsp_valid    = rsp_valid;
+    assign idma_dv.eh_req_ready = eh_req_ready;
+
+    clk_rst_gen #(
+        .ClkPeriod    (TCK),
+        .RstClkCycles (1)
+    ) i_clk_rst_gen (
+        .clk_o  (clk),
+        .rst_no (rst_n)
+    );
+
+    // Monitor taps used to check the FIXED side's beat count and address
+    // constancy. Transaction (burst) counts are derived from the AR/AW
+    // handshakes directly below instead, since they're immune to W-channel
+    // stalls and don't depend on axi_sim_mem's `last` monitor output.
+    logic          mon_r_valid;
+    addr_t         mon_r_addr;
+    logic          mon_w_valid;
+    addr_t         mon_w_addr;
+
+    // Read-side memory (Source)
+    axi_sim_mem #(
+        .AddrWidth         (AddrWidth),
+        .DataWidth         (DataWidth),
+        .IdWidth           (AxiIdWidth),
+        .UserWidth         (UserWidth),
+        .axi_req_t         (axi_req_t),
+        .axi_rsp_t         (axi_rsp_t),
+        .WarnUninitialized (1'b0),
+        .ClearErrOnAccess  (1'b1),
+        .ApplDelay         (TA),
+        .AcqDelay          (TT)
+    ) i_read_mem (
+        .clk_i              (clk),
+        .rst_ni             (rst_n),
+        .axi_req_i          (axi_read_req),
+        .axi_rsp_o          (axi_read_rsp),
+        .mon_r_valid_o      (mon_r_valid),
+        .mon_r_addr_o       (mon_r_addr),
+        .mon_r_last_o       (),
+        .mon_r_beat_count_o (),
+        .mon_r_user_o       (),
+        .mon_r_id_o         (),
+        .mon_r_data_o       (),
+        .mon_w_last_o       (),
+        .mon_w_beat_count_o (),
+        .mon_w_user_o       (),
+        .mon_w_id_o         (),
+        .mon_w_data_o       (),
+        .mon_w_addr_o       (),
+        .mon_w_valid_o      ()
+    );
+
+    // Write-side memory (Destination)
+    axi_sim_mem #(
+        .AddrWidth         (AddrWidth),
+        .DataWidth         (DataWidth),
+        .IdWidth           (AxiIdWidth),
+        .UserWidth         (UserWidth),
+        .axi_req_t         (axi_req_t),
+        .axi_rsp_t         (axi_rsp_t),
+        .WarnUninitialized (1'b0),
+        .ClearErrOnAccess  (1'b1),
+        .ApplDelay         (TA),
+        .AcqDelay          (TT)
+    ) i_write_mem (
+        .clk_i              (clk),
+        .rst_ni             (rst_n),
+        .axi_req_i          (axi_write_req),
+        .axi_rsp_o          (axi_write_rsp),
+        .mon_r_last_o       (),
+        .mon_r_beat_count_o (),
+        .mon_r_user_o       (),
+        .mon_r_id_o         (),
+        .mon_r_data_o       (),
+        .mon_r_addr_o       (),
+        .mon_r_valid_o      (),
+        .mon_w_valid_o      (mon_w_valid),
+        .mon_w_addr_o       (mon_w_addr),
+        .mon_w_last_o       (),
+        .mon_w_beat_count_o (),
+        .mon_w_user_o       (),
+        .mon_w_id_o         (),
+        .mon_w_data_o       ()
+    );
+
+    idma_backend_rw_axi #(
+        .CombinedShifter      (CombinedShifter),
+        .DataWidth            (DataWidth),
+        .AddrWidth            (AddrWidth),
+        .AxiIdWidth           (AxiIdWidth),
+        .UserWidth            (UserWidth),
+        .TFLenWidth           (TFLenWidth),
+        .BufferDepth          (BufferDepth),
+        .RAWCouplingAvail     (1'b0),
+        .MaskInvalidData      (1'b1),
+        .HardwareLegalizer    (1'b1),
+        .RejectZeroTransfers  (1'b1),
+        .ErrorCap             (ErrorCap),
+        .PrintFifoInfo        (1'b0),
+        .NumAxInFlight        (NumAxInFlight),
+        .MemSysDepth          (MemSysDepth),
+        .idma_req_t           (idma_req_t),
+        .idma_rsp_t           (idma_rsp_t),
+        .idma_eh_req_t        (idma_eh_req_t),
+        .idma_busy_t          (idma_busy_t),
+        .axi_req_t            (axi_req_t),
+        .axi_rsp_t            (axi_rsp_t),
+        .write_meta_channel_t (write_meta_channel_t),
+        .read_meta_channel_t  (read_meta_channel_t)
+    ) i_idma_backend (
+        .clk_i           (clk),
+        .rst_ni          (rst_n),
+        .idma_req_i      (idma_req),
+        .req_valid_i     (req_valid),
+        .req_ready_o     (req_ready),
+        .idma_rsp_o      (idma_rsp),
+        .rsp_valid_o     (rsp_valid),
+        .rsp_ready_i     (rsp_ready),
+        .idma_eh_req_i   (idma_eh_req),
+        .eh_req_valid_i  (eh_req_valid),
+        .eh_req_ready_o  (eh_req_ready),
+        .axi_read_req_o  (axi_read_req),
+        .axi_read_rsp_i  (axi_read_rsp),
+        .axi_write_req_o (axi_write_req),
+        .axi_write_rsp_i (axi_write_rsp),
+        .busy_o          (busy)
+    );
+
+    // ----------------------------------------------------------------------
+    // Stimulus
+    // ----------------------------------------------------------------------
+    int unsigned errors = 0;
+
+    // Test number used to generate a unique seed for each test
+    int unsigned test_no = 1;
+
+    // Clear both simulation memories
+    task automatic clear_mem ();
+        i_read_mem.mem.delete();
+        i_write_mem.mem.delete();
+    endtask
+
+    function automatic byte_t gen_data(input addr_t addr, input byte seed);
+        return seed ^ addr[7:0];
+    endfunction
+
+    // Preload read memory with a deterministic pattern
+    task automatic preload (input addr_t base, input int unsigned len, input byte_t seed);
+        for (int unsigned i = 0; i < len; i++)
+            i_read_mem.mem[base + i] = gen_data(i, seed);
+    endtask
+
+    // Check that write memory at `base` expected pattern for an continuous write
+    task automatic check_fixed_to_fixed (input string label, input addr_t base,
+                                         input int unsigned len, input byte_t seed);
+        byte_t got, exp;
+        for (int unsigned i = 0; i < len; i++) begin
+            exp = gen_data(i, seed);
+            if (!i_write_mem.mem.exists(base + i)) begin
+                errors++;
+                $error("[%s] Write @0x%h: Address never written", label, base + i);
+                continue;
+            end
+            got = i_write_mem.mem[base + i];
+            if (got !== exp) begin
+                errors++;
+                $error("[%s] Write @0x%h: got 0x%h exp 0x%h", label, base + i, got, exp);
+            end
+        end
+        $display("[%s] Write @0x%h len %0d: OK", label, base, len);
+    endtask
+
+    // Check that write memory at `base` holds the expected pattern for a FIXED write, a repeating
+    // pattern of `StrbWidth` bytes.
+    task automatic check_fixed_to_incr (input string label, input addr_t base,
+                                        input int unsigned length, input byte_t seed);
+        byte_t got, exp;
+        for (int unsigned i = 0; i < length; i++) begin
+            exp = gen_data(i % StrbWidth, seed);
+            if (!i_write_mem.mem.exists(base + i)) begin
+                errors++;
+                $error("[%s] Write @0x%h: Address never written", label, base + i);
+                continue;
+            end
+            got = i_write_mem.mem[base + i];
+            if (got !== exp) begin
+                errors++;
+                $error("[%s] Write @0x%h: got 0x%h exp 0x%h", label, base + i, got, exp);
+            end
+        end
+        $display("[%s] Write @0x%h len %0d: OK", label, base, length);
+    endtask
+
+    // Check that write memory at `base` holds the expected pattern for a FIXED
+    // write fed by an INCR source of `length` bytes.
+    // The expected pattern is the last beat of the INCR source, and possibly
+    // the second-to-last beat if the last beat is partial.
+    task automatic check_incr_to_fixed (input string label, input addr_t base,
+                                        input int unsigned length, input byte_t seed);
+        int unsigned exp_beats, tailer, checked_len;
+        byte_t got, exp;
+        exp_beats   = (length + StrbWidth - 1) / StrbWidth;
+        tailer      = length % StrbWidth;
+        checked_len = (tailer == 0) ? StrbWidth : ((exp_beats == 1) ? tailer : StrbWidth);
+        for (int unsigned i = 0; i < checked_len; i++) begin
+            int unsigned from_beat = (tailer == 0 || i < tailer) ? exp_beats - 1 : exp_beats - 2;
+            exp = gen_data(from_beat * StrbWidth + i, seed);
+            if (!i_write_mem.mem.exists(base + i)) begin
+                errors++;
+                $error("[%s] Write @0x%h: Address never written", label, base + i);
+                continue;
+            end
+            got = i_write_mem.mem[base + i];
+            if (got !== exp) begin
+                errors++;
+                $error("[%s] Write @0x%h: got 0x%h exp 0x%h", label, base + i, got, exp);
+            end
+        end
+        $display("[%s] Write @0x%h len %0d: OK", label, base, checked_len);
+    endtask
+
+    // Background monitors to check beat count, transaction count, and
+    // addresses for FIXED side bursts.
+    int unsigned r_beats, w_beats;
+    int unsigned r_txns, w_txns;
+    logic        r_addr_ok, w_addr_ok;
+    addr_t       r_exp_addr, w_exp_addr;
+
+    function automatic void reset_read_monitor (input addr_t exp_addr);
+        r_beats    = 0;
+        r_txns     = 0;
+        r_addr_ok  = 1'b1;
+        r_exp_addr = exp_addr;
+    endfunction
+
+    function automatic void reset_write_monitor (input addr_t exp_addr);
+        w_beats    = 0;
+        w_txns     = 0;
+        w_addr_ok  = 1'b1;
+        w_exp_addr = exp_addr;
+    endfunction
+
+    initial begin
+        r_beats   = 0;
+        r_txns    = 0;
+        r_addr_ok = 1'b1;
+
+        @(posedge rst_n);
+
+        forever begin
+            @(posedge clk);
+            if (axi_read_req.ar_valid && axi_read_rsp.ar_ready) r_txns++;
+            #(TT);
+            if (mon_r_valid) begin
+                r_beats++;
+                if (mon_r_addr != r_exp_addr) r_addr_ok = 1'b0;
+            end
+        end
+    end
+
+    initial begin
+        w_beats   = 0;
+        w_txns    = 0;
+        w_addr_ok = 1'b1;
+
+        @(posedge rst_n);
+
+        forever begin
+            @(posedge clk);
+            if (axi_write_req.aw_valid && axi_write_rsp.aw_ready) w_txns++;
+            #(TT);
+            if (mon_w_valid) begin
+                w_beats++;
+                if (mon_w_addr != w_exp_addr) w_addr_ok = 1'b0;
+            end
+        end
+    end
+
+    // Wait for the transfer to finish. When `mon_read` (resp. `mon_write`) is
+    // set, checks that the read (resp. write) monitor saw exactly `exp_beats`
+    // FIXED-side beats, split into exactly `exp_txns` AR/AW transactions, with
+    // the address held constant throughout.
+    task automatic wait_done (input string label = "", input int unsigned exp_beats = 0,
+                              input bit mon_read = 1'b0, input bit mon_write = 1'b0,
+                              input int unsigned exp_txns = 1);
+        @(posedge clk);
+        while (busy != '0) @(posedge clk);
+        repeat (5) @(posedge clk);
+
+        if (mon_read) begin
+            if (r_beats !== exp_beats) begin
+                errors++;
+                $error("[%s] AR: got %0d beats, exp %0d", label, r_beats, exp_beats);
+            end
+            if (r_txns !== exp_txns) begin
+                errors++;
+                $error("[%s] AR: got %0d transaction(s), exp %0d", label, r_txns, exp_txns);
+            end
+            if (!r_addr_ok) begin
+                errors++;
+                $error("[%s] AR: address was not constant across the FIXED burst", label);
+            end
+        end
+        if (mon_write) begin
+            if (w_beats !== exp_beats) begin
+                errors++;
+                $error("[%s] AW: got %0d beats, exp %0d", label, w_beats, exp_beats);
+            end
+            if (w_txns !== exp_txns) begin
+                errors++;
+                $error("[%s] AW: got %0d transaction(s), exp %0d", label, w_txns, exp_txns);
+            end
+            if (!w_addr_ok) begin
+                errors++;
+                $error("[%s] AW: address was not constant across the FIXED burst", label);
+            end
+        end
+    endtask
+
+    // FIXED src (one word, repeatedly read) -> INCR dst (length bytes, sequential).
+    task automatic fixed_to_incr_test (input string label, input int unsigned length,
+                                       input addr_t src = 32'h0000_1000,
+                                       input addr_t dst = 32'h0000_2000,
+                                       input int unsigned exp_txns = 1,
+                                       input logic [2:0] src_max_llen = 3'd0,
+                                       input bit src_reduce_len = 1'b0);
+        int unsigned exp_beats;
+        byte_t seed;
+        seed = byte_t'(test_no++);
+        exp_beats = (length + StrbWidth - 1) / StrbWidth;
+        clear_mem();
+        preload(src, StrbWidth, seed);
+        reset_read_monitor(src);
+        drv.launch_tf(.length (length), .src_addr (src), .dst_addr (dst),
+                      .src_protocol (idma_pkg::AXI), .dst_protocol (idma_pkg::AXI),
+                      .decouple_aw (1'b0), .decouple_rw (1'b0),
+                      .src_max_llen (src_max_llen), .dst_max_llen (3'd0),
+                      .src_reduce_len (src_reduce_len), .dst_reduce_len (1'b0), .id ('0),
+                      .src_burst (axi_pkg::BURST_FIXED), .dst_burst (axi_pkg::BURST_INCR));
+        wait_done(.label (label), .exp_beats (exp_beats), .mon_read (1'b1), .exp_txns (exp_txns));
+        check_fixed_to_incr(label, dst, length, seed);
+    endtask
+
+    // INCR src (length bytes, sequential) -> FIXED dst (one word: last beat remains).
+    task automatic incr_to_fixed_test (input string label, input int unsigned length,
+                                       input addr_t src = 32'h0000_1000,
+                                       input addr_t dst = 32'h0000_2000,
+                                       input int unsigned exp_txns = 1,
+                                       input logic [2:0] dst_max_llen = 3'd0,
+                                       input bit dst_reduce_len = 1'b0);
+        int unsigned exp_beats;
+        byte_t seed;
+        seed = byte_t'(test_no++);
+        exp_beats = (length + StrbWidth - 1) / StrbWidth;
+        clear_mem();
+        preload(src, length, seed);
+        reset_write_monitor(dst);
+        drv.launch_tf(.length (length), .src_addr (src), .dst_addr (dst),
+                      .src_protocol (idma_pkg::AXI), .dst_protocol (idma_pkg::AXI),
+                      .decouple_aw (1'b0), .decouple_rw (1'b0),
+                      .src_max_llen (3'd0), .dst_max_llen (dst_max_llen),
+                      .src_reduce_len (1'b0), .dst_reduce_len (dst_reduce_len), .id ('0),
+                      .src_burst (axi_pkg::BURST_INCR), .dst_burst (axi_pkg::BURST_FIXED));
+        wait_done(.label (label), .exp_beats (exp_beats), .mon_write (1'b1), .exp_txns (exp_txns));
+        check_incr_to_fixed(label, dst, length, seed);
+    endtask
+
+    // FIXED src -> FIXED dst: same one word on both ends, repeated length/StrbWidth times.
+    task automatic fixed_to_fixed_test (input string label, input int unsigned length,
+                                        input addr_t src = 32'h0000_1000,
+                                        input addr_t dst = 32'h0000_2000,
+                                        input int unsigned exp_txns = 1,
+                                        input logic [2:0] src_max_llen = 3'd0,
+                                        input bit src_reduce_len = 1'b0,
+                                        input logic [2:0] dst_max_llen = 3'd0,
+                                        input bit dst_reduce_len = 1'b0);
+        int unsigned exp_beats;
+        byte_t seed;
+        seed = byte_t'(test_no++);
+        exp_beats = (length + StrbWidth - 1) / StrbWidth;
+        clear_mem();
+        preload(src, StrbWidth, seed);
+        reset_read_monitor(src);
+        reset_write_monitor(dst);
+        drv.launch_tf(.length (length), .src_addr (src), .dst_addr (dst),
+                      .src_protocol (idma_pkg::AXI), .dst_protocol (idma_pkg::AXI),
+                      .decouple_aw (1'b0), .decouple_rw (1'b0),
+                      .src_max_llen (src_max_llen), .dst_max_llen (dst_max_llen),
+                      .src_reduce_len (src_reduce_len), .dst_reduce_len (dst_reduce_len), .id ('0),
+                      .src_burst (axi_pkg::BURST_FIXED), .dst_burst (axi_pkg::BURST_FIXED));
+        wait_done(.label (label), .exp_beats (exp_beats), .mon_read (1'b1), .mon_write (1'b1),
+                  .exp_txns (exp_txns));
+        check_fixed_to_fixed(label, dst, StrbWidth, seed);
+    endtask
+
+    // AXI4 caps a FIXED burst at 16 beats; use more to force the legalizer
+    // to split into multiple same-address sub-bursts instead of a single burst.
+    localparam int unsigned NumBeatsMulti = 40;
+
+    // llen reduction used in the llen reduction tests.
+    localparam logic [2:0] MaxLlenReduce = 3'd2; // 4 beats
+
+    initial begin
+        drv.reset_driver();
+        @(posedge rst_n);
+        repeat (4) @(posedge clk);
+
+        // Single sub-burst smoke tests
+        fixed_to_incr_test("fixed_to_incr_small", 4 * StrbWidth);
+        incr_to_fixed_test("incr_to_fixed_small", 4 * StrbWidth);
+        fixed_to_fixed_test("fixed_to_fixed", 4 * StrbWidth);
+
+        // Multi sub-burst: exercises the burst length limiting for the FIXED side
+        fixed_to_incr_test("fixed_to_incr_multi", NumBeatsMulti * StrbWidth,
+                           .exp_txns ((NumBeatsMulti + 15) / 16));
+        incr_to_fixed_test("incr_to_fixed_multi", NumBeatsMulti * StrbWidth,
+                           .exp_txns ((NumBeatsMulti + 15) / 16));
+
+        // Page-boundary split: the INCR side starts 2 beats before a 4K page
+        // boundary, so 4 beats force the legalizer's page splitter to split the
+        // burst, exercising that split against a FIXED side that must hold its
+        // address across it.
+        fixed_to_incr_test("fixed_to_incr_pagesplit", 4 * StrbWidth,
+                           .src (32'h0000_1000), .dst (32'h0000_2000 - 2 * StrbWidth),
+                           .exp_txns (2));
+        incr_to_fixed_test("incr_to_fixed_pagesplit", 4 * StrbWidth,
+                           .src (32'h0000_1000 - 2 * StrbWidth), .dst (32'h0000_2000),
+                           .exp_txns (2));
+
+        // llen reduction on the FIXED side
+        fixed_to_incr_test("fixed_to_incr_llen_reduce", 8 * StrbWidth,
+                           .exp_txns (8 / (1 << MaxLlenReduce)),
+                           .src_max_llen (MaxLlenReduce), .src_reduce_len (1'b1));
+        incr_to_fixed_test("incr_to_fixed_llen_reduce", 8 * StrbWidth,
+                           .exp_txns (8 / (1 << MaxLlenReduce)),
+                           .dst_max_llen (MaxLlenReduce), .dst_reduce_len (1'b1));
+
+        // Narrow tests where length < StrbWidth
+        for (int unsigned i = 1; i < StrbWidth; i++) begin
+            fixed_to_incr_test($sformatf("fixed_to_incr_narrow_%0d", i), i);
+            incr_to_fixed_test($sformatf("incr_to_fixed_narrow_%0d", i), i);
+        end
+
+        // Partial tests where the length is not a multiple of StrbWidth
+        fixed_to_incr_test("fixed_to_incr_partial", 2 * StrbWidth - 1);
+        incr_to_fixed_test("incr_to_fixed_partial", 2 * StrbWidth - 1);
+
+        if (errors == 0)
+            $display("[tb_idma_backend_fixed_burst] ALL CHECKS PASSED");
+        else
+            $fatal(1, "[tb_idma_backend_fixed_burst] %0d errors", errors);
+        $finish;
+    end
+
+    // Global watchdog
+    initial begin
+        repeat (WatchDogNumCycles * 5) @(posedge clk);
+        $fatal(1, "[tb_idma_backend_fixed_burst] watchdog timeout");
+    end
+
+endmodule

--- a/util/mario/legalizer.py
+++ b/util/mario/legalizer.py
@@ -62,6 +62,10 @@ def render_legalizer(prot_ids: dict, db: dict, tpl_file: str) -> str:
         has_page_write_bursting = eval_key(used_write_prots, 'bursts', 'split_at_page_boundary', db)
         has_pow2_write_bursting = eval_key(used_write_prots, 'bursts', 'only_pow2', db)
         has_write_bursting = has_page_write_bursting or has_pow2_write_bursting
+        has_fixed_read_bursting = any(
+            db[p].get('supports_fixed_bursts', 'false') == 'true' for p in used_read_prots)
+        has_fixed_write_bursting = any(
+            db[p].get('supports_fixed_bursts', 'false') == 'true' for p in used_write_prots)
         # assemble context
         context = {
             'name_uniqueifier': prot_id,
@@ -84,6 +88,10 @@ def render_legalizer(prot_ids: dict, db: dict, tpl_file: str) -> str:
                 has_page_write_bursting,
             'has_pow2_write_bursting':
                 has_pow2_write_bursting,
+            'has_fixed_read_bursting':
+                has_fixed_read_bursting,
+            'has_fixed_write_bursting':
+                has_fixed_write_bursting,
             'used_non_bursting_write_protocols':
                 prot_key(used_write_prots, 'bursts', 'not_supported', db),
             'used_non_bursting_read_protocols':


### PR DESCRIPTION

## Description

The iDMA backend currently allows any AXI burst type as input. All testbenches and most frontends hard-wire it to FIXED bursts, but the Descriptor Frontend technically allows any AXI burst type. It looks like this feature was intended, but never finished. The backend legalizer only checks the burst type with an assertion in simulation.

This PR implements Fixed burst support for AXI bursts. 
- The DB is updated with `supports_fixed_bursts` and `max_beats_per_fixed_burst` to control fixed burst support.
- The backend template is updated to support fixed bursts. The key changes are:
  - The page splitter is bypassed for fixed bursts, as they cannot reach over a page boundary. The reduce_llen option is still supported and includes a limit on fixed burst max length (16 for AXI)
  - The burst address is not advanced for fixed bursts
  - The burst type assertion is updated

To verify the changes, a dedicated testbench is added: `test/tb_idma_backend_fixed_burst.sv`.
The testbench checks the following burst type scenarios:
 - FIXED src -> INCR dst bursts
 - INCR src -> FIXED dst bursts
 - FIXED src -> FIXED dst bursts

The testbench checks these scenarios over the following test conditions:
- Simple, one-burst transfer
- Transfers longer than one legal AXI4 FIXED burst (16 beats) split the transfer correctly into multiple bursts
- Transfers that must be split due to the INCR interface crossing a page boundary check that the burst is correctly split into multiple bursts.
- Transfers that must be split due to the user-specified max_llen to check that the llen reduction is correctly applied to the FIXED bursts.
- Narrow transfers with a length smaller than the bus width.
- Partial thansfers, where the length is not a multiple of the bus width.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [x] This PR targets `devel` (not `master`).
- [x] Commits follow [Chris Beams style](https://chris.beams.io/posts/git-commit/) (≤100-char imperative subject, optional `area:` prefix).
- [x] `make idma_hw_all` and the relevant lints pass locally.
- [x] No AI-attribution lines on commits (e.g. `Co-authored-by:` for AI tools).
- [x] Related issues are referenced.

## Notes for reviewers

See also #72 .

Having *misaligned addresses* for a FIXED burst is currently *not supported*. I would be willing to implement this, but I am unsure which approach follows the design philosophy of the iDMA and would appreciate feedback. 

Currently, the write strobes are selected the same way as for the INCR burst, resulting in the first beat accessing `[addr,  bus_aligned(addr) + width)`, the subsequent beats `[bus_aligned(addr),  bus_aligned(addr) + width)` and the last beat `[bus_aligned(addr), bus_aligned(addr) + (len - (addr - bus_aligned(addr)) % width))`. This means the iDMA can write memory outside of the `[addr, addr + len)` range.

Possible approaches for a misaligned FIXED burst to address `addr` with length `len` on a `width` bytes wide bus are:
- Align the address to the bus, i.e. read/write the range `[bus_aligned(addr),  bus_aligned(addr) + width)`. A simple solution, but it can still write data outside of the memory range specified by the transfer of `[addr, addr + len)` but at least it is a predictable, intended feature.
- The "AXI way of doing things": As of "**AMBA® AXI Protocol Issue K, A4.1.7 Pseudocode description of the transfers**", for Fixed bursts, the Pseudocode collapses to:
```
FixedDataTransfer(addr, Size, Length, Data_Bytes)
  Size_Aligned_Addr = INT(addr/Size) * Size;
  Bus_Aligned_Addr = INT(addr/Data_Bytes) * Data_Bytes);
  aligned = (Size_Aligned_Addr == addr);

  for n = 1 to Length
    Lower_Byte_Lane = addr - Bus_Aligned_Addr;
    if aligned then
      Upper_Byte_Lane = Lower_Byte_Lane + Size - 1
    else
      Upper_Byte_Lane = Size_Aligned_Addr + Size - 1 - Bus_Aligned_Addr;
```
  This effectively has  `(Size_Aligned_Addr + Size - 1 - Bus_Aligned_Addr) - (addr - Bus_Aligned_Addr) + 1 = Size - (addr - Size_Aligned_Addr)` active bytes lanes per transfer. The result is that the further `addr` is from an alignment, the more beats are necessary to access `len` bytes.  For example, with `width=8`, `addr=5` and `len=14`, this would require a burst with `ceil(len / (width - (addr % width))) = ceil(14 / 3) = 5` bursts, instead of the three it would take normally. This can result in burst lengths up to the transfer length. While this would be easy to implement on the AXI/legalizer side, it would require changes to the datapath, as (among other changes) the shift in a `dp_req` would become dynamic.
- Interpret the FIXED burst to use `[addr, addr + width)` for the fixed side. While this makes the most sense from a software/configuration side, it is the most difficult one to implement in the legalizer. For a misaligned fixed burst, every fixed beat would have to be split into a INCR burst of length 2 (similar to what the `axi_dw_downsizer` does). A special case arises when the user-defined constraint with `llen=0` is set, which would require an additional state machine to handle this.
- The last option would be to reject misaligned fixed bursts like `RejectZeroTransfers` can be rejected. This would be my preferred solution.


In any case, this missing support of misaligned fixed bursts does not break any existing features, it just does not close the missing feature hole completely. This PR *could* be merged without it.